### PR TITLE
Fix the unintentional movement caused by snapping correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 >   - Fixed PendingConnection.PreviewTarget not being set to null when there is no actual target
 >   - Fixed connectors panel not being affected by Node.VerticalAlignment
 >   - Changing BorderThickness causes layout shift when selecting an item container
+>   - Fixed the unintentional movement caused by snapping correction
 
 #### **Version 5.0.2**
 

--- a/Nodify/Helpers/DraggingOptimized.cs
+++ b/Nodify/Helpers/DraggingOptimized.cs
@@ -46,7 +46,7 @@ namespace Nodify
                 Point result = container.Location + new Vector(r.X, r.Y);
 
                 // Correct the final position
-                if (NodifyEditor.EnableSnappingCorrection && r.X != 0 && r.Y != 0)
+                if (NodifyEditor.EnableSnappingCorrection && (r.X != 0 || r.Y != 0))
                 {
                     result.X = (int)result.X / _editor.GridCellSize * _editor.GridCellSize;
                     result.Y = (int)result.Y / _editor.GridCellSize * _editor.GridCellSize;

--- a/Nodify/Helpers/DraggingOptimized.cs
+++ b/Nodify/Helpers/DraggingOptimized.cs
@@ -46,7 +46,7 @@ namespace Nodify
                 Point result = container.Location + new Vector(r.X, r.Y);
 
                 // Correct the final position
-                if (NodifyEditor.EnableSnappingCorrection)
+                if (NodifyEditor.EnableSnappingCorrection && r.X != 0 && r.Y != 0)
                 {
                     result.X = (int)result.X / _editor.GridCellSize * _editor.GridCellSize;
                     result.Y = (int)result.Y / _editor.GridCellSize * _editor.GridCellSize;


### PR DESCRIPTION
### 📝 Description of the Change

Check the actual movement before apply the snapping correction.

When the snapping correction is enabled, the graph attempts to align the nodes to the grids.
However, even if a user merely selects a node, it might still move and snap to the grid.
Furthermore, when using grouped nodes, such as comment in the playground example, selecting the comment can inadvertently select many nodes. This can lead to several unintentional movements.

### 🐛 Possible Drawbacks

Are there any possible side-effects or negative impacts with this code change?

I think not.
Users who wish to adjust nodes based on grid size can easily nudge them slightly to achieve the desired alignment.
