### PR TITLE
Allow changing editor gestures at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 >	- Added DirectionalArrowsCount to BaseConnection to allow drawing multipe arrows on a connection flowing in the connection direction
 >	- Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to BaseConnection to allow customizing the directional arrows
 >	- Improved EditorGestures to allow changing input gestures at runtime
->	- Added new gesture types: AnyGesture, AllGestures and InputGestureRef
+>	- Added new gesture types: AnyGesture, AllGestures, and InputGestureRef
 > - Bugfixes:
 >	- Fixed BaseConnection.Text not always displaying in the center of the connection
 >	- Fixed a bug where the item container would incorrectly transition to the dragging state on mouse over

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 >	- Added source and target parameters to GetTextPosition in BaseConnection
 >	- EditorGestures is now a singleton instead of a static class (can be inherited to create custom mappings)
 >	- Selection gestures for ItemContainer and GroupingNode are now separated from the NodifyEditor selection gestures
+>	- Renamed EditorGestures.Editor.Zoom to ZoomModifierKey
 > - Features:
 >	- Added SourceOrientation and TargetOrientation to BaseConnection to support vertical connectors (vertical/mixed connection orientation)
 >	- Added DirectionalArrowsCount to BaseConnection to allow drawing multipe arrows on a connection flowing in the connection direction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@
 > - Breaking Changes:
 >	- Added a parameter for the orientation to DrawArrowGeometry, DrawDefaultArrowhead, DrawRectangleArrowhead and DrawEllipseArrowhead in BaseConnection
 >	- Added source and target parameters to GetTextPosition in BaseConnection
+>	- EditorGestures is now a singleton instead of a static class (can be inherited to create custom mappings)
+>	- Selection gestures for ItemContainer and GroupingNode are now separated from the NodifyEditor selection gestures
 > - Features:
 >	- Added SourceOrientation and TargetOrientation to BaseConnection to support vertical connectors (vertical/mixed connection orientation)
 >	- Added DirectionalArrowsCount to BaseConnection to allow drawing multipe arrows on a connection flowing in the connection direction
 >	- Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to BaseConnection to allow customizing the directional arrows
+>	- Improved EditorGestures to allow changing input gestures at runtime
+>	- Added new gesture types: AnyGesture, AllGestures and InputGestureRef
 > - Bugfixes:
 >	- Fixed BaseConnection.Text not always displaying in the center of the connection
+>	- Fixed a bug where the item container would incorrectly transition to the dragging state on mouse over
 
 #### **Version 5.2.0**
 

--- a/Examples/Nodify.Calculator/OperationViewModel.cs
+++ b/Examples/Nodify.Calculator/OperationViewModel.cs
@@ -20,7 +20,7 @@ namespace Nodify.Calculator
             });
         }
 
-        private void OnInputValueChanged(object sender, PropertyChangedEventArgs e)
+        private void OnInputValueChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(ConnectorViewModel.Value))
             {

--- a/Examples/Nodify.Playground/EditorInputMode.cs
+++ b/Examples/Nodify.Playground/EditorInputMode.cs
@@ -1,0 +1,69 @@
+﻿using System.Windows.Input;
+
+namespace Nodify.Playground
+{
+    public enum EditorInputMode
+    {
+        Default,
+        PanOnly,
+        SelectOnly
+    }
+
+    public enum EditorInputMappings
+    {
+        Default,
+        Blender3D
+    }
+
+    public static class EditorInputModeExtensions
+    {
+        public static void Apply(this EditorGestures mappings, EditorInputMode inputMode)
+        {
+            mappings.Apply(PlaygroundSettings.Instance.EditorInputMappings.ToInputMappings());
+
+            switch (inputMode)
+            {
+                case EditorInputMode.PanOnly:
+                    mappings.Editor.Selection.Apply(EditorGestures.SelectionGestures.None);
+                    mappings.ItemContainer.Selection.Apply(EditorGestures.SelectionGestures.None);
+                    mappings.ItemContainer.Drag.Value = MultiGesture.None;
+                    mappings.Connector.Connect.Value = MultiGesture.None;
+                    break;
+                case EditorInputMode.SelectOnly:
+                    mappings.Editor.Pan.Value = MultiGesture.None;
+                    mappings.ItemContainer.Drag.Value = MultiGesture.None;
+                    mappings.Connector.Connect.Value = MultiGesture.None;
+                    break;
+                case EditorInputMode.Default:
+                    break;
+            }
+        }
+
+        public static void Apply(this EditorGestures value, EditorInputMappings mappings)
+        {
+            var newMappings = mappings.ToInputMappings();
+            value.Apply(newMappings);
+        }
+
+        public static EditorGestures ToInputMappings(this EditorInputMappings mappings)
+        {
+            return mappings switch
+            {
+                EditorInputMappings.Blender3D => new Blender3DInputMappings(),
+                _ => new EditorGestures()
+            };
+        }
+    }
+
+    public class Blender3DInputMappings : EditorGestures
+    {
+        public Blender3DInputMappings()
+        {
+            Editor.Pan.Value = new AnyGesture(new MouseGesture(MouseAction.LeftClick), new MouseGesture(MouseAction.MiddleClick));
+            Editor.Selection.Apply(new SelectionGestures(MouseAction.RightClick));
+            // comment to drag with right click - we copy the default gestures of the item container which uses left click for selection
+            ItemContainer.Drag.Value = new AnyGesture(ItemContainer.Selection.Replace.Value, ItemContainer.Selection.Remove.Value, ItemContainer.Selection.Append.Value, ItemContainer.Selection.Invert.Value);
+            ItemContainer.Selection.Apply(new SelectionGestures(MouseAction.RightClick));
+        }
+    }
+}

--- a/Examples/Nodify.Playground/EditorInputMode.cs
+++ b/Examples/Nodify.Playground/EditorInputMode.cs
@@ -9,17 +9,17 @@ namespace Nodify.Playground
         SelectOnly
     }
 
-    public enum EditorInputMappings
+    public enum EditorGesturesMappings
     {
         Default,
-        Blender3D
+        Custom
     }
 
     public static class EditorInputModeExtensions
     {
         public static void Apply(this EditorGestures mappings, EditorInputMode inputMode)
         {
-            mappings.Apply(PlaygroundSettings.Instance.EditorInputMappings.ToInputMappings());
+            mappings.Apply(PlaygroundSettings.Instance.EditorGesturesMappings.ToGesturesMappings());
 
             switch (inputMode)
             {
@@ -39,25 +39,25 @@ namespace Nodify.Playground
             }
         }
 
-        public static void Apply(this EditorGestures value, EditorInputMappings mappings)
+        public static void Apply(this EditorGestures value, EditorGesturesMappings mappings)
         {
-            var newMappings = mappings.ToInputMappings();
+            var newMappings = mappings.ToGesturesMappings();
             value.Apply(newMappings);
         }
 
-        public static EditorGestures ToInputMappings(this EditorInputMappings mappings)
+        public static EditorGestures ToGesturesMappings(this EditorGesturesMappings mappings)
         {
             return mappings switch
             {
-                EditorInputMappings.Blender3D => new Blender3DInputMappings(),
+                EditorGesturesMappings.Custom => new CustomGesturesMappings(),
                 _ => new EditorGestures()
             };
         }
     }
 
-    public class Blender3DInputMappings : EditorGestures
+    public class CustomGesturesMappings : EditorGestures
     {
-        public Blender3DInputMappings()
+        public CustomGesturesMappings()
         {
             Editor.Pan.Value = new AnyGesture(new MouseGesture(MouseAction.LeftClick), new MouseGesture(MouseAction.MiddleClick));
             Editor.Selection.Apply(new SelectionGestures(MouseAction.RightClick));

--- a/Examples/Nodify.Playground/EditorInputMode.cs
+++ b/Examples/Nodify.Playground/EditorInputMode.cs
@@ -60,6 +60,7 @@ namespace Nodify.Playground
         public CustomGesturesMappings()
         {
             Editor.Pan.Value = new AnyGesture(new MouseGesture(MouseAction.LeftClick), new MouseGesture(MouseAction.MiddleClick));
+            Editor.ZoomModifierKey = ModifierKeys.Control;
             Editor.Selection.Apply(new SelectionGestures(MouseAction.RightClick));
             // comment to drag with right click - we copy the default gestures of the item container which uses left click for selection
             ItemContainer.Drag.Value = new AnyGesture(ItemContainer.Selection.Replace.Value, ItemContainer.Selection.Remove.Value, ItemContainer.Selection.Append.Value, ItemContainer.Selection.Invert.Value);

--- a/Examples/Nodify.Playground/EditorInputMode.cs
+++ b/Examples/Nodify.Playground/EditorInputMode.cs
@@ -63,7 +63,7 @@ namespace Nodify.Playground
             Editor.Selection.Apply(new SelectionGestures(MouseAction.RightClick));
             // comment to drag with right click - we copy the default gestures of the item container which uses left click for selection
             ItemContainer.Drag.Value = new AnyGesture(ItemContainer.Selection.Replace.Value, ItemContainer.Selection.Remove.Value, ItemContainer.Selection.Append.Value, ItemContainer.Selection.Invert.Value);
-            ItemContainer.Selection.Apply(new SelectionGestures(MouseAction.RightClick));
+            ItemContainer.Selection.Apply(Editor.Selection);
         }
     }
 }

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -89,7 +89,7 @@ namespace Nodify.Playground
                     () => Instance.ConnectionStyle,
                     val => Instance.ConnectionStyle = val,
                     "Connection style: "),
-                new ProxySettingViewModel<string>(
+                new ProxySettingViewModel<string?>(
                     () => Instance.ConnectionText,
                     val => Instance.ConnectionText = val,
                     "Connection text: "),
@@ -344,8 +344,8 @@ namespace Nodify.Playground
             set => SetProperty(ref _connectionStyle, value);
         }
 
-        private string _connectionText;
-        public string ConnectionText
+        private string? _connectionText;
+        public string? ConnectionText
         {
             get => _connectionText;
             set => SetProperty(ref _connectionText, value);

--- a/Examples/Nodify.Playground/PlaygroundSettings.cs
+++ b/Examples/Nodify.Playground/PlaygroundSettings.cs
@@ -11,9 +11,9 @@ namespace Nodify.Playground
         {
             Settings = new ObservableCollection<ISettingViewModel>()
             {
-                new ProxySettingViewModel<EditorInputMappings>(
-                    () => Instance.EditorInputMappings,
-                    val => Instance.EditorInputMappings = val,
+                new ProxySettingViewModel<EditorGesturesMappings>(
+                    () => Instance.EditorGesturesMappings,
+                    val => Instance.EditorGesturesMappings = val,
                     "Editor input mappings"),
                 new ProxySettingViewModel<EditorInputMode>(
                     () => Instance.EditorInputMode,
@@ -60,11 +60,11 @@ namespace Nodify.Playground
 
         public static PlaygroundSettings Instance { get; } = new PlaygroundSettings();
 
-        private EditorInputMappings _editorInputMappings;
-        public EditorInputMappings EditorInputMappings
+        private EditorGesturesMappings _editorGesturesMappings;
+        public EditorGesturesMappings EditorGesturesMappings
         {
-            get => _editorInputMappings;
-            set => SetProperty(ref _editorInputMappings, value)
+            get => _editorGesturesMappings;
+            set => SetProperty(ref _editorGesturesMappings, value)
                 .Then(() => EditorGestures.Mappings.Apply(value));
         }
 

--- a/Examples/Nodify.Playground/PlaygroundSettings.cs
+++ b/Examples/Nodify.Playground/PlaygroundSettings.cs
@@ -64,14 +64,16 @@ namespace Nodify.Playground
         public EditorInputMappings EditorInputMappings
         {
             get => _editorInputMappings;
-            set => SetProperty(ref _editorInputMappings, value);
+            set => SetProperty(ref _editorInputMappings, value)
+                .Then(() => EditorGestures.Mappings.Apply(value));
         }
 
         private EditorInputMode _editorInputMode;
         public EditorInputMode EditorInputMode
         {
             get => _editorInputMode;
-            set => SetProperty(ref _editorInputMode, value);
+            set => SetProperty(ref _editorInputMode, value)
+                .Then(() => EditorGestures.Mappings.Apply(value));
         }
 
         private bool _shouldConnectNodes = true;

--- a/Examples/Nodify.Playground/PlaygroundSettings.cs
+++ b/Examples/Nodify.Playground/PlaygroundSettings.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace Nodify.Playground
@@ -12,6 +11,14 @@ namespace Nodify.Playground
         {
             Settings = new ObservableCollection<ISettingViewModel>()
             {
+                new ProxySettingViewModel<EditorInputMappings>(
+                    () => Instance.EditorInputMappings,
+                    val => Instance.EditorInputMappings = val,
+                    "Editor input mappings"),
+                new ProxySettingViewModel<EditorInputMode>(
+                    () => Instance.EditorInputMode,
+                    val => Instance.EditorInputMode = val,
+                    "Editor input mode"),
                 new ProxySettingViewModel<bool>(
                     () => Instance.ShowGridLines,
                     val => Instance.ShowGridLines = val,
@@ -52,6 +59,20 @@ namespace Nodify.Playground
         }
 
         public static PlaygroundSettings Instance { get; } = new PlaygroundSettings();
+
+        private EditorInputMappings _editorInputMappings;
+        public EditorInputMappings EditorInputMappings
+        {
+            get => _editorInputMappings;
+            set => SetProperty(ref _editorInputMappings, value);
+        }
+
+        private EditorInputMode _editorInputMode;
+        public EditorInputMode EditorInputMode
+        {
+            get => _editorInputMode;
+            set => SetProperty(ref _editorInputMode, value);
+        }
 
         private bool _shouldConnectNodes = true;
         public bool ShouldConnectNodes

--- a/Examples/Nodify.Playground/PlaygroundViewModel.cs
+++ b/Examples/Nodify.Playground/PlaygroundViewModel.cs
@@ -19,12 +19,27 @@ namespace Nodify.Playground
 
             BindingOperations.EnableCollectionSynchronization(GraphViewModel.Nodes, GraphViewModel.Nodes);
             BindingOperations.EnableCollectionSynchronization(GraphViewModel.Connections, GraphViewModel.Connections);
+
+            Settings.PropertyChanged += OnSettingsChanged;
+        }
+
+        private void OnSettingsChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(PlaygroundSettings.EditorInputMappings))
+            {
+                EditorGestures.Mappings.Apply(Settings.EditorInputMappings);
+            }
+            else if (e.PropertyName == nameof(PlaygroundSettings.EditorInputMode))
+            {
+                EditorGestures.Mappings.Apply(Settings.EditorInputMode);
+            }
         }
 
         public ICommand GenerateRandomNodesCommand { get; }
         public ICommand PerformanceTestCommand { get; }
         public ICommand ToggleConnectionsCommand { get; }
         public ICommand ResetCommand { get; }
+
         public PlaygroundSettings Settings => PlaygroundSettings.Instance;
 
         private void ResetGraph()

--- a/Examples/Nodify.Playground/PlaygroundViewModel.cs
+++ b/Examples/Nodify.Playground/PlaygroundViewModel.cs
@@ -19,27 +19,12 @@ namespace Nodify.Playground
 
             BindingOperations.EnableCollectionSynchronization(GraphViewModel.Nodes, GraphViewModel.Nodes);
             BindingOperations.EnableCollectionSynchronization(GraphViewModel.Connections, GraphViewModel.Connections);
-
-            Settings.PropertyChanged += OnSettingsChanged;
-        }
-
-        private void OnSettingsChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(PlaygroundSettings.EditorInputMappings))
-            {
-                EditorGestures.Mappings.Apply(Settings.EditorInputMappings);
-            }
-            else if (e.PropertyName == nameof(PlaygroundSettings.EditorInputMode))
-            {
-                EditorGestures.Mappings.Apply(Settings.EditorInputMode);
-            }
         }
 
         public ICommand GenerateRandomNodesCommand { get; }
         public ICommand PerformanceTestCommand { get; }
         public ICommand ToggleConnectionsCommand { get; }
         public ICommand ResetCommand { get; }
-
         public PlaygroundSettings Settings => PlaygroundSettings.Instance;
 
         private void ResetGraph()

--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -647,7 +647,8 @@ namespace Nodify
 
             this.CaptureMouseSafe();
 
-            if (EditorGestures.Connection.Split.Matches(e.Source, e) && (SplitCommand?.CanExecute(this) ?? false))
+            EditorGestures.ConnectionGestures gestures = EditorGestures.Mappings.Connection;
+            if (gestures.Split.Matches(e.Source, e) && (SplitCommand?.CanExecute(this) ?? false))
             {
                 Point splitLocation = e.GetPosition(this);
                 object? connection = DataContext;
@@ -668,7 +669,7 @@ namespace Nodify
 
                 e.Handled = true;
             }
-            else if (EditorGestures.Connection.Disconnect.Matches(e.Source, e) && (DisconnectCommand?.CanExecute(this) ?? false))
+            else if (gestures.Disconnect.Matches(e.Source, e) && (DisconnectCommand?.CanExecute(this) ?? false))
             {
                 Point splitLocation = e.GetPosition(this);
                 object? connection = DataContext;

--- a/Nodify/Connections/Connector.cs
+++ b/Nodify/Connections/Connector.cs
@@ -327,11 +327,12 @@ namespace Nodify
 
             e.Handled = true;
 
-            if (EditorGestures.Connector.Disconnect.Matches(e.Source, e))
+            EditorGestures.ConnectorGestures gestures = EditorGestures.Mappings.Connector;
+            if (gestures.Disconnect.Matches(e.Source, e))
             {
                 OnDisconnect();
             }
-            else if (EditorGestures.Connector.Connect.Matches(e.Source, e))
+            else if (gestures.Connect.Matches(e.Source, e))
             {
                 if (EnableStickyConnections && IsPendingConnection)
                 {
@@ -351,12 +352,13 @@ namespace Nodify
             // Don't select the ItemContainer when starting a pending connecton for sticky connections
             e.Handled = EnableStickyConnections && IsPendingConnection;
 
-            if (!EnableStickyConnections && EditorGestures.Connector.Connect.Matches(e.Source, e))
+            EditorGestures.ConnectorGestures gestures = EditorGestures.Mappings.Connector;
+            if (!EnableStickyConnections && gestures.Connect.Matches(e.Source, e))
             {
                 OnConnectorDragCompleted();
                 e.Handled = true;
             }
-            else if (AllowPendingConnectionCancellation && IsPendingConnection && EditorGestures.Connector.CancelAction.Matches(e.Source, e))
+            else if (AllowPendingConnectionCancellation && IsPendingConnection && gestures.CancelAction.Matches(e.Source, e))
             {
                 // Cancel pending connection
                 OnConnectorDragCompleted(cancel: true);
@@ -375,7 +377,7 @@ namespace Nodify
         /// <inheritdoc />
         protected override void OnKeyUp(KeyEventArgs e)
         {
-            if (AllowPendingConnectionCancellation && EditorGestures.Connector.CancelAction.Matches(e.Source, e))
+            if (AllowPendingConnectionCancellation && EditorGestures.Mappings.Connector.CancelAction.Matches(e.Source, e))
             {
                 // Cancel pending connection
                 OnConnectorDragCompleted(cancel: true);

--- a/Nodify/EditorCommands.cs
+++ b/Nodify/EditorCommands.cs
@@ -28,7 +28,7 @@ namespace Nodify
         /// </summary>
         public static RoutedUICommand ZoomIn { get; } = new RoutedUICommand("Zoom in", nameof(ZoomIn), typeof(EditorCommands), new InputGestureCollection
         {
-           EditorGestures.ZoomIn 
+           EditorGestures.Mappings.Editor.ZoomIn
         });
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Nodify
         /// </summary>
         public static RoutedUICommand ZoomOut { get; } = new RoutedUICommand("Zoom out", nameof(ZoomOut), typeof(EditorCommands), new InputGestureCollection
         {
-            EditorGestures.ZoomOut
+            EditorGestures.Mappings.Editor.ZoomOut
         });
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Nodify
         /// </summary>
         public static RoutedUICommand BringIntoView { get; } = new RoutedUICommand("Bring location into view", nameof(BringIntoView), typeof(EditorCommands), new InputGestureCollection
         {
-            EditorGestures.ResetViewportLocation
+            EditorGestures.Mappings.Editor.ResetViewportLocation
         });
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Nodify
         /// </summary>
         public static RoutedUICommand FitToScreen { get; } = new RoutedUICommand("Fit to screen", nameof(FitToScreen), typeof(EditorCommands), new InputGestureCollection
         {
-            EditorGestures.FitToScreen
+            EditorGestures.Mappings.Editor.FitToScreen
         });
 
         /// <summary>

--- a/Nodify/EditorGestures.cs
+++ b/Nodify/EditorGestures.cs
@@ -2,117 +2,262 @@
 
 namespace Nodify
 {
-    /// <summary>Gestures used by the <see cref="NodifyEditor"/>.</summary>
-    public static class EditorGestures
+    /// <summary>Gestures used by built-in controls inside the <see cref="NodifyEditor"/>.</summary>
+    public class EditorGestures
     {
-        /// <summary>The selection strategies.</summary>
-        public static class Selection
+        public static readonly EditorGestures Mappings = new EditorGestures();
+
+        /// <summary>Gestures for the selection.</summary>
+        public class SelectionGestures
         {
-            /// <summary>The default <see cref="MouseAction"/> to use for selection.</summary>
-            public static MouseAction DefaultMouseAction { get; set; } = MouseAction.LeftClick;
+            /// <summary>Disable selection gestures.</summary>
+            public static readonly SelectionGestures None = new SelectionGestures(MouseAction.None);
+
+            public SelectionGestures(MouseAction mouseAction)
+            {
+                Replace = new MouseGesture(mouseAction);
+                Remove = new MouseGesture(mouseAction, ModifierKeys.Alt);
+                Append = new MouseGesture(mouseAction, ModifierKeys.Shift);
+                Invert = new MouseGesture(mouseAction, ModifierKeys.Control);
+                Select = new AnyGesture(Replace, Remove, Append, Invert);
+                Cancel = new KeyGesture(Key.Escape);
+            }
+
+            public SelectionGestures() : this(MouseAction.LeftClick)
+            {
+            }
 
             /// <summary>Gesture to replace previous selection with the selected items.</summary>
-            /// <remarks>Defaults to <see cref="DefaultMouseAction"/>.</remarks>
-            public static InputGesture Replace { get; set; } = new MouseGesture(DefaultMouseAction);
+            /// <remarks>Defaults to <see cref="MouseAction.LeftClick"/>.</remarks>
+            public InputGestureRef Replace { get; }
 
             /// <summary>Gesture to remove the selected items from the previous selection.</summary>
-            /// <remarks>Defaults to <see cref="ModifierKeys.Alt"/>+<see cref="DefaultMouseAction"/>.</remarks>
-            public static InputGesture Remove { get; set; } = new MouseGesture(DefaultMouseAction, ModifierKeys.Alt);
+            /// <remarks>Defaults to <see cref="ModifierKeys.Alt"/>+<see cref="MouseAction.LeftClick"/>.</remarks>
+            public InputGestureRef Remove { get; }
 
             /// <summary>Gesture to add the new selected items to the previous selection.</summary>
-            /// <remarks>Defaults to <see cref="ModifierKeys.Shift"/>+<see cref="DefaultMouseAction"/>.</remarks>
-            public static InputGesture Append { get; set; } = new MouseGesture(DefaultMouseAction, ModifierKeys.Shift);
+            /// <remarks>Defaults to <see cref="ModifierKeys.Shift"/>+<see cref="MouseAction.LeftClick"/>.</remarks>
+            public InputGestureRef Append { get; }
 
             /// <summary>Gesture to invert the selected items.</summary>
-            /// <remarks>Defaults to <see cref="ModifierKeys.Control"/>+<see cref="DefaultMouseAction"/>.</remarks>
-            public static InputGesture Invert { get; set; } = new MouseGesture(DefaultMouseAction, ModifierKeys.Control);
+            /// <remarks>Defaults to <see cref="ModifierKeys.Control"/>+<see cref="MouseAction.LeftClick"/>.</remarks>
+            public InputGestureRef Invert { get; }
 
             /// <summary>Cancel the current selection operation reverting to the previous selection.</summary>
             /// <remarks>Defaults to <see cref="Key.Escape"/>.</remarks>
-            public static InputGesture Cancel { get; set; } = new KeyGesture(Key.Escape);
+            public InputGestureRef Cancel { get; }
+
+            /// <summary>Gesture used to start selecting using a <see cref="SelectionGestures"/> strategy.</summary>
+            public InputGestureRef Select { get; }
+
+            /// <summary>Copies from the specified gestures.</summary>
+            /// <param name="gestures">The gestures to copy.</param>
+            public void Apply(SelectionGestures gestures)
+            {
+                Replace.Value = gestures.Replace.Value;
+                Remove.Value = gestures.Remove.Value;
+                Append.Value = gestures.Append.Value;
+                Invert.Value = gestures.Invert.Value;
+                Select.Value = gestures.Select.Value;
+                Cancel.Value = gestures.Cancel.Value;
+            }
         }
 
-        /// <summary>Gesture used to start selecting using a <see cref="Selection"/> strategy.</summary>
-        public static InputGesture Select { get; } = new MultiGesture(MultiGesture.Match.Any, Selection.Replace, Selection.Remove, Selection.Append, Selection.Invert);
-
-        /// <summary>Gesture used to start panning.</summary>
-        /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or <see cref="MouseAction.MiddleClick"/>.</remarks>
-        public static InputGesture Pan { get; set; } = new MultiGesture(MultiGesture.Match.Any, new MouseGesture(MouseAction.RightClick), new MouseGesture(MouseAction.MiddleClick));
-
-        /// <summary>The key modifier required to start zooming by mouse wheel.</summary>
-        /// <remarks>Defaults to <see cref="ModifierKeys.None"/>.</remarks>
-        public static ModifierKeys Zoom { get; set; } = ModifierKeys.None;
-
-        /// <summary>Gesture used to zoom in.</summary>
-        /// <remarks>Defaults to <see cref="ModifierKeys.Control"/>+<see cref="Key.OemPlus"/>.</remarks>
-        public static InputGesture ZoomIn { get; set; } = new MultiGesture(MultiGesture.Match.Any, new KeyGesture(Key.OemPlus, ModifierKeys.Control), new KeyGesture(Key.Add, ModifierKeys.Control));
-
-        /// <summary>Gesture used to zoom out.</summary>
-        /// <remarks>Defaults to <see cref="ModifierKeys.Control"/>+<see cref="Key.OemMinus"/>.</remarks>
-        public static InputGesture ZoomOut { get; set; } = new MultiGesture(MultiGesture.Match.Any, new KeyGesture(Key.OemMinus, ModifierKeys.Control), new KeyGesture(Key.Subtract, ModifierKeys.Control));
-
-        /// <summary>Gesture used to move the editor's viewport location to (0, 0).</summary>
-        /// <remarks>Defaults to <see cref="Key.Home"/>.</remarks>
-        public static InputGesture ResetViewportLocation { get; set; } = new KeyGesture(Key.Home);
-
-        /// <summary>Gesture used to fit as many containers as possible into the viewport.</summary>
-        /// <remarks>Defaults to <see cref="ModifierKeys.Shift"/>+<see cref="Key.Home"/>.</remarks>
-        public static InputGesture FitToScreen { get; set; } = new KeyGesture(Key.Home, ModifierKeys.Shift);
-
-        /// <summary>Gestures used by the <see cref="BaseConnection"/>.</summary>
-        public static class Connection
+        /// <summary>Gestures for the item containers.</summary>
+        public class ItemContainerGestures
         {
-            /// <summary>Gesture to call the <see cref="BaseConnection.SplitCommand"/> command.</summary>
-            /// <remarks>Defaults to <see cref="MouseAction.LeftDoubleClick"/>.</remarks>
-            public static InputGesture Split { get; set; } = new MouseGesture(MouseAction.LeftDoubleClick);
+            public ItemContainerGestures()
+            {
+                Selection = new SelectionGestures();
+                Selection.Select.Value = new AnyGesture(
+                    Selection.Replace,
+                    Selection.Remove,
+                    Selection.Append,
+                    Selection.Invert,
+                    new MouseGesture(MouseAction.RightClick));
 
-            /// <summary>Gesture to call the <see cref="BaseConnection.DisconnectCommand"/> command.</summary>
-            /// <remarks>Defaults to <see cref="ModifierKeys.Alt"/>+<see cref="MouseAction.LeftClick"/>.</remarks>
-            public static InputGesture Disconnect { get; set; } = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Alt);
-        }
+                Drag = new AnyGesture(Selection.Replace, Selection.Remove, Selection.Append, Selection.Invert);
+                CancelAction = new AnyGesture(new MouseGesture(MouseAction.RightClick), new KeyGesture(Key.Escape));
+            }
 
-        /// <summary>Gestures used by the <see cref="Connector"/>.</summary>
-        public static class Connector
-        {
-            /// <summary>Gesture to call the <see cref="Nodify.Connector.DisconnectCommand"/>.</summary>
-            /// <remarks>Defaults to <see cref="ModifierKeys.Alt"/>+<see cref="MouseAction.LeftClick"/>.</remarks>
-            public static InputGesture Disconnect { get; set; } = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Alt);
-
-            /// <summary>Gesture to start and complete a pending connection.</summary>
-            /// <remarks>Defaults to <see cref="MouseAction.LeftClick"/>.</remarks>
-            public static InputGesture Connect { get; set; } = new MouseGesture(MouseAction.LeftClick);
-
-            /// <summary>Gesture to cancel the pending connection.</summary>
-            /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or <see cref="Key.Escape"/>.</remarks>
-            public static InputGesture CancelAction { get; set; } = new MultiGesture(MultiGesture.Match.Any, new MouseGesture(MouseAction.RightClick), new KeyGesture(Key.Escape));
-        }
-
-        /// <summary>Gestures used by the <see cref="ItemContainer"/>.</summary>
-        public static class ItemContainer
-        {
-            /// <summary>Gesture to select the container using a <see cref="Selection"/> strategy.</summary>
-            /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or any of the <see cref="Selection"/> gestures.</remarks>
-            public static InputGesture Select { get; set; } = new MultiGesture(MultiGesture.Match.Any, Selection.Replace, Selection.Remove, Selection.Append, Selection.Invert, new MouseGesture(MouseAction.RightClick));
+            /// <summary>Gesture to select the container using a <see cref="SelectionGestures"/> strategy.</summary>
+            /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or any of the <see cref="SelectionGestures"/> gestures.</remarks>
+            public SelectionGestures Selection { get; }
 
             /// <summary>Gesture to start and complete a dragging operation.</summary>
             /// <remarks>Using a <see cref="Selection"/> strategy to drag from a new selection. 
             /// <br /> Defaults to any of the <see cref="Selection"/> gestures.
             /// </remarks>
-            public static InputGesture Drag { get; set; } = new MultiGesture(MultiGesture.Match.Any, Selection.Replace, Selection.Remove, Selection.Append, Selection.Invert);
+            public InputGestureRef Drag { get; }
 
             /// <summary>Gesture to cancel the dragging operation.</summary>
             /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or <see cref="Key.Escape"/>.</remarks>
-            public static InputGesture CancelAction { get; set; } = new MultiGesture(MultiGesture.Match.Any, new MouseGesture(MouseAction.RightClick), new KeyGesture(Key.Escape));
+            public InputGestureRef CancelAction { get; }
+
+            /// <summary>Copies from the specified gestures.</summary>
+            /// <param name="gestures">The gestures to copy.</param>
+            public void Apply(ItemContainerGestures gestures)
+            {
+                Selection.Apply(gestures.Selection);
+                Drag.Value = gestures.Drag.Value;
+                CancelAction.Value = gestures.CancelAction.Value;
+            }
+        }
+
+        /// <summary>Gestures for the editor.</summary>
+        public class NodifyEditorGestures
+        {
+            public NodifyEditorGestures()
+            {
+                Selection = new SelectionGestures();
+                Pan = new AnyGesture(new MouseGesture(MouseAction.RightClick), new MouseGesture(MouseAction.MiddleClick));
+                Zoom = ModifierKeys.None;
+                ZoomIn = new MultiGesture(MultiGesture.Match.Any, new KeyGesture(Key.OemPlus, ModifierKeys.Control), new KeyGesture(Key.Add, ModifierKeys.Control));
+                ZoomOut = new MultiGesture(MultiGesture.Match.Any, new KeyGesture(Key.OemMinus, ModifierKeys.Control), new KeyGesture(Key.Subtract, ModifierKeys.Control));
+                ResetViewportLocation = new KeyGesture(Key.Home);
+                FitToScreen = new KeyGesture(Key.Home, ModifierKeys.Shift);
+            }
+
+            /// <summary>Gesture used to start selecting using a <see cref="SelectionGestures"/> strategy.</summary>
+            public SelectionGestures Selection { get; }
+
+            /// <summary>Gesture used to start panning.</summary>
+            /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or <see cref="MouseAction.MiddleClick"/>.</remarks>
+            public InputGestureRef Pan { get; }
+
+            /// <summary>The key modifier required to start zooming by mouse wheel.</summary>
+            /// <remarks>Defaults to <see cref="ModifierKeys.None"/>.</remarks>
+            public ModifierKeys Zoom { get; set; }
+
+            /// <summary>Gesture used to zoom in.</summary>
+            /// <remarks>Defaults to <see cref="ModifierKeys.Control"/>+<see cref="Key.OemPlus"/>.</remarks>
+            public InputGestureRef ZoomIn { get; }
+
+            /// <summary>Gesture used to zoom out.</summary>
+            /// <remarks>Defaults to <see cref="ModifierKeys.Control"/>+<see cref="Key.OemMinus"/>.</remarks>
+            public InputGestureRef ZoomOut { get; }
+
+            /// <summary>Gesture used to move the editor's viewport location to (0, 0).</summary>
+            /// <remarks>Defaults to <see cref="Key.Home"/>.</remarks>
+            public InputGestureRef ResetViewportLocation { get; }
+
+            /// <summary>Gesture used to fit as many containers as possible into the viewport.</summary>
+            /// <remarks>Defaults to <see cref="ModifierKeys.Shift"/>+<see cref="Key.Home"/>.</remarks>
+            public InputGestureRef FitToScreen { get; }
+
+            /// <summary>Copies from the specified gestures.</summary>
+            /// <param name="gestures">The gestures to copy.</param>
+            public void Apply(NodifyEditorGestures gestures)
+            {
+                Selection.Apply(gestures.Selection);
+                Pan.Value = gestures.Pan.Value;
+                Zoom = gestures.Zoom;
+                ZoomIn.Value = gestures.ZoomIn.Value;
+                ZoomOut.Value = gestures.ZoomOut.Value;
+                ResetViewportLocation.Value = gestures.ResetViewportLocation.Value;
+                FitToScreen.Value = gestures.FitToScreen.Value;
+            }
+        }
+
+        /// <summary>Gestures used by the <see cref="Connector"/>.</summary>
+        public class ConnectorGestures
+        {
+            public ConnectorGestures()
+            {
+                Disconnect = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Alt);
+                Connect = new MouseGesture(MouseAction.LeftClick);
+                CancelAction = new AnyGesture(new MouseGesture(MouseAction.RightClick), new KeyGesture(Key.Escape));
+            }
+
+            /// <summary>Gesture to call the <see cref="Connector.DisconnectCommand"/>.</summary>
+            /// <remarks>Defaults to <see cref="ModifierKeys.Alt"/>+<see cref="MouseAction.LeftClick"/>.</remarks>
+            public InputGestureRef Disconnect { get; }
+
+            /// <summary>Gesture to start and complete a pending connection.</summary>
+            /// <remarks>Defaults to <see cref="MouseAction.LeftClick"/>.</remarks>
+            public InputGestureRef Connect { get; }
+
+            /// <summary>Gesture to cancel the pending connection.</summary>
+            /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or <see cref="Key.Escape"/>.</remarks>
+            public InputGestureRef CancelAction { get; }
+
+            /// <summary>Copies from the specified gestures.</summary>
+            /// <param name="gestures">The gestures to copy.</param>
+            public void Apply(ConnectorGestures gestures)
+            {
+                Disconnect.Value = gestures.Disconnect.Value;
+                Connect.Value = gestures.Connect.Value;
+                CancelAction.Value = gestures.CancelAction.Value;
+            }
+        }
+
+        /// <summary>Gestures used by the <see cref="BaseConnection"/>.</summary>
+        public class ConnectionGestures
+        {
+            public ConnectionGestures()
+            {
+                Split = new MouseGesture(MouseAction.LeftDoubleClick);
+                Disconnect = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Alt);
+            }
+
+            /// <summary>Gesture to call the <see cref="BaseConnection.SplitCommand"/> command.</summary>
+            /// <remarks>Defaults to <see cref="MouseAction.LeftDoubleClick"/>.</remarks>
+            public InputGestureRef Split { get; }
+
+            /// <summary>Gesture to call the <see cref="BaseConnection.DisconnectCommand"/> command.</summary>
+            /// <remarks>Defaults to <see cref="ModifierKeys.Alt"/>+<see cref="MouseAction.LeftClick"/>.</remarks>
+            public InputGestureRef Disconnect { get; }
+
+            /// <summary>Copies from the specified gestures.</summary>
+            /// <param name="gestures">The gestures to copy.</param>
+            public void Apply(ConnectionGestures gestures)
+            {
+                Split.Value = gestures.Split.Value;
+                Disconnect.Value = gestures.Disconnect.Value;
+            }
         }
 
         /// <summary>Gestures for the <see cref="GroupingNode"/>.</summary>
-        public static class GroupingNode
+        public class GroupingNodeGestures
         {
             /// <summary>The key modifier that will toggle between <see cref="GroupingMovementMode"/>s.</summary>
             /// <remarks>The modifier must be allowed by the <see cref="ItemContainer.Drag"/> gesture.
             /// <br /> Defaults to <see cref="ModifierKeys.Shift"/>.
             /// </remarks>
-            public static ModifierKeys SwitchMovementMode { get; set; } = ModifierKeys.Shift;
+            public ModifierKeys SwitchMovementMode { get; set; } = ModifierKeys.Shift;
+
+            /// <summary>Copies from the specified gestures.</summary>
+            /// <param name="gestures">The gestures to copy.</param>
+            public void Apply(GroupingNodeGestures gestures)
+            {
+                SwitchMovementMode = gestures.SwitchMovementMode;
+            }
+        }
+
+        /// <summary>Gestures for the editor.</summary>
+        public NodifyEditorGestures Editor { get; } = new NodifyEditorGestures();
+
+        /// <summary>Gestures for the item container.</summary>
+        public ItemContainerGestures ItemContainer { get; } = new ItemContainerGestures();
+
+        /// <summary>Gestures for the connector.</summary>
+        public ConnectorGestures Connector { get; } = new ConnectorGestures();
+
+        /// <summary>Gestures for the connection.</summary>
+        public ConnectionGestures Connection { get; } = new ConnectionGestures();
+
+        /// <summary>Gestures for the grouping node.</summary>
+        public GroupingNodeGestures GroupingNode { get; } = new GroupingNodeGestures();
+
+        /// <summary>Copies from the specified gestures.</summary>
+        /// <param name="gestures">The gestures to copy.</param>
+        public void Apply(EditorGestures gestures)
+        {
+            Editor.Apply(gestures.Editor);
+            ItemContainer.Apply(gestures.ItemContainer);
+            Connector.Apply(gestures.Connector);
+            Connection.Apply(gestures.Connection);
+            GroupingNode.Apply(gestures.GroupingNode);
         }
     }
 }

--- a/Nodify/EditorGestures.cs
+++ b/Nodify/EditorGestures.cs
@@ -111,7 +111,7 @@ namespace Nodify
             {
                 Selection = new SelectionGestures();
                 Pan = new AnyGesture(new MouseGesture(MouseAction.RightClick), new MouseGesture(MouseAction.MiddleClick));
-                Zoom = ModifierKeys.None;
+                ZoomModifierKey = ModifierKeys.None;
                 ZoomIn = new MultiGesture(MultiGesture.Match.Any, new KeyGesture(Key.OemPlus, ModifierKeys.Control), new KeyGesture(Key.Add, ModifierKeys.Control));
                 ZoomOut = new MultiGesture(MultiGesture.Match.Any, new KeyGesture(Key.OemMinus, ModifierKeys.Control), new KeyGesture(Key.Subtract, ModifierKeys.Control));
                 ResetViewportLocation = new KeyGesture(Key.Home);
@@ -127,7 +127,7 @@ namespace Nodify
 
             /// <summary>The key modifier required to start zooming by mouse wheel.</summary>
             /// <remarks>Defaults to <see cref="ModifierKeys.None"/>.</remarks>
-            public ModifierKeys Zoom { get; set; }
+            public ModifierKeys ZoomModifierKey { get; set; }
 
             /// <summary>Gesture used to zoom in.</summary>
             /// <remarks>Defaults to <see cref="ModifierKeys.Control"/>+<see cref="Key.OemPlus"/>.</remarks>
@@ -151,7 +151,7 @@ namespace Nodify
             {
                 Selection.Apply(gestures.Selection);
                 Pan.Value = gestures.Pan.Value;
-                Zoom = gestures.Zoom;
+                ZoomModifierKey = gestures.ZoomModifierKey;
                 ZoomIn.Value = gestures.ZoomIn.Value;
                 ZoomOut.Value = gestures.ZoomOut.Value;
                 ResetViewportLocation.Value = gestures.ResetViewportLocation.Value;

--- a/Nodify/EditorStates/ContainerDefaultState.cs
+++ b/Nodify/EditorStates/ContainerDefaultState.cs
@@ -31,12 +31,13 @@ namespace Nodify
         {
             _canceled = false;
 
-            if (EditorGestures.ItemContainer.Drag.Matches(e.Source, e))
+            EditorGestures.ItemContainerGestures gestures = EditorGestures.Mappings.ItemContainer;
+            if (gestures.Drag.Matches(e.Source, e))
             {
                 _canBeDragging = Container.IsDraggable;
 
                 // Clear the selection if dragging an item that is not part of the selection will not add it to the selection
-                if (_canBeDragging && !Container.IsSelected && !EditorGestures.Selection.Append.Matches(e.Source, e) && !EditorGestures.Selection.Invert.Matches(e.Source, e))
+                if (_canBeDragging && !Container.IsSelected && !gestures.Selection.Append.Matches(e.Source, e) && !gestures.Selection.Invert.Matches(e.Source, e))
                 {
                     Editor.UnselectAll();
                 }
@@ -46,17 +47,18 @@ namespace Nodify
         /// <inheritdoc />
         public override void HandleMouseUp(MouseButtonEventArgs e)
         {
-            if (!_canceled && EditorGestures.ItemContainer.Select.Matches(e.Source, e))
+            EditorGestures.ItemContainerGestures gestures = EditorGestures.Mappings.ItemContainer;
+            if (!_canceled && gestures.Selection.Select.Matches(e.Source, e))
             {
-                if (EditorGestures.Selection.Append.Matches(e.Source, e))
+                if (gestures.Selection.Append.Matches(e.Source, e))
                 {
                     Container.IsSelected = true;
                 }
-                else if (EditorGestures.Selection.Invert.Matches(e.Source, e))
+                else if (gestures.Selection.Invert.Matches(e.Source, e))
                 {
                     Container.IsSelected = !Container.IsSelected;
                 }
-                else if (EditorGestures.Selection.Remove.Matches(e.Source, e))
+                else if (gestures.Selection.Remove.Matches(e.Source, e))
                 {
                     Container.IsSelected = false;
                 }
@@ -71,6 +73,11 @@ namespace Nodify
                     Container.IsSelected = true;
                 }
 
+                _canBeDragging = false;
+            }
+
+            if(!_canceled && gestures.Drag.Matches(e.Source, e))
+            {
                 _canBeDragging = false;
             }
 

--- a/Nodify/EditorStates/ContainerDraggingState.cs
+++ b/Nodify/EditorStates/ContainerDraggingState.cs
@@ -60,8 +60,10 @@ namespace Nodify
         /// <inheritdoc />
         public override void HandleMouseUp(MouseButtonEventArgs e)
         {
-            bool canCancel = EditorGestures.ItemContainer.CancelAction.Matches(e.Source, e) && ItemContainer.AllowDraggingCancellation;
-            bool canComplete = EditorGestures.ItemContainer.Drag.Matches(e.Source, e);
+            EditorGestures.ItemContainerGestures gestures = EditorGestures.Mappings.ItemContainer;
+
+            bool canCancel = gestures.CancelAction.Matches(e.Source, e) && ItemContainer.AllowDraggingCancellation;
+            bool canComplete = gestures.Drag.Matches(e.Source, e);
             if (canCancel || canComplete)
             {
                 // Prevent canceling if drag and cancel are bound to the same mouse action
@@ -84,7 +86,7 @@ namespace Nodify
         /// <inheritdoc />
         public override void HandleKeyUp(KeyEventArgs e)
         {
-            Canceled = EditorGestures.ItemContainer.CancelAction.Matches(e.Source, e) && ItemContainer.AllowDraggingCancellation;
+            Canceled = EditorGestures.Mappings.ItemContainer.CancelAction.Matches(e.Source, e) && ItemContainer.AllowDraggingCancellation;
             if (Canceled)
             {
                 PopState();

--- a/Nodify/EditorStates/EditorDefaultState.cs
+++ b/Nodify/EditorStates/EditorDefaultState.cs
@@ -30,13 +30,14 @@ namespace Nodify
         /// <inheritdoc />
         public override void HandleMouseDown(MouseButtonEventArgs e)
         {
-            if (EditorGestures.Select.Matches(e.Source, e))
+            EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
+            if (gestures.Selection.Select.Matches(e.Source, e))
             {
                 SelectionType selectionType = GetSelectionType(e);
                 var selecting = new EditorSelectingState(Editor, selectionType);
                 PushState(selecting);
             }
-            else if (!Editor.DisablePanning && EditorGestures.Pan.Matches(e.Source, e))
+            else if (!Editor.DisablePanning && gestures.Pan.Matches(e.Source, e))
             {
                 PushState(new EditorPanningState(Editor));
             }
@@ -44,17 +45,18 @@ namespace Nodify
 
         private static SelectionType GetSelectionType(MouseButtonEventArgs e)
         {
-            if (EditorGestures.Selection.Append.Matches(e.Source, e))
+            EditorGestures.SelectionGestures gestures = EditorGestures.Mappings.Editor.Selection;
+            if (gestures.Append.Matches(e.Source, e))
             {
                 return SelectionType.Append;
             }
 
-            if (EditorGestures.Selection.Invert.Matches(e.Source, e))
+            if (gestures.Invert.Matches(e.Source, e))
             {
                 return SelectionType.Invert;
             }
 
-            if (EditorGestures.Selection.Remove.Matches(e.Source, e))
+            if (gestures.Remove.Matches(e.Source, e))
             {
                 return SelectionType.Remove;
             }

--- a/Nodify/EditorStates/EditorPanningState.cs
+++ b/Nodify/EditorStates/EditorPanningState.cs
@@ -40,7 +40,8 @@ namespace Nodify
         /// <inheritdoc />
         public override void HandleMouseUp(MouseButtonEventArgs e)
         {
-            if (EditorGestures.Pan.Matches(e.Source, e))
+            EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
+            if (gestures.Pan.Matches(e.Source, e))
             {
                 // Handle right click if panning and moved the mouse more than threshold so context menu doesn't open
                 if (e.ChangedButton == MouseButton.Right)
@@ -54,7 +55,7 @@ namespace Nodify
 
                 PopState();
             }
-            else if (EditorGestures.Select.Matches(e.Source, e) && Editor.IsSelecting)
+            else if (gestures.Selection.Select.Matches(e.Source, e) && Editor.IsSelecting)
             {
                 PopState();
                 // Cancel selection and continue panning

--- a/Nodify/EditorStates/EditorSelectingState.cs
+++ b/Nodify/EditorStates/EditorSelectingState.cs
@@ -47,7 +47,7 @@ namespace Nodify
         /// <inheritdoc />
         public override void HandleMouseDown(MouseButtonEventArgs e)
         {
-            if (!Editor.DisablePanning && EditorGestures.Pan.Matches(e.Source, e))
+            if (!Editor.DisablePanning && EditorGestures.Mappings.Editor.Pan.Matches(e.Source, e))
             {
                 PushState(new EditorPanningState(Editor));
             }
@@ -56,8 +56,10 @@ namespace Nodify
         /// <inheritdoc />
         public override void HandleMouseUp(MouseButtonEventArgs e)
         {
-            bool canCancel = EditorGestures.Selection.Cancel.Matches(e.Source, e);
-            bool canComplete = EditorGestures.Select.Matches(e.Source, e);
+            EditorGestures.SelectionGestures gestures = EditorGestures.Mappings.Editor.Selection;
+
+            bool canCancel = gestures.Cancel.Matches(e.Source, e);
+            bool canComplete = gestures.Select.Matches(e.Source, e);
             if (canCancel || canComplete)
             {
                 _canceled = !canComplete && canCancel;
@@ -71,7 +73,7 @@ namespace Nodify
 
         public override void HandleKeyUp(KeyEventArgs e)
         {
-            if (EditorGestures.Selection.Cancel.Matches(e.Source, e))
+            if (EditorGestures.Mappings.Editor.Selection.Cancel.Matches(e.Source, e))
             {
                 _canceled = true;
                 PopState();

--- a/Nodify/Helpers/MultiGesture.cs
+++ b/Nodify/Helpers/MultiGesture.cs
@@ -5,10 +5,12 @@ namespace Nodify
     /// <summary>Combines multiple input gestures.</summary>
     public class MultiGesture : InputGesture
     {
+        public static readonly MultiGesture None = new MultiGesture(Match.Any);
+
         /// <summary>The strategy used by <see cref="Matches(object, InputEventArgs)"/>.</summary>
         public enum Match
         {
-            /// <summary>Any gesture can match.</summary>
+            /// <summary>At least one gesture must match.</summary>
             Any,
             /// <summary>All gestures must match.</summary>
             All
@@ -62,5 +64,47 @@ namespace Nodify
 
             return false;
         }
+    }
+
+    /// <inheritdoc cref="MultiGesture.Match.Any" />
+    public sealed class AnyGesture : MultiGesture
+    {
+        public AnyGesture(params InputGesture[] gestures) : base(Match.Any, gestures)
+        {
+        }
+    }
+
+    /// <inheritdoc cref="MultiGesture.Match.All" />
+    public sealed class AllGestures : MultiGesture
+    {
+        public AllGestures(params InputGesture[] gestures) : base(Match.All, gestures)
+        {
+        }
+    }
+
+    /// <summary>
+    /// An input gesture that allows changing its logic at runtime without changing its reference.
+    /// Useful for classes that capture the object reference without the posibility of updating it. (e.g. <see cref="EditorCommands"/>)
+    /// </summary>
+    public sealed class InputGestureRef : InputGesture
+    {
+        /// <summary>The referenced gesture.</summary>
+        public InputGesture Value { get; set; } = MultiGesture.None;
+
+        private InputGestureRef() { }
+
+        public override bool Matches(object targetElement, InputEventArgs inputEventArgs)
+        {
+            return Value.Matches(targetElement, inputEventArgs);
+        }
+
+        public static implicit operator InputGestureRef(MouseGesture gesture)
+            => new InputGestureRef { Value = gesture };
+
+        public static implicit operator InputGestureRef(KeyGesture gesture)
+            => new InputGestureRef { Value = gesture };
+
+        public static implicit operator InputGestureRef(MultiGesture gesture)
+            => new InputGestureRef { Value = gesture };
     }
 }

--- a/Nodify/Nodes/GroupingNode.cs
+++ b/Nodify/Nodes/GroupingNode.cs
@@ -218,25 +218,26 @@ namespace Nodify
 
         private void OnHeaderMouseDown(object sender, MouseButtonEventArgs e)
         {
-            if (Container != null && Editor != null && EditorGestures.ItemContainer.Drag.Matches(e.Source, e))
+            EditorGestures.ItemContainerGestures gestures = EditorGestures.Mappings.ItemContainer;
+            if (Container != null && Editor != null && gestures.Drag.Matches(e.Source, e))
             {
                 // Switch the default movement mode if necessary
                 var prevMovementMode = MovementMode;
-                if (Keyboard.Modifiers == EditorGestures.GroupingNode.SwitchMovementMode)
+                if (Keyboard.Modifiers == EditorGestures.Mappings.GroupingNode.SwitchMovementMode)
                 {
                     MovementMode = MovementMode == GroupingMovementMode.Group ? GroupingMovementMode.Self : GroupingMovementMode.Group;
                 }
 
                 // Select the content and move with it
-                if (EditorGestures.Selection.Append.Matches(e.Source, e))
+                if (gestures.Selection.Append.Matches(e.Source, e))
                 {
                     Editor.SelectArea(new Rect(Container.Location, RenderSize), append: true, fit: true);
                 }
-                else if (EditorGestures.Selection.Remove.Matches(e.Source, e))
+                else if (gestures.Selection.Remove.Matches(e.Source, e))
                 {
                     Editor.UnselectArea(new Rect(Container.Location, RenderSize), fit: true);
                 }
-                else if (EditorGestures.Selection.Invert.Matches(e.Source, e))
+                else if (gestures.Selection.Invert.Matches(e.Source, e))
                 {
                     if (Container.IsSelected)
                     {
@@ -248,7 +249,7 @@ namespace Nodify
                         Editor.SelectArea(new Rect(Container.Location, RenderSize), append: true, fit: true);
                     }
                 }
-                else if (EditorGestures.Selection.Replace.Matches(e.Source, e) || EditorGestures.ItemContainer.Drag.Matches(e.Source, e))
+                else if (gestures.Selection.Replace.Matches(e.Source, e) || EditorGestures.Mappings.ItemContainer.Drag.Matches(e.Source, e))
                 {
                     Editor.SelectArea(new Rect(Container.Location, RenderSize), append: Container.IsSelected, fit: true);
                 }

--- a/Nodify/Nodify.csproj
+++ b/Nodify/Nodify.csproj
@@ -16,17 +16,22 @@
     <PackageIcon>icon.png</PackageIcon>
     <RepositoryUrl>https://github.com/miroiu/nodify</RepositoryUrl>
     <PackageTags>wpf mvvm node-editor controls</PackageTags>
-    <Version>5.3.0</Version>
+    <Version>6.0.0</Version>
     <PackageReleaseNotes>
       > - Breaking Changes:
       >	  - Added a parameter for the orientation to DrawArrowGeometry, DrawDefaultArrowhead, DrawRectangleArrowhead and DrawEllipseArrowhead in BaseConnection
       >	  - Added source and target parameters to GetTextPosition in BaseConnection
+      >	  - EditorGestures is now a singleton instead of a static class (can be inherited from to create custom mappings)
+      >	  - Selection gestures for ItemContainer and GroupingNode are now separated from the NodifyEditor selection gestures
       > - Features:
       >	  - Added SourceOrientation and TargetOrientation to BaseConnection to support vertical connectors (vertical/mixed connection orientation)
       >	  - Added DirectionalArrowsCount to BaseConnection to allow drawing multipe arrows on a connection flowing in the connection direction
       >	  - Added DrawDirectionalArrowsGeometry and DrawDirectionalArrowheadGeometry to BaseConnection to allow customizing the directional arrows
+      >	  - Improved EditorGestures to allow changing input gestures at runtime
+      >	  - Added new gesture types: AnyGesture, AllGestures and InputGestureRef
       > - Bugfixes:
       >	  - Fixed BaseConnection.Text not always displaying in the center of the connection
+      >	  - Fixed a bug where the item container would incorrectly transition to the dragging state on mouse over
     </PackageReleaseNotes>
     <AssemblyOriginatorKeyFile>..\build\Nodify.snk</AssemblyOriginatorKeyFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -664,7 +664,7 @@ namespace Nodify
         /// <summary>
         /// Gets the panel that holds all the <see cref="ItemContainer"/>s.
         /// </summary>
-        protected internal Panel ItemsHost { get; private set; }
+        protected internal Panel ItemsHost { get; private set; } = default!;
 
         private IDraggingStrategy? _draggingStrategy;
         private DispatcherTimer? _autoPanningTimer;
@@ -1055,7 +1055,7 @@ namespace Nodify
         {
             State.HandleMouseWheel(e);
 
-            if (!e.Handled && EditorGestures.Mappings.Editor.Zoom == Keyboard.Modifiers)
+            if (!e.Handled && EditorGestures.Mappings.Editor.ZoomModifierKey == Keyboard.Modifiers)
             {
                 double zoom = Math.Pow(2.0, e.Delta / 3.0 / Mouse.MouseWheelDeltaForOneLine);
                 ZoomAtPosition(zoom, e.GetPosition(ItemsHost));

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -1055,7 +1055,7 @@ namespace Nodify
         {
             State.HandleMouseWheel(e);
 
-            if (!e.Handled && EditorGestures.Zoom == Keyboard.Modifiers)
+            if (!e.Handled && EditorGestures.Mappings.Editor.Zoom == Keyboard.Modifiers)
             {
                 double zoom = Math.Pow(2.0, e.Delta / 3.0 / Mouse.MouseWheelDeltaForOneLine);
                 ZoomAtPosition(zoom, e.GetPosition(ItemsHost));


### PR DESCRIPTION
### 📝 Description of the Change

This PR aims to provide more options for customizing the editor gestures at runtime (see the Playground app for a simple example).

- Separated selection gestures for ItemContainer and GroupingNode from the NodifyEditor
- Added new gesture types: AnyGesture, AllGestures, and InputGestureRef
- Fixed a bug where the item container would incorrectly transition to the dragging state on mouse over

The EditorGestures class is now a singleton and can be accessed through `EditorGestures.Mappings` which allows customizing the editor gestures in a couple of ways:

- override specific gestures exposed by the EditorGestures.Mappings 
```csharp
// single gesture
EditorGestures.Mappings.ItemContainer.Drag.Value = MultiGesture.None;

// multiple gestures
EditorGestures.Mappings.Editor.Selection.Apply(new SelectionGestures(MouseAction.RightClick));
EditorGestures.Mappings.ItemContainer.Apply(new ItemContainerGestures());
```
- define templates that you can apply to the EditorGestures.Mappings 
```csharp
public class Blender3DInputMappings : EditorGestures
{
    public Blender3DInputMappings()
    {
        Editor.Pan.Value = new AnyGesture(new MouseGesture(MouseAction.LeftClick), new MouseGesture(MouseAction.MiddleClick));
        Editor.Selection.Apply(new SelectionGestures(MouseAction.RightClick));
        ItemContainer.Selection.Apply(Editor.Selection);
    }
}

// apply custom gesture mappings
EditorGestures.Mappings.Apply(new Blender3DInputMappings());

// note that you can reset the gestures as follows
EditorGestures.Mappings.Apply(new EditorGestures());
```

You can also inherit from `SelectionGestures`, `ItemContainerGestures`, `NodifyEditorGestures`, `ConnectorGestures`, `ConnectionGestures`, and `GroupingNodeGestures` or simply create an instance and customize it. These can be applied in the same way:

```csharp
EditorGestures.Mappings.ItemContainer.Apply(new ItemContainerGestures());
```

