### PR TITLE
Allow displaying text on connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 > - Breaking Changes:
 > - Features:
+>	- Added Text to BaseConnection, allowing displaying of text on connections
+>	- Added Foreground, FontSize, FontWeight, FontStyle, FontStretch and FontFamily to BaseConnection, allowing styling the displaying text
 > - Bugfixes:
 
 #### **Version 5.1.0**

--- a/Examples/Nodify.Playground/BaseSettingViewModel.cs
+++ b/Examples/Nodify.Playground/BaseSettingViewModel.cs
@@ -29,6 +29,7 @@ namespace Nodify.Playground
             Description = description;
             Type = typeof(T) switch
             {
+                { } t when t == typeof(string) => SettingsType.Text,
                 { } t when t == typeof(bool) => SettingsType.Boolean,
                 { } t when t == typeof(uint) || t == typeof(double) => SettingsType.Number,
                 { } t when t == typeof(PointEditor) => SettingsType.Point,

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -95,6 +95,7 @@
             <Setter Property="ArrowShape" Value="{Binding ArrowHeadShape, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="Spacing" Value="{Binding ConnectionSpacing, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="Direction" Value="{Binding Output.Flow, Converter={StaticResource FlowToDirectionConverter}}" />
+            <Setter Property="Text" Value="{Binding ConnectionText, Source={x:Static local:EditorSettings.Instance}}" />
         </Style>
 
         <DataTemplate x:Key="CircuitConnectionTemplate">

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -85,6 +85,14 @@ namespace Nodify.Playground
                     val => Instance.AutoPanningEdgeDistance = val,
                     "Auto panning edge distance: ",
                     "Distance from edge to trigger auto panning"),
+                new ProxySettingViewModel<ConnectionStyle>(
+                    () => Instance.ConnectionStyle,
+                    val => Instance.ConnectionStyle = val,
+                    "Connection style: "),
+                new ProxySettingViewModel<string>(
+                    () => Instance.ConnectionText,
+                    val => Instance.ConnectionText = val,
+                    "Connection text: "),
                 new ProxySettingViewModel<double>(
                     () => Instance.CircuitConnectionAngle,
                     val => Instance.CircuitConnectionAngle = val,
@@ -100,10 +108,6 @@ namespace Nodify.Playground
                     val => Instance.ConnectionArrowSize = val,
                     "Connection arrowhead size: ",
                     "The size of the arrowhead."),
-                new ProxySettingViewModel<ConnectionStyle>(
-                    () => Instance.ConnectionStyle,
-                    val => Instance.ConnectionStyle = val,
-                    "Connection style: "),
                 new ProxySettingViewModel<ArrowHeadEnds>(
                     () => Instance.ArrowHeadEnds,
                     val => Instance.ArrowHeadEnds = val,
@@ -230,13 +234,6 @@ namespace Nodify.Playground
 
         #region Default settings
 
-        private ConnectionStyle _connectionStyle;
-        public ConnectionStyle ConnectionStyle
-        {
-            get => _connectionStyle;
-            set => SetProperty(ref _connectionStyle, value);
-        }
-
         private bool _enablePendingConnectionSnapping = true;
         public bool EnablePendingConnectionSnapping
         {
@@ -335,6 +332,20 @@ namespace Nodify.Playground
             set => SetProperty(ref _location, value);
         }
 
+        private ConnectionStyle _connectionStyle;
+        public ConnectionStyle ConnectionStyle
+        {
+            get => _connectionStyle;
+            set => SetProperty(ref _connectionStyle, value);
+        }
+
+        private string _connectionText;
+        public string ConnectionText
+        {
+            get => _connectionText;
+            set => SetProperty(ref _connectionText, value);
+        }
+
         private double _circuitConnectionAngle = 45;
         public double CircuitConnectionAngle
         {
@@ -366,7 +377,7 @@ namespace Nodify.Playground
         private ArrowHeadEnds _arrowHeadEnds = ArrowHeadEnds.End;
         public ArrowHeadEnds ArrowHeadEnds
         {
-            get => _arrowHeadEnds;  
+            get => _arrowHeadEnds;
             set => SetProperty(ref _arrowHeadEnds, value);
         }
 

--- a/Examples/Nodify.Playground/ISettingViewModel.cs
+++ b/Examples/Nodify.Playground/ISettingViewModel.cs
@@ -5,7 +5,8 @@
         Boolean,
         Number,
         Option,
-        Point
+        Point,
+        Text
     }
 
     public interface ISettingViewModel

--- a/Examples/Nodify.Playground/SettingsView.xaml
+++ b/Examples/Nodify.Playground/SettingsView.xaml
@@ -11,6 +11,9 @@
              mc:Ignorable="d">
     <ItemsControl ItemsSource="{Binding Items, RelativeSource={RelativeSource AncestorType=UserControl}}">
         <ItemsControl.Resources>
+            <DataTemplate x:Key="TextEditorTemplate" DataType="{x:Type local:ISettingViewModel}">
+                <TextBox Text="{Binding Value}" TextWrapping="Wrap" AcceptsReturn="True" />
+            </DataTemplate>
             <DataTemplate x:Key="NumberEditorTemplate" DataType="{x:Type local:ISettingViewModel}">
                 <TextBox Text="{Binding Value}" />
             </DataTemplate>
@@ -55,6 +58,10 @@
                                     <DataTrigger Binding="{Binding Type}" Value="Option">
                                         <Setter Property="ContentTemplate"
                                                 Value="{StaticResource ResourceKey=OptionEditorTemplate}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Type}" Value="Text">
+                                        <Setter Property="ContentTemplate"
+                                                Value="{StaticResource ResourceKey=TextEditorTemplate}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>

--- a/Nodify/Connections/CircuitConnection.cs
+++ b/Nodify/Connections/CircuitConnection.cs
@@ -29,14 +29,7 @@ namespace Nodify
 
         protected override ((Point ArrowStartSource, Point ArrowStartTarget), (Point ArrowEndSource, Point ArrowEndTarget)) DrawLineGeometry(StreamGeometryContext context, Point source, Point target)
         {
-            double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
-            var spacing = new Vector(Spacing * direction, 0d);
-            var arrowOffset = new Vector(ArrowSize.Width * direction, 0d);
-            Point endPoint = Spacing > 0 ? target - arrowOffset : target;
-
-            Point p1 = source + spacing;
-            Point p3 = endPoint - spacing;
-            Point p2 = GetControlPoint(p1, p3);
+            var (p1, p2, p3) = GetLinePoints(source, target);
 
             context.BeginFigure(source, false, false);
             context.LineTo(p1, true, true);
@@ -52,7 +45,21 @@ namespace Nodify
             return ((p1, source), (p2, target));
         }
 
-        private Point GetControlPoint(Point source, Point target)
+        private (Point P1, Point P2, Point P3) GetLinePoints(in Point source, in Point target)
+        {
+            double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
+            var spacing = new Vector(Spacing * direction, 0d);
+            var arrowOffset = new Vector(ArrowSize.Width * direction, 0d);
+            Point endPoint = Spacing > 0 ? target - arrowOffset : target;
+
+            Point p1 = source + spacing;
+            Point p3 = endPoint - spacing;
+            Point p2 = GetControlPoint(p1, p3);
+
+            return (p1, p2, p3);
+        }
+
+        private Point GetControlPoint(in Point source, in Point target)
         {
             Vector delta = target - source;
             double tangent = Math.Tan(Angle * Degrees);
@@ -83,6 +90,22 @@ namespace Nodify
             }
 
             return new Point(target.X, source.Y - slopeHeight);
+        }
+
+        protected override Point GetTextPosition(FormattedText text)
+        {
+            (Vector sourceOffset, Vector targetOffset) = GetOffset();
+            var (p1, p2, p3) = GetLinePoints(Source + sourceOffset, Target + targetOffset);
+
+            Vector deltaSource = p1 - p2;
+            Vector deltaTarget = p3 - p2;
+
+            if (deltaSource.LengthSquared > deltaTarget.LengthSquared)
+            {
+                return new Point((p1.X + p2.X - text.Width) / 2, (p1.Y + p2.Y - text.Height) / 2);
+            }
+
+            return new Point((p3.X + p2.X - text.Width) / 2, (p3.Y + p2.Y - text.Height) / 2);
         }
     }
 }

--- a/Nodify/Helpers/BoxValue.cs
+++ b/Nodify/Helpers/BoxValue.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using System.Windows.Media;
 
 namespace Nodify
 {
@@ -22,5 +23,11 @@ namespace Nodify
         public static readonly object Thickness2 = new Thickness(2);
         public static readonly object ArrowSize = new Size(8, 8);
         public static readonly object ConnectionOffset = new Size(14, 0);
+
+#if NET5_0_OR_GREATER || NETFRAMEWORK
+        public static readonly object BrushBlack = Brushes.Black;
+#else
+        public static readonly object BrushBlack = new SolidColorBrush(Colors.Black);
+#endif
     }
 }

--- a/Nodify/Helpers/BoxValue.cs
+++ b/Nodify/Helpers/BoxValue.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows;
-using System.Windows.Media;
 
 namespace Nodify
 {
@@ -23,11 +22,5 @@ namespace Nodify
         public static readonly object Thickness2 = new Thickness(2);
         public static readonly object ArrowSize = new Size(8, 8);
         public static readonly object ConnectionOffset = new Size(14, 0);
-
-#if NET5_0_OR_GREATER || NETFRAMEWORK
-        public static readonly object BrushBlack = Brushes.Black;
-#else
-        public static readonly object BrushBlack = new SolidColorBrush(Colors.Black);
-#endif
     }
 }


### PR DESCRIPTION
<!-- 
  ## Hello and welcome!

  Consider creating an issue or link to an existing one before submitting the pull request. Thanks!
-->

### 📝 Description of the Change

This PR adds the ability to display text on connections and allows customizing it.

New connection properties: `Text`, `Foreground`, `FontSize`, `FontWeight`, `FontStyle`, `FontStretch` and `FontFamily`

New playground setting: `Connection Text`

![image](https://github.com/miroiu/nodify/assets/12727904/c5aac21c-6149-4be5-8354-3ef474d7f6b8)

Related issues: #79, #63 

### 🐛 Possible Drawbacks

It may have a minor performance impact.
