### PR TITLE
Extension of vertical-connection feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > - Breaking Changes:
 > - Features:
->	- Added Orientation to BaseConnection to support vertical connections
+>	- Added SourceOrientation and TargetOrientation to BaseConnection to support vertical ports (vertical/mixed connection orientation)
 > - Bugfixes:
 
 #### **Version 5.2.0**

--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -117,8 +117,9 @@ namespace Nodify
         public static readonly DependencyProperty TargetOffsetProperty = DependencyProperty.Register(nameof(TargetOffset), typeof(Size), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.ConnectionOffset, FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty SourceOffsetModeProperty = DependencyProperty.Register(nameof(SourceOffsetMode), typeof(ConnectionOffsetMode), typeof(BaseConnection), new FrameworkPropertyMetadata(ConnectionOffsetMode.Static, FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty TargetOffsetModeProperty = DependencyProperty.Register(nameof(TargetOffsetMode), typeof(ConnectionOffsetMode), typeof(BaseConnection), new FrameworkPropertyMetadata(ConnectionOffsetMode.Static, FrameworkPropertyMetadataOptions.AffectsRender));
+        public static readonly DependencyProperty SourceOrientationProperty = DependencyProperty.Register(nameof(SourceOrientation), typeof(Orientation), typeof(BaseConnection), new FrameworkPropertyMetadata(Orientation.Horizontal, FrameworkPropertyMetadataOptions.AffectsRender));
+        public static readonly DependencyProperty TargetOrientationProperty = DependencyProperty.Register(nameof(TargetOrientation), typeof(Orientation), typeof(BaseConnection), new FrameworkPropertyMetadata(Orientation.Horizontal, FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty DirectionProperty = DependencyProperty.Register(nameof(Direction), typeof(ConnectionDirection), typeof(BaseConnection), new FrameworkPropertyMetadata(default(ConnectionDirection), FrameworkPropertyMetadataOptions.AffectsRender));
-        public static readonly DependencyProperty OrientationProperty = StackPanel.OrientationProperty.AddOwner(typeof(BaseConnection), new FrameworkPropertyMetadata(Orientation.Horizontal));
         public static readonly DependencyProperty SpacingProperty = DependencyProperty.Register(nameof(Spacing), typeof(double), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.Double0, FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty ArrowSizeProperty = DependencyProperty.Register(nameof(ArrowSize), typeof(Size), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.ArrowSize, FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty ArrowEndsProperty = DependencyProperty.Register(nameof(ArrowEnds), typeof(ArrowHeadEnds), typeof(BaseConnection), new FrameworkPropertyMetadata(ArrowHeadEnds.End, FrameworkPropertyMetadataOptions.AffectsRender));
@@ -188,21 +189,30 @@ namespace Nodify
         }
 
         /// <summary>
+        /// Gets or sets the orientation in which this connection is flowing.
+        /// </summary>
+        public Orientation SourceOrientation
+        {
+            get => (Orientation)GetValue(SourceOrientationProperty);
+            set => SetValue(SourceOrientationProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the orientation in which this connection is flowing.
+        /// </summary>
+        public Orientation TargetOrientation
+        {
+            get => (Orientation)GetValue(TargetOrientationProperty);
+            set => SetValue(TargetOrientationProperty, value);
+        }
+
+        /// <summary>
         /// Gets or sets the direction in which this connection is oriented.
         /// </summary>
         public ConnectionDirection Direction
         {
             get => (ConnectionDirection)GetValue(DirectionProperty);
             set => SetValue(DirectionProperty, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the orientation in which this connection is flowing.
-        /// </summary>
-        public Orientation Orientation
-        {
-            get => (Orientation)GetValue(OrientationProperty);
-            set => SetValue(OrientationProperty, value);
         }
 
         /// <summary>
@@ -363,14 +373,14 @@ namespace Nodify
                         switch (ArrowEnds)
                         {
                             case ArrowHeadEnds.Start:
-                                DrawArrowGeometry(context, arrowStart.ArrowStartSource, arrowStart.ArrowStartTarget, reverseDirection, ArrowShape, Orientation);
+                                DrawArrowGeometry(context, arrowStart.ArrowStartSource, arrowStart.ArrowStartTarget, reverseDirection, ArrowShape, SourceOrientation);
                                 break;
                             case ArrowHeadEnds.End:
-                                DrawArrowGeometry(context, arrowEnd.ArrowEndSource, arrowEnd.ArrowEndTarget, Direction, ArrowShape, Orientation);
+                                DrawArrowGeometry(context, arrowEnd.ArrowEndSource, arrowEnd.ArrowEndTarget, Direction, ArrowShape, TargetOrientation);
                                 break;
                             case ArrowHeadEnds.Both:
-                                DrawArrowGeometry(context, arrowEnd.ArrowEndSource, arrowEnd.ArrowEndTarget, Direction, ArrowShape, Orientation);
-                                DrawArrowGeometry(context, arrowStart.ArrowStartSource, arrowStart.ArrowStartTarget, reverseDirection, ArrowShape, Orientation);
+                                DrawArrowGeometry(context, arrowEnd.ArrowEndSource, arrowEnd.ArrowEndTarget, Direction, ArrowShape, TargetOrientation);
+                                DrawArrowGeometry(context, arrowStart.ArrowStartSource, arrowStart.ArrowStartTarget, reverseDirection, ArrowShape, SourceOrientation);
                                 break;
                             case ArrowHeadEnds.None:
                             default:
@@ -512,9 +522,13 @@ namespace Nodify
             var sourceOffset = GetOffset(SourceOffsetMode, sourceDelta, SourceOffset, arrowDirection);
             var targetOffset = GetOffset(TargetOffsetMode, targetDelta, TargetOffset, -arrowDirection);
 
-            if (Orientation == Orientation.Vertical)
+            if (SourceOrientation == Orientation.Vertical)
             {
                 (sourceOffset.X, sourceOffset.Y) = (sourceOffset.Y, sourceOffset.X);
+            }
+
+            if (TargetOrientation == Orientation.Vertical)
+            {
                 (targetOffset.X, targetOffset.Y) = (targetOffset.Y, targetOffset.X);
             }
 

--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -131,7 +131,7 @@ namespace Nodify
         public static readonly DependencyProperty FontFamilyProperty = TextElement.FontFamilyProperty.AddOwner(typeof(BaseConnection));
         public static readonly DependencyProperty FontWeightProperty = TextElement.FontWeightProperty.AddOwner(typeof(BaseConnection));
         public static readonly DependencyProperty FontStyleProperty = TextElement.FontStyleProperty.AddOwner(typeof(BaseConnection));
-        public static readonly DependencyProperty FontStretchtProperty = TextElement.FontStretchProperty.AddOwner(typeof(BaseConnection));
+        public static readonly DependencyProperty FontStretchProperty = TextElement.FontStretchProperty.AddOwner(typeof(BaseConnection));
 
         /// <summary>
         /// Gets or sets the start point of this connection.
@@ -311,8 +311,8 @@ namespace Nodify
         /// <inheritdoc cref="TextElement.FontStretch" />
         public FontStretch FontStretch
         {
-            get => (FontStretch)GetValue(FontStretchtProperty);
-            set => SetValue(FontStretchtProperty, value);
+            get => (FontStretch)GetValue(FontStretchProperty);
+            set => SetValue(FontStretchProperty, value);
         }
 
         #endregion

--- a/Nodify/Connections/CircuitConnection.cs
+++ b/Nodify/Connections/CircuitConnection.cs
@@ -50,18 +50,18 @@ namespace Nodify
         {
             double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
             var spacing = new Vector(Spacing * direction, 0d);
+            var spacingVertical = new Vector(spacing.Y, spacing.X);
             var arrowOffset = new Vector(ArrowSize.Width * direction, 0d);
 
-            if (Orientation == Orientation.Vertical)
+            if (TargetOrientation == Orientation.Vertical)
             {
-                (spacing.X, spacing.Y) = (spacing.Y, spacing.X);
                 (arrowOffset.X, arrowOffset.Y) = (arrowOffset.Y, arrowOffset.X);
             }
 
             Point endPoint = Spacing > 0 ? target - arrowOffset : target;
 
-            Point p1 = source + spacing;
-            Point p3 = endPoint - spacing;
+            Point p1 = source + (SourceOrientation == Orientation.Vertical ? spacingVertical : spacing);
+            Point p3 = endPoint - (TargetOrientation == Orientation.Vertical ? spacingVertical : spacing);
             Point p2 = GetControlPoint(p1, p3);
 
             return (p1, p2, p3);

--- a/Nodify/Connections/Connection.cs
+++ b/Nodify/Connections/Connection.cs
@@ -24,14 +24,10 @@ namespace Nodify
         {
             double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
             var spacing = new Vector(Spacing * direction, 0d);
+            var spacingVertical = new Vector(spacing.Y, spacing.X);
 
-            if(Orientation == Orientation.Vertical)
-            {
-                (spacing.X, spacing.Y) = (spacing.Y, spacing.X);
-            }
-
-            Point startPoint = source + spacing;
-            Point endPoint = target - spacing;
+            Point startPoint = source + (SourceOrientation == Orientation.Vertical ? spacingVertical : spacing);
+            Point endPoint = target - (TargetOrientation == Orientation.Vertical ? spacingVertical : spacing);
 
             Vector delta = target - source;
             double height = Math.Abs(delta.Y);
@@ -45,15 +41,15 @@ namespace Nodify
             offset = Math.Min(_baseOffset + Math.Sqrt(width * _offsetGrowthRate), offset);
 
             var controlPoint = new Vector(offset * direction, 0d);
-
-            if (Orientation == Orientation.Vertical)
-            {
-                (controlPoint.X, controlPoint.Y) = (controlPoint.Y, controlPoint.X);
-            }
+            var controlPointVertical = new Vector(controlPoint.Y, controlPoint.X);
 
             context.BeginFigure(source, false, false);
             context.LineTo(startPoint, true, true);
-            context.BezierTo(startPoint + controlPoint, endPoint - controlPoint, endPoint, true, true);
+            context.BezierTo(
+                startPoint + (SourceOrientation == Orientation.Vertical ? controlPointVertical : controlPoint),
+                endPoint - (TargetOrientation == Orientation.Vertical ? controlPointVertical : controlPoint),
+                endPoint,
+                true, true);
             context.LineTo(target, true, true);
 
             return ((target, source), (source, target));

--- a/Nodify/Connections/Connection.cs
+++ b/Nodify/Connections/Connection.cs
@@ -41,6 +41,13 @@ namespace Nodify
             offset = Math.Min(_baseOffset + Math.Sqrt(width * _offsetGrowthRate), offset);
 
             var controlPoint = new Vector(offset * direction, 0d);
+
+            // Avoid sharp bend if orientation different (when close to each other)
+            if (TargetOrientation != SourceOrientation)
+            {
+                controlPoint *= 0.5;
+            }
+
             var controlPointVertical = new Vector(controlPoint.Y, controlPoint.X);
 
             context.BeginFigure(source, false, false);

--- a/Nodify/Connections/LineConnection.cs
+++ b/Nodify/Connections/LineConnection.cs
@@ -19,14 +19,10 @@ namespace Nodify
         {
             double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
             var spacing = new Vector(Spacing * direction, 0d);
+            var spacingVertical = new Vector(spacing.Y, spacing.X);
 
-            if (Orientation == Orientation.Vertical)
-            {
-                (spacing.X, spacing.Y) = (spacing.Y, spacing.X);
-            }
-
-            Point p1 = source + spacing;
-            Point p2 = target - spacing;
+            Point p1 = source + (SourceOrientation == Orientation.Vertical ? spacingVertical : spacing);
+            Point p2 = target - (TargetOrientation == Orientation.Vertical ? spacingVertical : spacing);
 
             context.BeginFigure(source, false, false);
             context.LineTo(p1, true, true);


### PR DESCRIPTION
The adjustments discussed in [!99](https://github.com/miroiu/nodify/pull/99)

### 📝 Description of the Change

Split of connection orientation to source/target.

Please note the _baseOffset of 100 is quite large i noticed during my testing, however to avoid effecting existing drawing i didn't adjust it. Instead i half the offset if there is an difference of orientation, avoiding some sharp bending if the nodes get to close to each other.

So drawing of horizontal connections remains the same.

I tested all 3 connection types and 3 arrow types in both directions/orientations.

Usage pattern:

`PortViewModel.cs`:
```C#
private Orientation _orientation;
public Orientation Orientation
{
    get => _orientation;
    set => SetProperty(ref _orientation, value);
}
```

`*.xaml`:
```xml
        <DataTemplate x:Key="ConnectionTemplate">
            <nodify:Connection Style="{StaticResource ConnectionStyle}"
                               SourceOrientation="{Binding Output.Orientation}"
                               TargetOrientation="{Binding Input.Orientation}" />
        </DataTemplate>
```

### 🐛 Possible Drawbacks

Increased connection drawing complexity.
