### PR TITLE
Configurable arrowhead end

### DIFF
--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -80,6 +80,7 @@
             <Setter Property="SplitCommand" Value="{Binding SplitCommand}" />
             <Setter Property="DisconnectCommand" Value="{Binding DisconnectCommand}" />
             <Setter Property="OffsetMode" Value="{Binding ConnectionOffsetMode, Source={x:Static local:EditorSettings.Instance}}" />
+            <Setter Property="Ends" Value="{Binding ArrowHeadEnds, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="SourceOffset" Value="{Binding ConnectionSourceOffset.Size, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="TargetOffset" Value="{Binding ConnectionTargetOffset.Size, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="ArrowSize" Value="{Binding ConnectionArrowSize.Size, Source={x:Static local:EditorSettings.Instance}}" />
@@ -233,6 +234,7 @@
                                                        SourceOffset="{Binding ConnectionSourceOffset.Size, Source={x:Static local:EditorSettings.Instance}}"
                                                        TargetOffset="{Binding ConnectionTargetOffset.Size, Source={x:Static local:EditorSettings.Instance}}"
                                                        ArrowSize="{Binding ConnectionArrowSize.Size, Source={x:Static local:EditorSettings.Instance}}"
+                                                       Ends="{Binding ArrowHeadEnds, Source={x:Static local:EditorSettings.Instance}}"
                                                        Spacing="{Binding ConnectionSpacing, Source={x:Static local:EditorSettings.Instance}}" />
                                     <Border Background="{TemplateBinding Background}"
                                             Canvas.Left="{Binding TargetAnchor.X, RelativeSource={RelativeSource TemplatedParent}}"

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -141,6 +141,13 @@
             set => SetProperty(ref _connectionOffsetMode, value);
         }
 
+        private ArrowHeadEnds _arrowHeadEnds = ArrowHeadEnds.End;
+        public ArrowHeadEnds ArrowHeadEnds
+        {
+            get => _arrowHeadEnds;  
+            set => SetProperty(ref _arrowHeadEnds, value);
+        }
+
         private PointEditor _connectionSourceOffset = new PointEditor { X = 15, Y = 0 };
         public PointEditor ConnectionSourceOffset
         {

--- a/Examples/Nodify.Playground/EditorSettingsView.xaml
+++ b/Examples/Nodify.Playground/EditorSettingsView.xaml
@@ -45,6 +45,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <TextBlock Text="Realtime selection: "
@@ -240,28 +241,40 @@
                       Margin="0 5 5 0" />
 
             <TextBlock Grid.Row="22"
+                       Text="Arrow head end: "
+                       ToolTip="Bring location into view animation speed in pixels per second"
+                       Margin="0 5 5 0" />
+            <ComboBox Grid.Row="22"
+                      Grid.Column="1"
+                      DisplayMemberPath="Name"
+                      SelectedValuePath="Value"
+                      SelectedValue="{Binding ArrowHeadEnds, Mode=TwoWay, Source={x:Static local:EditorSettings.Instance}}"
+                      ItemsSource="{Binding ArrowHeadEnds, Converter={shared:EnumValuesConverter}, Source={x:Static local:EditorSettings.Instance}}"
+                      Margin="0 5 5 0" />
+            
+            <TextBlock Grid.Row="23"
                        Text="Bring into view speed: "
                        ToolTip="Bring location into view animation speed in pixels per second"
                        Margin="0 5 5 0" />
-            <TextBox Grid.Row="22"
+            <TextBox Grid.Row="23"
                      Grid.Column="1"
                      Text="{Binding BringIntoViewSpeed, Mode=TwoWay, Source={x:Static local:EditorSettings.Instance}}"
                      Margin="0 5 5 0" />
 
-            <TextBlock Grid.Row="23"
+            <TextBlock Grid.Row="24"
                        Text="Bring into view max duration: "
                        ToolTip="Bring location into view max animation duration"
                        Margin="0 5 5 0" />
-            <TextBox Grid.Row="23"
+            <TextBox Grid.Row="24"
                      Grid.Column="1"
                      Text="{Binding BringIntoViewMaxDuration, Mode=TwoWay, Source={x:Static local:EditorSettings.Instance}}"
                      Margin="0 5 5 0" />
 
-            <TextBlock Grid.Row="24"
+            <TextBlock Grid.Row="25"
                        Text="Grouping node movement: "
                        ToolTip="Whether the grouping node is sticky or not"
                        Margin="0 5 5 0" />
-            <ComboBox Grid.Row="24"
+            <ComboBox Grid.Row="25"
                       Grid.Column="1"
                       DisplayMemberPath="Name"
                       SelectedValuePath="Value"
@@ -269,7 +282,7 @@
                       ItemsSource="{Binding GroupingNodeMovement, Converter={shared:EnumValuesConverter}, Source={x:Static local:EditorSettings.Instance}}"
                       Margin="0 5 5 0" />
 
-            <Expander Grid.Row="25"
+            <Expander Grid.Row="26"
                       Grid.ColumnSpan="2"
                       Header="Advanced"
                       Padding="0 5 0 0"

--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -87,7 +87,7 @@ namespace Nodify
         public static readonly DependencyProperty TargetOffsetProperty = DependencyProperty.Register(nameof(TargetOffset), typeof(Size), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.Size, FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty OffsetModeProperty = DependencyProperty.Register(nameof(OffsetMode), typeof(ConnectionOffsetMode), typeof(BaseConnection), new FrameworkPropertyMetadata(default(ConnectionOffsetMode), FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty DirectionProperty = DependencyProperty.Register(nameof(Direction), typeof(ConnectionDirection), typeof(BaseConnection), new FrameworkPropertyMetadata(default(ConnectionDirection), FrameworkPropertyMetadataOptions.AffectsRender));
-        public static readonly DependencyProperty ArrowHeadEndsProperty = DependencyProperty.Register(nameof(Ends), typeof(ArrowHeadEnds), typeof(BaseConnection), new FrameworkPropertyMetadata(default(ArrowHeadEnds), FrameworkPropertyMetadataOptions.Affects));
+        public static readonly DependencyProperty ArrowHeadEndsProperty = DependencyProperty.Register(nameof(Ends), typeof(ArrowHeadEnds), typeof(BaseConnection), new FrameworkPropertyMetadata(default(ArrowHeadEnds), FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty SpacingProperty = DependencyProperty.Register(nameof(Spacing), typeof(double), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.Double0, FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty ArrowSizeProperty = DependencyProperty.Register(nameof(ArrowSize), typeof(Size), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.ArrowSize, FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty SplitCommandProperty = DependencyProperty.Register(nameof(SplitCommand), typeof(ICommand), typeof(BaseConnection));
@@ -256,35 +256,18 @@ namespace Nodify
 
             //Shumayl: Ugly implementation. Consider creating a new method. 
             //Shumayl: Modify XML and check if the below works first. 
-            switch (Ends) 
+            (Point from, Point to) = Ends switch
             {
-                case ArrowHeadEnds.Start: 
-                    (Point from, Point to) = GetArrowHeadPoints(source, target);
-                    context.BeginFigure(target, true, true);
-                    context.LineTo(from, true, true);
-                    context.LineTo(to, true, true);
-                    break;
-                case ArrowHeadEnds.End:
-                    (Point to, Point from) = GetArrowHeadPoints(source, target);
-                    context.BeginFigure(target, true, true);
-                    context.LineTo(from, true, true);
-                    context.LineTo(to, true, true);
-                    break;
-                case ArrowHeadEnds.Both:
-                    (Point from, Point to) = GetArrowHeadPoints(source, target);
-                    context.BeginFigure(target, true, true);
-                    context.LineTo(from, true, true);
-                    context.LineTo(to, true, true);
-                    (Point to, Point from) = GetArrowHeadPoints(source, target);
-                    context.BeginFigure(target, true, true);
-                    context.LineTo(from, true, true);
-                    context.LineTo(to, true, true);
-                    break;
-                case ArrowHeadEnds.None:
-                    break;
-                case default:
-                    break;
+                ArrowHeadEnds.Start => GetArrowHeadPoints(source, target),
+                ArrowHeadEnds.End => GetArrowHeadPoints(target, source),
+                ArrowHeadEnds.Both => GetArrowHeadPoints(source, target),
+                ArrowHeadEnds.None => GetArrowHeadPoints(source, target),
+                _ => GetArrowHeadPoints(source, target)
             };
+
+            context.BeginFigure(target, true, true);
+            context.LineTo(from, true, true);
+            context.LineTo(to, true, true);
         }
 
         protected virtual (Point From, Point To) GetArrowHeadPoints(Point source, Point target)
@@ -292,7 +275,7 @@ namespace Nodify
             double headWidth = ArrowSize.Width;
             double headHeight = ArrowSize.Height;
 
-            double Direction = direction == ConnectionDirection.Forward ? 1d : -1d;
+            double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
             var from = new Point(target.X - headWidth * direction, target.Y + headHeight);
             var to = new Point(target.X - headWidth * direction, target.Y - headHeight);
             return (from, to);

--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO.Packaging;
+using System.Security.Cryptography;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -241,7 +243,23 @@ namespace Nodify
 
                     if (ArrowSize.Width != 0d && ArrowSize.Height != 0d)
                     {
-                        DrawArrowGeometry(context, arrowSource, arrowTarget);
+                        switch(Ends)
+                        {
+                            case ArrowHeadEnds.Start: 
+                                DrawArrowGeometry(context, arrowTarget, arrowSource);
+                                break; 
+                            case ArrowHeadEnds.End:
+                                DrawArrowGeometry(context, arrowSource, arrowTarget);
+                                break;
+                            case ArrowHeadEnds.Both:
+                                DrawArrowGeometry(context, arrowSource, arrowTarget);
+                                DrawArrowGeometry(context, arrowTarget, arrowSource);
+                                break;
+                            case ArrowHeadEnds.None:
+                                break;
+                            default:
+                                break;
+                        };
                     }
                 }
 
@@ -253,17 +271,7 @@ namespace Nodify
 
         protected virtual void DrawArrowGeometry(StreamGeometryContext context, Point source, Point target)
         {
-
-            //Shumayl: Ugly implementation. Consider creating a new method. 
-            //Shumayl: Modify XML and check if the below works first. 
-            (Point from, Point to) = Ends switch
-            {
-                ArrowHeadEnds.Start => GetArrowHeadPoints(source, target),
-                ArrowHeadEnds.End => GetArrowHeadPoints(target, source),
-                ArrowHeadEnds.Both => GetArrowHeadPoints(source, target),
-                ArrowHeadEnds.None => GetArrowHeadPoints(source, target),
-                _ => GetArrowHeadPoints(source, target)
-            };
+            (Point from, Point to) = GetArrowHeadPoints(source, target);
 
             context.BeginFigure(target, true, true);
             context.LineTo(from, true, true);
@@ -279,7 +287,7 @@ namespace Nodify
             var from = new Point(target.X - headWidth * direction, target.Y + headHeight);
             var to = new Point(target.X - headWidth * direction, target.Y - headHeight);
             return (from, to);
-        }
+    }
 
         /// <summary>
         /// Gets the resulting offset after applying the <see cref="OffsetMode"/>.


### PR DESCRIPTION
<!-- 
  ## Hello and welcome!

  Consider creating an issue or link to an existing one before submitting the pull request. Thanks!
-->

### 📝 Description of the Change

This pull request aims to address #44. `ArrowHeadEnds` now dictates the location at which the arrow gets drawn. However, this will not alter the direction of the arrow.

The behavior is now as follows:

`ArrowHeadEnds.End`
<img width="664" alt="nodify-arrowheadends-end" src="https://user-images.githubusercontent.com/83513359/201487980-b04106ab-9f1c-4f9b-98f4-20101c0a2262.png">

`ArrowHeadEnds.Start`
<img width="664" alt="nodify-arrowheadends-start" src="https://user-images.githubusercontent.com/83513359/201487999-727b84c9-8f5f-4597-bf3a-665bbe59f59b.png">

`ArrowHeadEnds.Both`
<img width="664" alt="nodify-arrowheadends-both" src="https://user-images.githubusercontent.com/83513359/201488006-bc5f0e71-d712-4e4d-ac23-438ce5590267.png">

`ArrowHeadEnds.None`
<img width="664" alt="nodify-arrowheadends-none" src="https://user-images.githubusercontent.com/83513359/201488020-e8118ad5-cf59-4ca8-8af7-19862ecec93e.png">

Please advice if this behavior is in line with the requirement, or if I misinterpreted the requirement.

### 🐛 Possible Drawbacks

I am not sure if this is the best way to implement this, and any advice to make the code better is much appreciated. I would also appreciate any pointers on code style. Thank you in advance for your help.

I will rebase and squash the commits once the changes are finalized.