### PR TITLE
Fix wrong connector position for knot nodes when using step connection

### DIFF
--- a/Examples/Nodify.Playground/Converters/FlowToConnectorPositionConverter.cs
+++ b/Examples/Nodify.Playground/Converters/FlowToConnectorPositionConverter.cs
@@ -9,21 +9,40 @@ namespace Nodify.Playground
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is ConnectorViewModel connector)
+            if (value is ConnectionViewModel connection)
             {
-                if (connector.Node.Orientation == Orientation.Horizontal)
+                var connector = parameter is "Input" ? connection.Input : connection.Output;
+
+                if (connector.Node is KnotNodeViewModel)
                 {
-                    return connector.Flow == ConnectorFlow.Output
-                        ? ConnectorPosition.Right
-                        : ConnectorPosition.Left;
+                    var otherConnector = connection.Input == connector ? connection.Output : connection.Input;
+
+                    if (otherConnector.Node is KnotNodeViewModel)
+                    {
+                        return ToPosition(connector == connection.Input ? ConnectorFlow.Input : ConnectorFlow.Output, connector.Node.Orientation);
+                    }
+
+                    return ToPosition(otherConnector.Flow == ConnectorFlow.Output ? ConnectorFlow.Input : ConnectorFlow.Output, connector.Node.Orientation);
                 }
 
-                return connector.Flow == ConnectorFlow.Output
-                    ? ConnectorPosition.Bottom
-                    : ConnectorPosition.Top;
+                return ToPosition(connector.Flow, connector.Node.Orientation);
             }
 
             return value;
+        }
+
+        private ConnectorPosition ToPosition(ConnectorFlow flow, Orientation orientation)
+        {
+            if (orientation == Orientation.Horizontal)
+            {
+                return flow == ConnectorFlow.Output
+                    ? ConnectorPosition.Right
+                    : ConnectorPosition.Left;
+            }
+
+            return flow == ConnectorFlow.Output
+                ? ConnectorPosition.Bottom
+                : ConnectorPosition.Top;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/Examples/Nodify.Playground/Editor/GraphSchema.cs
+++ b/Examples/Nodify.Playground/Editor/GraphSchema.cs
@@ -79,12 +79,10 @@ namespace Nodify.Playground
 
         public void SplitConnection(ConnectionViewModel connection, Point location)
         {
-            var connector = connection.Output;
-
-            var knot = new KnotNodeViewModel
+            var knot = new KnotNodeViewModel(connection.Output.Node.Orientation)
             {
                 Location = location,
-                Flow = connector.Flow,
+                Flow = connection.Output.Flow,
                 Connector = new ConnectorViewModel
                 {
                     MaxConnections = connection.Output.MaxConnections + connection.Input.MaxConnections,
@@ -93,7 +91,7 @@ namespace Nodify.Playground
             };
             connection.Graph.Nodes.Add(knot);
 
-            AddConnection(connector, knot.Connector);
+            AddConnection(connection.Output, knot.Connector);
             AddConnection(knot.Connector, connection.Input);
 
             connection.Remove();

--- a/Examples/Nodify.Playground/Editor/KnotNodeViewModel.cs
+++ b/Examples/Nodify.Playground/Editor/KnotNodeViewModel.cs
@@ -1,7 +1,18 @@
-﻿namespace Nodify.Playground
+﻿using System.Windows.Controls;
+
+namespace Nodify.Playground
 {
     public class KnotNodeViewModel : NodeViewModel
     {
+        public KnotNodeViewModel(Orientation orientation)
+        {
+            Orientation = orientation;
+        }
+
+        public KnotNodeViewModel() : this(Orientation.Horizontal)
+        {
+        }
+
         private ConnectorViewModel _connector = default!;
         public ConnectorViewModel Connector
         {

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -110,8 +110,8 @@
 
         <DataTemplate x:Key="StepConnectionTemplate">
             <nodify:StepConnection Style="{StaticResource ConnectionStyle}"
-                                   SourcePosition="{Binding Output, Converter={StaticResource FlowToConnectorPositionConverter}}"
-                                   TargetPosition="{Binding Input, Converter={StaticResource FlowToConnectorPositionConverter}}" />
+                                   SourcePosition="{Binding ., Converter={StaticResource FlowToConnectorPositionConverter}, ConverterParameter=Output}"
+                                   TargetPosition="{Binding ., Converter={StaticResource FlowToConnectorPositionConverter}, ConverterParameter=Input}" />
         </DataTemplate>
 
         <DataTemplate x:Key="ConnectionTemplate">


### PR DESCRIPTION
### 📝 Description of the Change

- fixes wrong connector position for step connection when used with knot node
- adds vertical orientation to knot nodes

Closes #110 

![step](https://github.com/miroiu/nodify/assets/12727904/1661f9d0-4407-432b-8cfe-02b1725bf96d)
![default](https://github.com/miroiu/nodify/assets/12727904/0aacae53-3055-4cc8-832e-d33c3111c085)

### 🐛 Possible Drawbacks

No.
