### PR TITLE
Fix reset of viewport does not set the origin to (0, 0)

### DIFF
--- a/Nodify/EditorCommands.cs
+++ b/Nodify/EditorCommands.cs
@@ -185,7 +185,7 @@ namespace Nodify
                         editor.BringIntoView(Point.Parse(str));
                         break;
                     default:
-                        editor.BringIntoView(new Point());
+                        editor.BringIntoView(null);
                         break;
                 }
             }

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -798,9 +798,10 @@ namespace Nodify
         /// <param name="animated">True to animate the movement.</param>
         /// <param name="onFinish">The callback invoked when movement is finished.</param>
         /// <remarks>Temporarily disables editor controls when animated.</remarks>
-        public void BringIntoView(Point point, bool animated = true, Action? onFinish = null)
+        public void BringIntoView(Point? point, bool animated = true, Action? onFinish = null)
         {
-            Point newLocation = (Point)((Vector)point - (Vector)ViewportSize / 2);
+            // if point is null, the viewport shall be reseted to the origin
+            Point newLocation = point == null ? new Point(0, 0) : (Point)((Vector)point - (Vector)ViewportSize / 2);
 
             if (animated && newLocation != ViewportLocation)
             {


### PR DESCRIPTION
**Describe the bug**
If the `ResetViewportLocation` gesture is performed, the viewport is not reset to (0, 0) as stated in the summary. Instead, the point (0, 0) is centered.

**To Reproduce**
1. Move the viewport to any location
2. Hit the "Home" button / call `OnBringIntoView`

This PR fixes this behavior by changing the `PringIntoView` point to a nullable and use this info to decide if the ViewportSize shall be taken into account or not.