### PR TITLE
Added directional arrows on connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 > - Features:
 >	- Added SourceOrientation and TargetOrientation to BaseConnection to support vertical connectors (vertical/mixed connection orientation)
 >	- Added DirectionalArrowsCount to BaseConnection to allow drawing multipe arrows on a connection flowing in the connection direction
->	- Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to allow customizing the directional arrows
+>	- Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to BaseConnection to allow customizing the directional arrows
 > - Bugfixes:
 >	- Fixed BaseConnection.Text not always displaying in the center of the connection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 >	- Added DirectionalArrowsCount to BaseConnection to allow drawing multipe arrows on a connection flowing in the connection direction
 >	- Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to allow customizing the directional arrows
 > - Bugfixes:
->	- Fixed BaseConnection.Text not always displaying in the center of connection
+>	- Fixed BaseConnection.Text not always displaying in the center of the connection
 
 #### **Version 5.2.0**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 > - Breaking Changes:
 >	- Added a parameter for the orientation to DrawArrowGeometry, DrawDefaultArrowhead, DrawRectangleArrowhead and DrawEllipseArrowhead in BaseConnection
+>	- Added source and target parameters to GetTextPosition in BaseConnection
 > - Features:
 >	- Added SourceOrientation and TargetOrientation to BaseConnection to support vertical connectors (vertical/mixed connection orientation)
+>	- Added DirectionalArrowsCount to BaseConnection to allow drawing multipe arrows on a connection flowing in the connection direction
+>	- Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to allow customizing the directional arrows
 > - Bugfixes:
+>	- Fixed BaseConnection.Text not always displaying in the center of connection
 
 #### **Version 5.2.0**
 

--- a/Examples/Nodify.Playground/Editor/FlowNodeViewModel.cs
+++ b/Examples/Nodify.Playground/Editor/FlowNodeViewModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Nodify.Playground
+﻿using System.Windows.Controls;
+
+namespace Nodify.Playground
 {
     public class FlowNodeViewModel : NodeViewModel
     {
@@ -12,8 +14,12 @@
         public NodifyObservableCollection<ConnectorViewModel> Input { get; } = new NodifyObservableCollection<ConnectorViewModel>();
         public NodifyObservableCollection<ConnectorViewModel> Output { get; } = new NodifyObservableCollection<ConnectorViewModel>();
 
+        public Orientation Orientation { get; protected set; }
+
         public FlowNodeViewModel()
         {
+            Orientation = Orientation.Horizontal;
+
             Input.WhenAdded(c => c.Node = this)
                  .WhenRemoved(c => c.Disconnect());
 

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -95,6 +95,7 @@
             <Setter Property="ArrowShape" Value="{Binding ArrowHeadShape, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="Spacing" Value="{Binding ConnectionSpacing, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="Direction" Value="{Binding Output.Flow, Converter={StaticResource FlowToDirectionConverter}}" />
+            <Setter Property="DirectionalArrowsCount" Value="{Binding DirectionalArrowsCount, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="Text" Value="{Binding ConnectionText, Source={x:Static local:EditorSettings.Instance}}" />
         </Style>
 
@@ -239,6 +240,7 @@
                                     <nodify:Connection Source="{TemplateBinding SourceAnchor}"
                                                        Target="{TemplateBinding TargetAnchor}"
                                                        Direction="{TemplateBinding Direction}"
+                                                       DirectionalArrowsCount="{Binding DirectionalArrowsCount, Source={x:Static local:EditorSettings.Instance}}"
                                                        StrokeThickness="{TemplateBinding StrokeThickness}"
                                                        SourceOffset="{Binding ConnectionSourceOffset.Size, Source={x:Static local:EditorSettings.Instance}}"
                                                        TargetOffset="{Binding ConnectionTargetOffset.Size, Source={x:Static local:EditorSettings.Instance}}"

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -95,6 +95,8 @@
             <Setter Property="ArrowShape" Value="{Binding ArrowHeadShape, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="Spacing" Value="{Binding ConnectionSpacing, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="Direction" Value="{Binding Output.Flow, Converter={StaticResource FlowToDirectionConverter}}" />
+            <Setter Property="SourceOrientation" Value="{Binding Output.Node.Orientation}" />
+            <Setter Property="TargetOrientation" Value="{Binding Input.Node.Orientation}" />
             <Setter Property="DirectionalArrowsCount" Value="{Binding DirectionalArrowsCount, Source={x:Static local:EditorSettings.Instance}}" />
             <Setter Property="Text" Value="{Binding ConnectionText, Source={x:Static local:EditorSettings.Instance}}" />
         </Style>
@@ -240,6 +242,8 @@
                                     <nodify:Connection Source="{TemplateBinding SourceAnchor}"
                                                        Target="{TemplateBinding TargetAnchor}"
                                                        Direction="{TemplateBinding Direction}"
+                                                       SourceOrientation="{Binding Source.Node.Orientation}"
+                                                       TargetOrientation="{Binding TargetOrientation}"
                                                        DirectionalArrowsCount="{Binding DirectionalArrowsCount, Source={x:Static local:EditorSettings.Instance}}"
                                                        StrokeThickness="{TemplateBinding StrokeThickness}"
                                                        SourceOffset="{Binding ConnectionSourceOffset.Size, Source={x:Static local:EditorSettings.Instance}}"
@@ -380,6 +384,58 @@
                     <nodify:Node Input="{Binding Input}"
                                  Output="{Binding Output}"
                                  Header="{Binding Title}" />
+                </DataTemplate>
+
+                <DataTemplate DataType="{x:Type local:VerticalNodeViewModel}">
+                    <nodify:Node Header="{Binding Input}"
+                                 Footer="{Binding Output}"
+                                 Content="{Binding Title}">
+                        <nodify:Node.ContentTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" Margin="5" />
+                            </DataTemplate>
+                        </nodify:Node.ContentTemplate>
+                        <nodify:Node.HeaderTemplate>
+                            <DataTemplate>
+                                <ItemsControl ItemsSource="{Binding}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="{x:Type local:ConnectorViewModel}">
+                                            <StackPanel Orientation="Vertical" Margin="5 0 5 0">
+                                                <nodify:Connector Anchor="{Binding Anchor, Mode=OneWayToSource}" />
+                                                <TextBlock Text="{Binding Title}" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Horizontal"  HorizontalAlignment="Center"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                </ItemsControl>
+                            </DataTemplate>
+                        </nodify:Node.HeaderTemplate>
+                        <nodify:Node.FooterTemplate>
+                            <DataTemplate>
+                                <ItemsControl ItemsSource="{Binding}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="{x:Type local:ConnectorViewModel}">
+                                            <StackPanel Orientation="Vertical"
+                                                        Margin="5 0 5 0">
+                                                <TextBlock Text="{Binding Title}" />
+                                                <nodify:Connector Anchor="{Binding Anchor, Mode=OneWayToSource}" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Horizontal"
+                                                        HorizontalAlignment="Center" />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                </ItemsControl>
+                            </DataTemplate>
+                        </nodify:Node.FooterTemplate>
+                    </nodify:Node>
                 </DataTemplate>
             </nodify:NodifyEditor.Resources>
 

--- a/Examples/Nodify.Playground/Editor/PendingConnectionViewModel.cs
+++ b/Examples/Nodify.Playground/Editor/PendingConnectionViewModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Nodify.Playground
+﻿using System.Windows.Controls;
+
+namespace Nodify.Playground
 {
     public class PendingConnectionViewModel : ObservableObject
     {
@@ -13,7 +15,13 @@
         public ConnectorViewModel? Source
         {
             get => _source;
-            set => SetProperty(ref _source, value);
+            set
+            {
+                if(SetProperty(ref _source, value))
+                {
+                    SetTargetOrientation();
+                }
+            }
         }
 
         private object? _previewTarget;
@@ -36,6 +44,13 @@
             set => SetProperty(ref _previewText, value);
         }
 
+        private Orientation _targetOrientation;
+        public Orientation TargetOrientation
+        {
+            get => _targetOrientation;
+            set => SetProperty(ref _targetOrientation, value);
+        }
+
         protected virtual void OnPreviewTargetChanged()
         {
             bool canConnect = PreviewTarget != null && Graph.Schema.CanAddConnection(Source!, PreviewTarget);
@@ -45,6 +60,19 @@
                 ConnectorViewModel con => $"{(canConnect ? "Connect" : "Can't connect")} to {con.Title ?? "pin"}",
                 FlowNodeViewModel flow => $"{(canConnect ? "Connect" : "Can't connect")} to {flow.Title ?? "node"}",
                 _ => null
+            };
+
+            SetTargetOrientation();
+        }
+
+        private void SetTargetOrientation()
+        {
+            TargetOrientation = PreviewTarget switch
+            {
+                ConnectorViewModel con when con.Node is FlowNodeViewModel flow => flow.Orientation,
+                FlowNodeViewModel flow => flow.Orientation,
+                NodifyEditorViewModel editor when Source?.Node is FlowNodeViewModel flow => flow.Orientation,
+                _ => Orientation.Horizontal,
             };
         }
     }

--- a/Examples/Nodify.Playground/Editor/VerticalNodeViewModel.cs
+++ b/Examples/Nodify.Playground/Editor/VerticalNodeViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Nodify.Playground
+{
+    public class VerticalNodeViewModel : FlowNodeViewModel
+    {
+        public VerticalNodeViewModel()
+        {
+            Orientation = Orientation.Vertical;
+        }
+    }
+}

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -108,6 +108,11 @@ namespace Nodify.Playground
                     val => Instance.ConnectionArrowSize = val,
                     "Connection arrowhead size: ",
                     "The size of the arrowhead."),
+                new ProxySettingViewModel<uint>(
+                    () => Instance.DirectionalArrowsCount,
+                    val => Instance.DirectionalArrowsCount = val,
+                    "Directional arrows count: ",
+                    "The number of arrowheads to draw on the line flowing in the direction of the connection."),
                 new ProxySettingViewModel<ArrowHeadEnds>(
                     () => Instance.ArrowHeadEnds,
                     val => Instance.ArrowHeadEnds = val,
@@ -400,6 +405,13 @@ namespace Nodify.Playground
         {
             get => _connectionTargetOffset;
             set => SetProperty(ref _connectionTargetOffset, value);
+        }
+
+        private uint _directionalArrowsCount;
+        public uint DirectionalArrowsCount
+        {
+            get => _directionalArrowsCount;
+            set => SetProperty(ref _directionalArrowsCount, value);
         }
 
         private PointEditor _connectionArrowSize = new PointEditor { X = 8, Y = 8 };

--- a/Examples/Nodify.Playground/PlaygroundViewModel.cs
+++ b/Examples/Nodify.Playground/PlaygroundViewModel.cs
@@ -36,10 +36,24 @@ namespace Nodify.Playground
 
         private async void GenerateRandomNodes()
         {
-            var nodes = RandomNodesGenerator.GenerateNodes<FlowNodeViewModel>(new NodesGeneratorSettings(Settings.MinNodes)
+            uint minNodesByType = Settings.MinNodes / 2;
+            uint maxNodesByType = Settings.MaxNodes / 2;
+
+            var nodes = RandomNodesGenerator.GenerateNodes<FlowNodeViewModel>(new NodesGeneratorSettings(minNodesByType)
             {
-                MinNodesCount = Settings.MinNodes,
-                MaxNodesCount = Settings.MaxNodes,
+                MinNodesCount = minNodesByType,
+                MaxNodesCount = maxNodesByType,
+                MinInputCount = Settings.MinConnectors,
+                MaxInputCount = Settings.MaxConnectors,
+                MinOutputCount = Settings.MinConnectors,
+                MaxOutputCount = Settings.MaxConnectors,
+                GridSnap = EditorSettings.Instance.GridSpacing
+            });
+
+            var verticalNodes = RandomNodesGenerator.GenerateNodes<VerticalNodeViewModel>(new NodesGeneratorSettings(minNodesByType)
+            {
+                MinNodesCount = minNodesByType,
+                MaxNodesCount = maxNodesByType,
                 MinInputCount = Settings.MinConnectors,
                 MaxInputCount = Settings.MaxConnectors,
                 MinOutputCount = Settings.MinConnectors,
@@ -49,6 +63,7 @@ namespace Nodify.Playground
 
             GraphViewModel.Nodes.Clear();
             await CopyToAsync(nodes, GraphViewModel.Nodes);
+            await CopyToAsync(verticalNodes, GraphViewModel.Nodes);
 
             if (Settings.ShouldConnectNodes)
             {

--- a/Nodify/Connections/CircuitConnection.cs
+++ b/Nodify/Connections/CircuitConnection.cs
@@ -30,23 +30,67 @@ namespace Nodify
 
         protected override ((Point ArrowStartSource, Point ArrowStartTarget), (Point ArrowEndSource, Point ArrowEndTarget)) DrawLineGeometry(StreamGeometryContext context, Point source, Point target)
         {
-            var (p1, p2, p3) = GetLinePoints(source, target);
+            var (p0, p1, p2) = GetLinePoints(source, target);
 
             context.BeginFigure(source, false, false);
+            context.LineTo(p0, true, true);
             context.LineTo(p1, true, true);
             context.LineTo(p2, true, true);
-            context.LineTo(p3, true, true);
             context.LineTo(target, true, true);
 
             if (Spacing < 1d)
             {
-                return ((p2, source), (p2, target));
+                return ((p1, source), (p1, target));
             }
 
-            return ((p1, source), (p2, target));
+            return ((p0, source), (p1, target));
         }
 
-        private (Point P1, Point P2, Point P3) GetLinePoints(in Point source, in Point target)
+        protected override Point GetTextPosition(FormattedText text, Point source, Point target)
+        {
+            var (p0, p1, p2) = GetLinePoints(source, target);
+
+            Vector deltaSource = p1 - p0;
+            Vector deltaTarget = p2 - p1;
+
+            if (deltaSource.LengthSquared > deltaTarget.LengthSquared)
+            {
+                return new Point((p0.X + p1.X - text.Width) / 2, (p0.Y + p1.Y - text.Height) / 2);
+            }
+
+            return new Point((p2.X + p1.X - text.Width) / 2, (p2.Y + p1.Y - text.Height) / 2);
+        }
+
+        protected override void DrawDirectionalArrowsGeometry(StreamGeometryContext context, Point source, Point target)
+        {
+            var (p0, p1, p2) = GetLinePoints(source, target);
+
+            Vector deltaSource = p1 - p0;
+            Vector deltaTarget = p2 - p1;
+
+            double lengthRatio = deltaTarget.LengthSquared / (deltaSource.LengthSquared + deltaTarget.LengthSquared);
+
+            int segment1ArrowCount = (int)Math.Round(DirectionalArrowsCount * (1 - lengthRatio));
+            DrawDirectionalArrowsToSegment(context, p0, p1, segment1ArrowCount);
+
+            int segment2ArrowCount = (int)DirectionalArrowsCount - segment1ArrowCount;
+            DrawDirectionalArrowsToSegment(context, p1, p2, segment2ArrowCount);
+        }
+
+        private void DrawDirectionalArrowsToSegment(StreamGeometryContext context, Point p0, Point p1, int arrowsCount)
+        {
+            double spacing = 1d / (arrowsCount + 1);
+            for (int i = 1; i <= arrowsCount; i++)
+            {
+                var direction = p0 - p1;
+                double t = spacing * i;
+                var to = InterpolateLineSegment(p0, p1, t);
+
+                base.DrawDirectionalArrowheadGeometry(context, direction, to);
+            }
+        }
+
+        private (Point P0, Point P1, Point P2) GetLinePoints(in Point source, in Point target)
         {
             double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
             var spacing = new Vector(Spacing * direction, 0d);
@@ -98,22 +142,6 @@ namespace Nodify
             }
 
             return new Point(target.X, source.Y - slopeHeight);
-        }
-
-        protected override Point GetTextPosition(FormattedText text)
-        {
-            (Vector sourceOffset, Vector targetOffset) = GetOffset();
-            var (p1, p2, p3) = GetLinePoints(Source + sourceOffset, Target + targetOffset);
-
-            Vector deltaSource = p1 - p2;
-            Vector deltaTarget = p3 - p2;
-
-            if (deltaSource.LengthSquared > deltaTarget.LengthSquared)
-            {
-                return new Point((p1.X + p2.X - text.Width) / 2, (p1.Y + p2.Y - text.Height) / 2);
-            }
-
-            return new Point((p3.X + p2.X - text.Width) / 2, (p3.Y + p2.Y - text.Height) / 2);
         }
     }
 }

--- a/Nodify/Connections/Connection.cs
+++ b/Nodify/Connections/Connection.cs
@@ -39,8 +39,8 @@ namespace Nodify
             {
                 double t = spacing * i;
                 var to = InterpolateCubicBezier(p0, p1, p2, p3, t);
-
                 var direction = GetBezierTangent(p0, p1, p2, p3, t);
+
                 base.DrawDirectionalArrowheadGeometry(context, direction, to);
             }
         }

--- a/Nodify/Connections/Connection.cs
+++ b/Nodify/Connections/Connection.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 namespace Nodify
 {
     /// <summary>
-    /// Represents a quadratic curve.
+    /// Represents a cubic bezier curve.
     /// </summary>
     public class Connection : BaseConnection
     {
@@ -38,10 +38,9 @@ namespace Nodify
             for (int i = 1; i <= DirectionalArrowsCount; i++)
             {
                 double t = spacing * i;
-                var from = InterpolateCubicBezier(p0, p1, p2, p3, t - 0.01);
                 var to = InterpolateCubicBezier(p0, p1, p2, p3, t);
 
-                var direction = from - to;
+                var direction = GetBezierTangent(p0, p1, p2, p3, t);
                 base.DrawDirectionalArrowheadGeometry(context, direction, to);
             }
         }
@@ -88,6 +87,15 @@ namespace Nodify
             Point p3 = endPoint;
 
             return (p0, p1, p2, p3);
+        }
+
+        private static Vector GetBezierTangent(Point P0, Point P1, Point P2, Point P3, double t)
+        {
+            // Calculate the derivatives of the Bezier curve equation and negate the result
+            return -(-3 * (1 - t) * (1 - t) * (Vector)P0 +
+                    (3 * (1 - t) * (1 - t) * (Vector)P1 - 6 * t * (1 - t) * (Vector)P1) +
+                    (6 * t * (1 - t) * (Vector)P2 - 3 * t * t * (Vector)P2) +
+                    3 * t * t * (Vector)P3);
         }
 
         protected static Point InterpolateCubicBezier(Point P0, Point P1, Point P2, Point P3, double t)

--- a/Nodify/Connections/LineConnection.cs
+++ b/Nodify/Connections/LineConnection.cs
@@ -17,16 +17,11 @@ namespace Nodify
 
         protected override ((Point ArrowStartSource, Point ArrowStartTarget), (Point ArrowEndSource, Point ArrowEndTarget)) DrawLineGeometry(StreamGeometryContext context, Point source, Point target)
         {
-            double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
-            var spacing = new Vector(Spacing * direction, 0d);
-            var spacingVertical = new Vector(spacing.Y, spacing.X);
-
-            Point p1 = source + (SourceOrientation == Orientation.Vertical ? spacingVertical : spacing);
-            Point p2 = target - (TargetOrientation == Orientation.Vertical ? spacingVertical : spacing);
+            var (p0, p1) = GetLinePoints(source, target);
 
             context.BeginFigure(source, false, false);
+            context.LineTo(p0, true, true);
             context.LineTo(p1, true, true);
-            context.LineTo(p2, true, true);
             context.LineTo(target, true, true);
 
             return ((target, source), (source, target));
@@ -55,6 +50,38 @@ namespace Nodify
             {
                 base.DrawDefaultArrowhead(context, source, target, arrowDirection, orientation);
             }
+        }
+
+        protected override void DrawDirectionalArrowsGeometry(StreamGeometryContext context, Point source, Point target)
+        {
+            var (p0, p1) = GetLinePoints(source, target);
+            var direction = p0 - p1;
+
+            double spacing = 1d / (DirectionalArrowsCount + 1);
+            for (int i = 1; i <= DirectionalArrowsCount; i++)
+            {
+                double t = spacing * i;
+                var to = InterpolateLineSegment(p0, p1, t);
+
+                base.DrawDirectionalArrowheadGeometry(context, direction, to);
+            }
+        }
+
+        private (Point P0, Point P1) GetLinePoints(Point source, Point target)
+        {
+            double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
+            var spacing = new Vector(Spacing * direction, 0d);
+            var spacingVertical = new Vector(spacing.Y, spacing.X);
+
+            var p0 = source + (SourceOrientation == Orientation.Vertical ? spacingVertical : spacing);
+            var p1 = target - (TargetOrientation == Orientation.Vertical ? spacingVertical : spacing);
+
+            return (p0, p1);
+        }
+
+        protected static Point InterpolateLineSegment(Point p0, Point p1, double t)
+        {
+            return (Point)((1 - t) * (Vector)p0 + t * (Vector)p1);
         }
     }
 }

--- a/Nodify/Helpers/BoxValue.cs
+++ b/Nodify/Helpers/BoxValue.cs
@@ -18,6 +18,7 @@ namespace Nodify
         public static readonly object Int0 = 0;
         public static readonly object Int1 = 1;
         public static readonly object UInt1 = 1u;
+        public static readonly object UInt0 = 0u;
 
         public static readonly object Thickness2 = new Thickness(2);
         public static readonly object ArrowSize = new Size(8, 8);

--- a/Nodify/Nodify.csproj
+++ b/Nodify/Nodify.csproj
@@ -26,7 +26,7 @@
       >	  - Added DirectionalArrowsCount to BaseConnection to allow drawing multipe arrows on a connection flowing in the connection direction
       >	  - Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to allow customizing the directional arrows
       > - Bugfixes:
-      >	  - Fixed BaseConnection.Text not always displaying in the center of connection
+      >	  - Fixed BaseConnection.Text not always displaying in the center of the connection
     </PackageReleaseNotes>
     <AssemblyOriginatorKeyFile>..\build\Nodify.snk</AssemblyOriginatorKeyFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Nodify/Nodify.csproj
+++ b/Nodify/Nodify.csproj
@@ -24,7 +24,7 @@
       > - Features:
       >	  - Added SourceOrientation and TargetOrientation to BaseConnection to support vertical connectors (vertical/mixed connection orientation)
       >	  - Added DirectionalArrowsCount to BaseConnection to allow drawing multipe arrows on a connection flowing in the connection direction
-      >	  - Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to allow customizing the directional arrows
+      >	  - Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to BaseConnection to allow customizing the directional arrows
       > - Bugfixes:
       >	  - Fixed BaseConnection.Text not always displaying in the center of the connection
     </PackageReleaseNotes>

--- a/Nodify/Nodify.csproj
+++ b/Nodify/Nodify.csproj
@@ -16,13 +16,17 @@
     <PackageIcon>icon.png</PackageIcon>
     <RepositoryUrl>https://github.com/miroiu/nodify</RepositoryUrl>
     <PackageTags>wpf mvvm node-editor controls</PackageTags>
-    <Version>5.2.0</Version>
+    <Version>5.3.0</Version>
     <PackageReleaseNotes>
+      > - Breaking Changes:
+      >	  - Added a parameter for the orientation to DrawArrowGeometry, DrawDefaultArrowhead, DrawRectangleArrowhead and DrawEllipseArrowhead in BaseConnection
+      >	  - Added source and target parameters to GetTextPosition in BaseConnection
       > - Features:
-      >	  - Added Text to BaseConnection, allowing displaying of text on connections
-      >  	- Added Foreground, FontSize, FontWeight, FontStyle, FontStretch and FontFamily to BaseConnection, allowing styling the displaying text
+      >	  - Added SourceOrientation and TargetOrientation to BaseConnection to support vertical connectors (vertical/mixed connection orientation)
+      >	  - Added DirectionalArrowsCount to BaseConnection to allow drawing multipe arrows on a connection flowing in the connection direction
+      >	  - Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to allow customizing the directional arrows
       > - Bugfixes:
-      >   - Fixed MouseCapture not being released when EnableStickyConnections is enabled and the PendingConnection is canceled by a key gesture
+      >	  - Fixed BaseConnection.Text not always displaying in the center of connection
     </PackageReleaseNotes>
     <AssemblyOriginatorKeyFile>..\build\Nodify.snk</AssemblyOriginatorKeyFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
<!-- 
  ## Hello and welcome!

  Consider creating an issue or link to an existing one before submitting the pull request. Thanks!
-->

### 📝 Description of the Change

Added directional arrows to all connection types that can be displayed by setting `DirectionalArrowsCount`.

> Note that the arrows will flow in the direction of the connection (BaseConnection.Direction) and the arrowhead size is determined by BaseConnection.ArrowSize

![image](https://github.com/miroiu/nodify/assets/12727904/e74f0506-de58-41be-92d1-9ea76f071b5a)
![image](https://github.com/miroiu/nodify/assets/12727904/c06ed5fa-235c-436d-895f-dacab9c92983)
![image](https://github.com/miroiu/nodify/assets/12727904/97c9ac10-6852-4b9a-a023-7a871f986b37)


### 🐛 Possible Drawbacks

Introduces breaking changes that may affect some code bases. There's no way to draw directional arrows by default (developers must override DrawDirectionalArrowsGeometry for each custom connection).
