### PR TITLE
Release mouse capture on connector cancel due to KeyUp event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 >	- Added Text to BaseConnection, allowing displaying of text on connections
 >	- Added Foreground, FontSize, FontWeight, FontStyle, FontStretch and FontFamily to BaseConnection, allowing styling the displaying text
 > - Bugfixes:
+>   - Fixed MouseCapture not being released when EnableStickyConnections is enabled and the PendingConnection is canceled by a key gesture 
 
 #### **Version 5.1.0**
 

--- a/Nodify/Connections/Connector.cs
+++ b/Nodify/Connections/Connector.cs
@@ -379,6 +379,7 @@ namespace Nodify
             {
                 // Cancel pending connection
                 OnConnectorDragCompleted(cancel: true);
+                ReleaseMouseCapture();
             }
         }
 


### PR DESCRIPTION
### 📝 Description of the Change

Mouse Capture wasn't released when pending connection was canceled via a hotkey. This is a problem when `EnableStickyConnections` is enabled and the cancel hot key is pressed after the mouse is released (but the mouse is still captured)

### 🐛 Possible Drawbacks

n/a
