### PR TITLE
Add new built-in connection type: StepConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 > - Breaking Changes:
 > - Features:
+>	- Added new built-in connection type: StepConnection
 > - Bugfixes:
+>	- Fixed CircuitConnection directional arrows not interpolating correctly
+>	- Fixed style not applying to the default Connection template outside App.xaml
 	
 #### **Version 6.0.0**
 

--- a/Examples/Nodify.Playground/Converters/FlowToConnectorPositionConverter.cs
+++ b/Examples/Nodify.Playground/Converters/FlowToConnectorPositionConverter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace Nodify.Playground
+{
+    public class FlowToConnectorPositionConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is ConnectorViewModel connector)
+            {
+                if (connector.Node.Orientation == Orientation.Horizontal)
+                {
+                    return connector.Flow == ConnectorFlow.Output
+                        ? ConnectorPosition.Right
+                        : ConnectorPosition.Left;
+                }
+
+                return connector.Flow == ConnectorFlow.Output
+                    ? ConnectorPosition.Bottom
+                    : ConnectorPosition.Top;
+            }
+
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -18,6 +18,7 @@
     <UserControl.Resources>
         <shared:RandomBrushConverter x:Key="RandomBrushConverter" />
         <local:FlowToDirectionConverter x:Key="FlowToDirectionConverter" />
+        <local:FlowToConnectorPositionConverter x:Key="FlowToConnectorPositionConverter" />
 
         <GeometryDrawing x:Key="SmallGridGeometry"
                          Geometry="M0,0 L0,1 0.03,1 0.03,0.03 1,0.03 1,0 Z"
@@ -105,6 +106,12 @@
         <DataTemplate x:Key="CircuitConnectionTemplate">
             <nodify:CircuitConnection Angle="{Binding CircuitConnectionAngle, Source={x:Static local:EditorSettings.Instance}}"
                                       Style="{StaticResource ConnectionStyle}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="StepConnectionTemplate">
+            <nodify:StepConnection Style="{StaticResource ConnectionStyle}"
+                                   SourcePosition="{Binding Output, Converter={StaticResource FlowToConnectorPositionConverter}}"
+                                   TargetPosition="{Binding Input, Converter={StaticResource FlowToConnectorPositionConverter}}" />
         </DataTemplate>
 
         <DataTemplate x:Key="ConnectionTemplate">
@@ -203,6 +210,11 @@
                                      Value="Circuit">
                             <Setter Property="ConnectionTemplate"
                                     Value="{StaticResource CircuitConnectionTemplate}" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding ConnectionStyle, Mode=TwoWay, Source={x:Static local:EditorSettings.Instance}}"
+                                     Value="Step">
+                            <Setter Property="ConnectionTemplate"
+                                    Value="{StaticResource StepConnectionTemplate}" />
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -7,7 +7,8 @@ namespace Nodify.Playground
     {
         Default,
         Line,
-        Circuit
+        Circuit,
+        Step
     }
 
     public class EditorSettings : ObservableObject

--- a/Nodify/Connections/CircuitConnection.cs
+++ b/Nodify/Connections/CircuitConnection.cs
@@ -65,27 +65,13 @@ namespace Nodify
         {
             var (p0, p1, p2) = GetLinePoints(source, target);
 
-            Vector deltaSource = p1 - p0;
-            Vector deltaTarget = p2 - p1;
-
-            double lengthRatio = deltaTarget.LengthSquared / (deltaSource.LengthSquared + deltaTarget.LengthSquared);
-
-            int segment1ArrowCount = (int)Math.Round(DirectionalArrowsCount * (1 - lengthRatio));
-            DrawDirectionalArrowsToSegment(context, p0, p1, segment1ArrowCount);
-
-            int segment2ArrowCount = (int)DirectionalArrowsCount - segment1ArrowCount;
-            DrawDirectionalArrowsToSegment(context, p1, p2, segment2ArrowCount);
-        }
-
-        private void DrawDirectionalArrowsToSegment(StreamGeometryContext context, Point p0, Point p1, int arrowsCount)
-        {
-            double spacing = 1d / (arrowsCount + 1);
-            for (int i = 1; i <= arrowsCount; i++)
+            double spacing = 1d / (DirectionalArrowsCount + 1);
+            for (int i = 1; i <= DirectionalArrowsCount; i++)
             {
-                var direction = p0 - p1;
                 double t = (spacing * i + DirectionalArrowsOffset).WrapToRange(0d, 1d);
-                var to = InterpolateLineSegment(p0, p1, t);
+                var (segment, to) = InterpolateLine(p0, p1, p2, t);
 
+                var direction = segment.SegmentStart - segment.SegmentEnd;
                 base.DrawDirectionalArrowheadGeometry(context, direction, to);
             }
         }

--- a/Nodify/Connections/LineConnection.cs
+++ b/Nodify/Connections/LineConnection.cs
@@ -83,5 +83,47 @@ namespace Nodify
         {
             return (Point)((1 - t) * (Vector)p0 + t * (Vector)p1);
         }
+
+        protected static ((Point SegmentStart, Point SegmentEnd), Point InterpolatedPoint) InterpolateLine(Point p0, Point p1, Point p2, Point p3, double t)
+        {
+            double length1 = (p1 - p0).Length;
+            double length2 = (p2 - p1).Length;
+            double length3 = (p3 - p2).Length;
+            double totalLength = length1 + length2 + length3;
+
+            double ratio1 = length1 / totalLength;
+            double ratio2 = length2 / totalLength;
+            double ratio3 = length3 / totalLength;
+
+            // Interpolate within the appropriate segment based on t
+            if (t <= ratio1)
+            {
+                return ((p0, p1), InterpolateLineSegment(p0, p1, t / ratio1));
+            }
+            else if (t <= ratio1 + ratio2)
+            {
+                return ((p1, p2), InterpolateLineSegment(p1, p2, (t - ratio1) / ratio2));
+            }
+
+            return ((p2, p3), InterpolateLineSegment(p2, p3, (t - ratio1 - ratio2) / ratio3));
+        }
+
+        protected static ((Point SegmentStart, Point SegmentEnd), Point InterpolatedPoint) InterpolateLine(Point p0, Point p1, Point p2, double t)
+        {
+            double length1 = (p1 - p0).Length;
+            double length2 = (p2 - p1).Length;
+            double totalLength = length1 + length2;
+
+            double ratio1 = length1 / totalLength;
+            double ratio2 = length2 / totalLength;
+
+            // Interpolate within the appropriate segment based on t
+            if (t <= ratio1)
+            {
+                return ((p0, p1), InterpolateLineSegment(p0, p1, t / ratio1));
+            }
+
+            return ((p1, p2), InterpolateLineSegment(p1, p2, (t - ratio1) / ratio2));
+        }
     }
 }

--- a/Nodify/Connections/StepConnection.cs
+++ b/Nodify/Connections/StepConnection.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace Nodify
+{
+    public enum ConnectorPosition
+    {
+        Top,
+        Left,
+        Bottom,
+        Right
+    }
+
+    public class StepConnection : LineConnection
+    {
+        public static readonly DependencyProperty SourcePositionProperty = DependencyProperty.Register(nameof(SourcePosition), typeof(ConnectorPosition), typeof(StepConnection), new FrameworkPropertyMetadata(ConnectorPosition.Right, FrameworkPropertyMetadataOptions.AffectsRender, OnConnectorPositionChanged));
+        public static readonly DependencyProperty TargetPositionProperty = DependencyProperty.Register(nameof(TargetPosition), typeof(ConnectorPosition), typeof(StepConnection), new FrameworkPropertyMetadata(ConnectorPosition.Left, FrameworkPropertyMetadataOptions.AffectsRender, OnConnectorPositionChanged));
+
+        private static void OnConnectorPositionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var connection = (StepConnection)d;
+            connection.CoerceValue(DirectionProperty);
+            connection.CoerceValue(SourceOrientationProperty);
+            connection.CoerceValue(TargetOrientationProperty);
+        }
+
+        static StepConnection()
+        {
+            SourceOrientationProperty.OverrideMetadata(typeof(StepConnection), new FrameworkPropertyMetadata(Orientation.Horizontal, null, CoerceSourceOrientation));
+            TargetOrientationProperty.OverrideMetadata(typeof(StepConnection), new FrameworkPropertyMetadata(Orientation.Horizontal, null, CoerceTargetOrientation));
+            DirectionProperty.OverrideMetadata(typeof(StepConnection), new FrameworkPropertyMetadata(ConnectionDirection.Forward, null, CoerceConnectionDirection));
+        }
+
+        private static object CoerceSourceOrientation(DependencyObject d, object baseValue)
+        {
+            var connection = (StepConnection)d;
+            return connection.SourcePosition == ConnectorPosition.Left || connection.SourcePosition == ConnectorPosition.Right
+                ? Orientation.Horizontal
+                : Orientation.Vertical;
+        }
+
+        private static object CoerceTargetOrientation(DependencyObject d, object baseValue)
+        {
+            var connection = (StepConnection)d;
+            return connection.TargetPosition == ConnectorPosition.Left || connection.TargetPosition == ConnectorPosition.Right
+                ? Orientation.Horizontal
+                : Orientation.Vertical;
+        }
+
+        private static object CoerceConnectionDirection(DependencyObject d, object baseValue)
+        {
+            var connection = (StepConnection)d;
+            return connection.TargetPosition == ConnectorPosition.Left || connection.TargetPosition == ConnectorPosition.Top
+               ? ConnectionDirection.Forward
+               : ConnectionDirection.Backward;
+        }
+
+        /// <summary>
+        /// Gets or sets the position of the source connector.
+        /// </summary>
+        public ConnectorPosition SourcePosition
+        {
+            get => (ConnectorPosition)GetValue(SourcePositionProperty);
+            set => SetValue(SourcePositionProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the position of the target connector.
+        /// </summary>
+        public ConnectorPosition TargetPosition
+        {
+            get => (ConnectorPosition)GetValue(TargetPositionProperty);
+            set => SetValue(TargetPositionProperty, value);
+        }
+
+        protected override ((Point ArrowStartSource, Point ArrowStartTarget), (Point ArrowEndSource, Point ArrowEndTarget)) DrawLineGeometry(StreamGeometryContext context, Point source, Point target)
+        {
+            var (p0, p1, p2, p3) = GetLinePoints(source, target);
+
+            context.BeginFigure(source, false, false);
+            context.LineTo(p0, true, true);
+            context.LineTo(p1, true, true);
+            context.LineTo(p2, true, true);
+            context.LineTo(p3, true, true);
+            context.LineTo(target, true, true);
+
+            if (Spacing < 1d)
+            {
+                return ((p1, source), (p2, target));
+            }
+
+            return ((target, source), (source, target));
+        }
+
+        protected override Point GetTextPosition(FormattedText text, Point source, Point target)
+        {
+            var (p0, p1, p2, p3) = GetLinePoints(source, target);
+
+            Vector delta1 = p1 - p0;
+            Vector delta2 = p2 - p1;
+            Vector delta3 = p3 - p2;
+
+            var max = GetMax(delta1, GetMax(delta2, delta3));
+
+            if (max == delta1)
+            {
+                return new Point((p0.X + p1.X - text.Width) / 2, (p0.Y + p1.Y - text.Height) / 2);
+            }
+            else if (max == delta2)
+            {
+                return new Point((p2.X + p1.X - text.Width) / 2, (p2.Y + p1.Y - text.Height) / 2);
+            }
+
+            return new Point((p3.X + p2.X - text.Width) / 2, (p3.Y + p2.Y - text.Height) / 2);
+
+            static Vector GetMax(in Vector a, in Vector b)
+                => a.LengthSquared > b.LengthSquared ? a : b;
+        }
+
+        protected override void DrawDirectionalArrowsGeometry(StreamGeometryContext context, Point source, Point target)
+        {
+            var (p0, p1, p2, p3) = GetLinePoints(source, target);
+
+            double spacing = 1d / (DirectionalArrowsCount + 1);
+            for (int i = 1; i <= DirectionalArrowsCount; i++)
+            {
+                double t = (spacing * i + DirectionalArrowsOffset).WrapToRange(0d, 1d);
+                var (segment, to) = InterpolateLine(p0, p1, p2, p3, t);
+
+                var direction = segment.SegmentStart - segment.SegmentEnd;
+                base.DrawDirectionalArrowheadGeometry(context, direction, to);
+            }
+        }
+
+        private (Point P0, Point P1, Point P2, Point P3) GetLinePoints(Point source, Point target)
+        {
+            var sourceDir = GetConnectorDirection(SourcePosition);
+            var targetDir = GetConnectorDirection(TargetPosition);
+
+            Point startPoint = source + new Vector(Spacing * sourceDir.X, Spacing * sourceDir.Y);
+            Point endPoint = target + new Vector(Spacing * targetDir.X, Spacing * targetDir.Y);
+
+            var connectionDir = GetConnectionDirection(startPoint, SourcePosition, endPoint);
+            bool horizontalConnection = connectionDir.X != 0;
+
+            if (IsOppositePosition(SourcePosition, TargetPosition))
+            {
+                var (p1, p2) = GetOppositePositionPoints();
+                return (startPoint, p1, p2, endPoint);
+            }
+
+            // same: left to left / top to top etc
+            if (SourcePosition == TargetPosition)
+            {
+                var p = GetSamePositionPoint();
+                return (startPoint, p, p, endPoint);
+            }
+
+            // mixed: right to bottom / left to top etc
+            bool isSameDir = horizontalConnection ? sourceDir.X == targetDir.Y : sourceDir.Y == targetDir.X;
+            bool startGreaterThanEnd = horizontalConnection ? startPoint.Y > endPoint.Y : startPoint.X > endPoint.X;
+
+            bool positiveDir = horizontalConnection ? sourceDir.X == 1 : sourceDir.Y == 1;
+            bool shouldFlip = positiveDir
+                ? isSameDir ? !startGreaterThanEnd : startGreaterThanEnd
+                : isSameDir ? startGreaterThanEnd : !startGreaterThanEnd;
+
+            if (shouldFlip)
+            {
+                var sourceTarget = new Point(startPoint.X, endPoint.Y);
+                var targetSource = new Point(endPoint.X, startPoint.Y);
+
+                var pf = horizontalConnection ? sourceTarget : targetSource;
+                return (startPoint, pf, pf, endPoint);
+            }
+
+            var pp = GetSamePositionPoint();
+            return (startPoint, pp, pp, endPoint);
+
+            (Point P1, Point P2) GetOppositePositionPoints()
+            {
+                var center = startPoint + (endPoint - startPoint) / 2;
+
+                (Point P1, Point P2) verticalSplit = (new Point(center.X, startPoint.Y), new Point(center.X, endPoint.Y));
+                (Point P1, Point P2) horizontalSplit = (new Point(startPoint.X, center.Y), new Point(endPoint.X, center.Y));
+
+                if (horizontalConnection)
+                {
+                    // left to right / right to left
+                    return sourceDir.X == connectionDir.X ? verticalSplit : horizontalSplit;
+                }
+
+                // top to bottom / bottom to top
+                return sourceDir.Y == connectionDir.Y ? horizontalSplit : verticalSplit;
+            }
+
+            Point GetSamePositionPoint()
+            {
+                var sourceTarget = new Point(startPoint.X, endPoint.Y);
+                var targetSource = new Point(endPoint.X, startPoint.Y);
+
+                if (horizontalConnection)
+                {
+                    // left to left / right to right
+                    return sourceDir.X == connectionDir.X ? targetSource : sourceTarget;
+                }
+
+                // top to top / bottom to bottom
+                return sourceDir.Y == connectionDir.Y ? sourceTarget : targetSource;
+            }
+
+            static Point GetConnectionDirection(in Point source, ConnectorPosition sourcePosition, in Point target)
+            {
+                return sourcePosition == ConnectorPosition.Left || sourcePosition == ConnectorPosition.Right
+                    ? new Point(Math.Sign(target.X - source.X), 0)
+                    : new Point(0, Math.Sign(target.Y - source.Y));
+            }
+
+            static Point GetConnectorDirection(ConnectorPosition position)
+                => position switch
+                {
+                    ConnectorPosition.Top => new Point(0, -1),
+                    ConnectorPosition.Left => new Point(-1, 0),
+                    ConnectorPosition.Bottom => new Point(0, 1),
+                    ConnectorPosition.Right => new Point(1, 0),
+                    _ => default,
+                };
+
+            static bool IsOppositePosition(ConnectorPosition sourcePosition, ConnectorPosition targetPosition)
+            {
+                return sourcePosition == ConnectorPosition.Left && targetPosition == ConnectorPosition.Right
+                    || sourcePosition == ConnectorPosition.Right && targetPosition == ConnectorPosition.Left
+                    || sourcePosition == ConnectorPosition.Top && targetPosition == ConnectorPosition.Bottom
+                    || sourcePosition == ConnectorPosition.Bottom && targetPosition == ConnectorPosition.Top;
+            }
+        }
+    }
+}

--- a/Nodify/Themes/Brushes.xaml
+++ b/Nodify/Themes/Brushes.xaml
@@ -192,6 +192,12 @@
                      o:Freeze="True"
                      Color="{DynamicResource CircuitConnection.StrokeColor}" />
 
+    <!--STEP CONNECTION-->
+
+    <SolidColorBrush x:Key="StepConnection.StrokeBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource StepConnection.StrokeColor}" />
+
     <!--PENDING CONNECTION-->
     
     <SolidColorBrush x:Key="PendingConnection.StrokeBrush"

--- a/Nodify/Themes/Controls.xaml
+++ b/Nodify/Themes/Controls.xaml
@@ -39,9 +39,9 @@
         <Setter Property="SelectedBrush"
                 Value="{StaticResource ItemContainer.SelectedBrush}" />
     </Style>
-    
+
     <!--DECORATOR CONTAINER-->
-    
+
     <local:UnscaleTransformConverter x:Key="UnscaleTransformConverter" />
 
     <Style TargetType="{x:Type local:DecoratorContainer}"
@@ -179,6 +179,16 @@
                 Value="{StaticResource CircuitConnection.StrokeBrush}" />
         <Setter Property="Fill"
                 Value="{StaticResource CircuitConnection.StrokeBrush}" />
+    </Style>
+
+    <!--STEP CONNECTION-->
+
+    <Style TargetType="{x:Type local:StepConnection}"
+           BasedOn="{StaticResource {x:Type local:StepConnection}}">
+        <Setter Property="Stroke"
+                Value="{StaticResource StepConnection.StrokeBrush}" />
+        <Setter Property="Fill"
+                Value="{StaticResource StepConnection.StrokeBrush}" />
     </Style>
 
     <!--PENDING CONNECTION-->

--- a/Nodify/Themes/Dark.xaml
+++ b/Nodify/Themes/Dark.xaml
@@ -66,6 +66,9 @@
     <!--CIRCUIT CONNECTION-->
     <Color x:Key="CircuitConnection.StrokeColor">DodgerBlue</Color>
 
+    <!--STEP CONNECTION-->
+    <Color x:Key="StepConnection.StrokeColor">DodgerBlue</Color>
+
     <!--PENDING CONNECTION-->
     <Color x:Key="PendingConnection.StrokeColor">DodgerBlue</Color>
     <Color x:Key="PendingConnection.BorderColor">Black</Color>

--- a/Nodify/Themes/Light.xaml
+++ b/Nodify/Themes/Light.xaml
@@ -66,6 +66,9 @@
     <!--CIRCUIT CONNECTION-->
     <Color x:Key="CircuitConnection.StrokeColor">#5CA2C9</Color>
 
+    <!--STEP CONNECTION-->
+    <Color x:Key="StepConnection.StrokeColor">#5CA2C9</Color>
+
     <!--PENDING CONNECTION-->
     <Color x:Key="PendingConnection.StrokeColor">#5CA2C9</Color>
     <Color x:Key="PendingConnection.BorderColor">Black</Color>

--- a/Nodify/Themes/Nodify.xaml
+++ b/Nodify/Themes/Nodify.xaml
@@ -66,6 +66,9 @@
     <!--CIRCUIT CONNECTION-->
     <Color x:Key="CircuitConnection.StrokeColor">#FD5618</Color>
 
+    <!--STEP CONNECTION-->
+    <Color x:Key="StepConnection.StrokeColor">#FD5618</Color>
+
     <!--PENDING CONNECTION-->
     <Color x:Key="PendingConnection.StrokeColor">#FD5618</Color>
     <Color x:Key="PendingConnection.BorderColor">#451E63</Color>

--- a/Nodify/Themes/Styles/Connection.xaml
+++ b/Nodify/Themes/Styles/Connection.xaml
@@ -35,4 +35,15 @@
                 Value="30" />
     </Style>
 
+    <Style TargetType="{x:Type local:StepConnection}">
+        <Setter Property="StrokeThickness"
+                Value="3" />
+        <Setter Property="Stroke"
+                Value="DodgerBlue" />
+        <Setter Property="Fill"
+                Value="DodgerBlue" />
+        <Setter Property="Spacing"
+                Value="30" />
+    </Style>
+
 </ResourceDictionary>

--- a/Nodify/Themes/Styles/NodifyEditor.xaml
+++ b/Nodify/Themes/Styles/NodifyEditor.xaml
@@ -7,7 +7,7 @@
     <local:UnscaleDoubleConverter x:Key="UnscaleDoubleConverter" />
 
     <DataTemplate x:Key="ConnectionTemplate">
-        <local:Connection />
+        <local:Connection Style="{DynamicResource {x:Type local:Connection}}" />
     </DataTemplate>
 
     <DataTemplate x:Key="PendingConnectionTemplate">


### PR DESCRIPTION
### 📝 Description of the Change

This PR adds a new built-in connection type supporting all existing features: StepConnection

![step-connection](https://github.com/miroiu/nodify/assets/12727904/ef5de7cc-c9fa-49ab-954a-3cdf60e654f6)

No need for `Direction`, `SourceOrientation`, and `TargetOrientation` to be set but it requires two new parameters: `SourcePosition` and `TargetPosition` which opens up new possibilities. I may consider removing `Direction` and `Orientation` and adding these new parameters to the base connection.

### 🐛 Possible Drawbacks

More complex code to maintain.