### PR TITLE
Add a Minimap control to Nodify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 > - Breaking Changes:
 > - Features:
+>	- Added a Minimap control to Nodify
 >	- Added ContentContainerStyle, HeaderContainerStyle and FooterContainerStyle dependency properties to Node
 >	- Added BringIntoView that takes a Rect parameter to NodifyEditor
 >	- Added the NodifyEditor's DataContext as the parameter of the ItemsSelectStartedCommand, ItemsSelectCompletedCommand, ItemsDragStartedCommand and ItemsDragCompletedCommand commands

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -472,6 +472,33 @@
         <Grid Background="{StaticResource LargeGridLinesDrawingBrush}"
               Visibility="{Binding ShowGridLines, Source={x:Static local:PlaygroundSettings.Instance}, Converter={shared:BooleanToVisibilityConverter}}"
               Panel.ZIndex="-2" />
+        
+        <nodify:Minimap ItemsSource="{Binding Nodes}"
+                        ViewportSize="{Binding ViewportSize, ElementName=Editor}"
+                        ViewportLocation="{Binding ViewportLocation, ElementName=Editor}"
+                        Visibility="{Binding ShowMinimap, Source={x:Static local:PlaygroundSettings.Instance}, Converter={shared:BooleanToVisibilityConverter}}"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Width="300"
+                        Height="200"
+                        Margin="5 40">
+            <nodify:Minimap.ItemTemplate>
+                <DataTemplate DataType="{x:Type local:NodeViewModel}">
+                    <Grid />
+                </DataTemplate>
+            </nodify:Minimap.ItemTemplate>
+            <nodify:Minimap.ItemContainerStyle>
+                <Style TargetType="{x:Type nodify:MinimapItem}"
+                       BasedOn="{StaticResource {x:Type nodify:MinimapItem}}">
+                    <Setter Property="Location"
+                            Value="{Binding Location}" />
+                    <Setter Property="Width"
+                            Value="150" />
+                    <Setter Property="Height"
+                            Value="130" />
+                </Style>
+            </nodify:Minimap.ItemContainerStyle>
+        </nodify:Minimap>
     </Grid>
 
 </UserControl>

--- a/Examples/Nodify.Playground/PlaygroundSettings.cs
+++ b/Examples/Nodify.Playground/PlaygroundSettings.cs
@@ -20,6 +20,11 @@ namespace Nodify.Playground
                     val => Instance.EditorInputMode = val,
                     "Editor input mode"),
                 new ProxySettingViewModel<bool>(
+                    () => Instance.ShowMinimap,
+                    val => Instance.ShowMinimap = val,
+                    "Show minimap",
+                    "Set Enable nodes dragging optimization to false for realtime updates"),
+                new ProxySettingViewModel<bool>(
                     () => Instance.ShowGridLines,
                     val => Instance.ShowGridLines = val,
                     "Show grid lines:"),
@@ -74,6 +79,13 @@ namespace Nodify.Playground
             get => _editorInputMode;
             set => SetProperty(ref _editorInputMode, value)
                 .Then(() => EditorGestures.Mappings.Apply(value));
+        }
+
+        private bool _showMinimap = true;
+        public bool ShowMinimap
+        {
+            get => _showMinimap;
+            set => SetProperty(ref _showMinimap, value);
         }
 
         private bool _shouldConnectNodes = true;

--- a/Examples/Nodify.Shapes/Canvas/CanvasView.xaml
+++ b/Examples/Nodify.Shapes/Canvas/CanvasView.xaml
@@ -341,6 +341,106 @@
             </nodify:NodifyEditor.ItemContainerStyle>
         </nodify:NodifyEditor>
 
+        <!--MINIMAP-->
+        <shared:ResizablePanel Directions="BottomLeft"
+                               VerticalAlignment="Top"
+                               HorizontalAlignment="Right"
+                               Width="300"
+                               Height="200"
+                               MinWidth="250"
+                               MinHeight="150"
+                               BorderBrush="{x:Null}"
+                               Margin="20">
+            <shared:ResizablePanel.Resources>
+                <Style TargetType="{x:Type shared:Resizer}">
+                    <Setter Property="Cursor"
+                            Value="SizeNESW" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type shared:Resizer}">
+                                <Grid Margin="-3 -6 -6 -3" Background="Transparent">
+                                    <Rectangle Height="12"
+                                               Width="3"
+                                               Fill="#d2d4d7"
+                                               HorizontalAlignment="Left"
+                                               VerticalAlignment="Bottom" />
+                                    <Rectangle Height="3"
+                                               Width="12"
+                                               Fill="#d2d4d7"
+                                               VerticalAlignment="Bottom"
+                                               HorizontalAlignment="Left" />
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </shared:ResizablePanel.Resources>
+            <Border CornerRadius="3"
+                    BorderBrush="#1e293b"
+                    BorderThickness="3">
+                <Border.Effect>
+                    <DropShadowEffect ShadowDepth="1" />
+                </Border.Effect>
+
+                <nodify:Minimap ItemsSource="{Binding Shapes}"
+                                ViewportLocation="{Binding ViewportLocation, ElementName=Editor}"
+                                ViewportSize="{Binding ViewportSize, ElementName=Editor}">
+                    <nodify:Minimap.Resources>
+                        <DataTemplate DataType="{x:Type local:EllipseViewModel}">
+                            <Ellipse Stretch="Fill"
+                                     Fill="{Binding Color, Converter={StaticResource ColorToSolidColorBrushConverter}}"
+                                     Stroke="{Binding BorderColor, Converter={StaticResource ColorToSolidColorBrushConverter}}"
+                                     StrokeThickness="2"
+                                     Opacity="0.8" />
+                        </DataTemplate>
+
+                        <DataTemplate DataType="{x:Type local:RectangleViewModel}">
+                            <Rectangle Stretch="Fill"
+                                       Fill="{Binding Color, Converter={StaticResource ColorToSolidColorBrushConverter}}"
+                                       Stroke="{Binding BorderColor, Converter={StaticResource ColorToSolidColorBrushConverter}}"
+                                       StrokeThickness="2"
+                                       Opacity="0.8" />
+                        </DataTemplate>
+
+                        <DataTemplate DataType="{x:Type local:TriangleViewModel}">
+                            <Polygon Points="0,100 50,0 100,100"
+                                     Stretch="Fill"
+                                     Fill="{Binding Color, Converter={StaticResource ColorToSolidColorBrushConverter}}"
+                                     Stroke="{Binding BorderColor, Converter={StaticResource ColorToSolidColorBrushConverter}}"
+                                     StrokeThickness="2"
+                                     Opacity="0.8" />
+                        </DataTemplate>
+                    </nodify:Minimap.Resources>
+                    <nodify:Minimap.Background>
+                        <SolidColorBrush Color="#111a2d"
+                                         Opacity="0.5" />
+                    </nodify:Minimap.Background>
+                    <nodify:Minimap.ItemContainerStyle>
+                        <Style TargetType="{x:Type nodify:MinimapItem}">
+                            <Setter Property="Location"
+                                    Value="{Binding Location}" />
+                            <Setter Property="Width"
+                                    Value="{Binding Width}" />
+                            <Setter Property="Height"
+                                    Value="{Binding Height}" />
+                        </Style>
+                    </nodify:Minimap.ItemContainerStyle>
+                    <nodify:Minimap.ViewportStyle>
+                        <Style TargetType="Rectangle">
+                            <Setter Property="StrokeThickness"
+                                    Value="3" />
+                            <Setter Property="Fill">
+                                <Setter.Value>
+                                    <SolidColorBrush Color="#445e87"
+                                                     Opacity="0.3" />
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </nodify:Minimap.ViewportStyle>
+                </nodify:Minimap>
+            </Border>
+        </shared:ResizablePanel>
+
         <!--TOOLBARS-->
 
         <Border VerticalAlignment="Bottom"

--- a/Examples/Nodify.Shapes/MainWindow.xaml.cs
+++ b/Examples/Nodify.Shapes/MainWindow.xaml.cs
@@ -10,6 +10,8 @@ namespace Nodify.Shapes
         public MainWindow()
         {
             InitializeComponent();
+
+            NodifyEditor.EnableDraggingContainersOptimizations = false;
         }
     }
 }

--- a/Nodify/EditorGestures.cs
+++ b/Nodify/EditorGestures.cs
@@ -234,6 +234,24 @@ namespace Nodify
             }
         }
 
+        public class MinimapGestures
+        {
+            public MinimapGestures()
+            {
+                DragViewport = new MouseGesture(MouseAction.LeftClick);
+            }
+
+            /// <summary>Gesture to move the viewport inside the <see cref="Minimap">.</summary>
+            public InputGestureRef DragViewport { get; }
+
+            /// <summary>Copies from the specified gestures.</summary>
+            /// <param name="gestures">The gestures to copy.</param>
+            public void Apply(MinimapGestures gestures)
+            {
+                DragViewport.Value = gestures.DragViewport.Value;
+            }
+        }
+
         /// <summary>Gestures for the editor.</summary>
         public NodifyEditorGestures Editor { get; } = new NodifyEditorGestures();
 
@@ -249,6 +267,9 @@ namespace Nodify
         /// <summary>Gestures for the grouping node.</summary>
         public GroupingNodeGestures GroupingNode { get; } = new GroupingNodeGestures();
 
+        /// <summary>Gestures for the minimap.</summary>
+        public MinimapGestures Minimap { get; } = new MinimapGestures();
+
         /// <summary>Copies from the specified gestures.</summary>
         /// <param name="gestures">The gestures to copy.</param>
         public void Apply(EditorGestures gestures)
@@ -258,6 +279,7 @@ namespace Nodify
             Connector.Apply(gestures.Connector);
             Connection.Apply(gestures.Connection);
             GroupingNode.Apply(gestures.GroupingNode);
+            Minimap.Apply(gestures.Minimap);
         }
     }
 }

--- a/Nodify/Minimap/Minimap.cs
+++ b/Nodify/Minimap/Minimap.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Shapes;
+
+namespace Nodify
+{
+    [StyleTypedProperty(Property = nameof(ViewportStyle), StyleTargetType = typeof(Rectangle))]
+    [StyleTypedProperty(Property = nameof(ItemContainerStyle), StyleTargetType = typeof(MinimapItem))]
+    [TemplatePart(Name = ElementItemsHost, Type = typeof(Panel))]
+    public class Minimap : ItemsControl
+    {
+        protected const string ElementItemsHost = "PART_ItemsHost";
+
+        public static readonly DependencyProperty ViewportLocationProperty = NodifyEditor.ViewportLocationProperty.AddOwner(typeof(Minimap), new FrameworkPropertyMetadata(BoxValue.Point, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+        public static readonly DependencyProperty ViewportSizeProperty = NodifyEditor.ViewportSizeProperty.AddOwner(typeof(Minimap));
+        public static readonly DependencyProperty ViewportStyleProperty = DependencyProperty.Register(nameof(ViewportStyle), typeof(Style), typeof(Minimap));
+        public static readonly DependencyProperty ExtentProperty = NodifyCanvas.ExtentProperty.AddOwner(typeof(Minimap));
+
+        /// <inheritdoc cref="NodifyEditor.ViewportLocation" />
+        public Point ViewportLocation
+        {
+            get => (Point)GetValue(ViewportLocationProperty);
+            set => SetValue(ViewportLocationProperty, value);
+        }
+
+        /// <inheritdoc cref="NodifyEditor.ViewportSize" />
+        public Size ViewportSize
+        {
+            get => (Size)GetValue(ViewportSizeProperty);
+            set => SetValue(ViewportSizeProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the style to use for the viewport rectangle.
+        /// </summary>
+        public Style ViewportStyle
+        {
+            get => (Style)GetValue(ViewportStyleProperty);
+            set => SetValue(ViewportStyleProperty, value);
+        }
+
+        /// <summary>The area covered by the items and the viewport rectangle in graph space.</summary>
+        public Rect Extent
+        {
+            get => (Rect)GetValue(ExtentProperty);
+            set => SetValue(ExtentProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the panel that holds all the <see cref="MinimapItem"/>s.
+        /// </summary>
+        protected internal Panel ItemsHost { get; private set; } = default!;
+
+        static Minimap()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(Minimap), new FrameworkPropertyMetadata(typeof(Minimap)));
+        }
+
+        public override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            ItemsHost = GetTemplateChild(ElementItemsHost) as Panel ?? throw new InvalidOperationException($"{ElementItemsHost} is missing or is not of type Panel.");
+        }
+
+        protected bool IsDragging { get; private set; }
+
+        protected override void OnMouseDown(MouseButtonEventArgs e)
+        {
+            var gestures = EditorGestures.Mappings.Minimap;
+            if (gestures.DragViewport.Matches(this, e))
+            {
+                this.CaptureMouseSafe();
+                IsDragging = true;
+
+                var position = e.GetPosition(ItemsHost);
+                ViewportLocation = position - new Vector(ViewportSize.Width / 2, ViewportSize.Height / 2) + (Vector)Extent.Location;
+
+                e.Handled = true;
+            }
+        }
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            if (IsDragging)
+            {
+                var position = e.GetPosition(ItemsHost);
+                ViewportLocation = position - new Vector(ViewportSize.Width / 2, ViewportSize.Height / 2) + (Vector)Extent.Location;
+            }
+        }
+
+        protected override void OnMouseUp(MouseButtonEventArgs e)
+        {
+            var gestures = EditorGestures.Mappings.Minimap;
+            if (IsDragging && gestures.DragViewport.Matches(this, e))
+            {
+                IsDragging = false;
+            }
+
+            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released)
+            {
+                ReleaseMouseCapture();
+            }
+        }
+
+        protected override DependencyObject GetContainerForItemOverride()
+            => new MinimapItem();
+
+        protected override bool IsItemItsOwnContainerOverride(object item)
+            => item is MinimapItem;
+    }
+}

--- a/Nodify/Minimap/MinimapItem.cs
+++ b/Nodify/Minimap/MinimapItem.cs
@@ -1,0 +1,19 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace Nodify
+{
+    public class MinimapItem : ContentControl
+    {
+        public static readonly DependencyProperty LocationProperty = ItemContainer.LocationProperty.AddOwner(typeof(MinimapItem), new FrameworkPropertyMetadata(BoxValue.Point, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault | FrameworkPropertyMetadataOptions.AffectsParentMeasure));
+
+        /// <summary>
+        /// Gets or sets the location of this <see cref="MinimapItem"/> inside the <see cref="Minimap"/>.
+        /// </summary>
+        public Point Location
+        {
+            get => (Point)GetValue(LocationProperty);
+            set => SetValue(LocationProperty, value);
+        }
+    }
+}

--- a/Nodify/Minimap/MinimapPanel.cs
+++ b/Nodify/Minimap/MinimapPanel.cs
@@ -1,0 +1,97 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace Nodify
+{
+    internal class MinimapPanel : Panel
+    {
+        public static readonly DependencyProperty ViewportLocationProperty = NodifyEditor.ViewportLocationProperty.AddOwner(typeof(MinimapPanel), new FrameworkPropertyMetadata(BoxValue.Point, FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        public static readonly DependencyProperty ViewportSizeProperty = NodifyEditor.ViewportSizeProperty.AddOwner(typeof(MinimapPanel), new FrameworkPropertyMetadata(BoxValue.Size, FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        public static readonly DependencyProperty ExtentProperty = NodifyCanvas.ExtentProperty.AddOwner(typeof(MinimapPanel));
+
+        /// <inheritdoc cref="Minimap.ViewportLocation" />
+        public Point ViewportLocation
+        {
+            get => (Point)GetValue(ViewportLocationProperty);
+            set => SetValue(ViewportLocationProperty, value);
+        }
+
+        /// <inheritdoc cref="Minimap.ViewportSize" />
+        public Size ViewportSize
+        {
+            get => (Size)GetValue(ViewportSizeProperty);
+            set => SetValue(ViewportSizeProperty, value);
+        }
+
+        /// <inheritdoc cref="Minimap.Extent" />
+        public Rect Extent
+        {
+            get => (Rect)GetValue(ExtentProperty);
+            set => SetValue(ExtentProperty, value);
+        }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            double minX = double.MaxValue;
+            double minY = double.MaxValue;
+
+            double maxX = double.MinValue;
+            double maxY = double.MinValue;
+
+            UIElementCollection children = InternalChildren;
+            for (int i = 0; i < children.Count; i++)
+            {
+                var item = (MinimapItem)children[i];
+                item.Measure(availableSize);
+
+                Size size = item.DesiredSize;
+
+                if (item.Location.X < minX)
+                {
+                    minX = item.Location.X;
+                }
+
+                if (item.Location.Y < minY)
+                {
+                    minY = item.Location.Y;
+                }
+
+                double sizeX = item.Location.X + size.Width;
+                if (sizeX > maxX)
+                {
+                    maxX = sizeX;
+                }
+
+                double sizeY = item.Location.Y + size.Height;
+                if (sizeY > maxY)
+                {
+                    maxY = sizeY;
+                }
+            }
+
+            var itemsExtent = minX == double.MaxValue
+                ? new Rect(0, 0, 0, 0)
+                : new Rect(minX, minY, maxX - minX, maxY - minY);
+
+            itemsExtent.Union(new Rect(ViewportLocation, ViewportSize));
+
+            Extent = itemsExtent;
+
+            return itemsExtent.Size;
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            UIElementCollection children = InternalChildren;
+            for (int i = 0; i < children.Count; i++)
+            {
+                var item = (MinimapItem)children[i];
+                item.Arrange(new Rect(item.Location - (Vector)Extent.Location, item.DesiredSize));
+            }
+
+            return finalSize;
+        }
+    }
+}

--- a/Nodify/Minimap/SubtractConverter.cs
+++ b/Nodify/Minimap/SubtractConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Nodify
+{
+    internal class SubtractConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            double result = (double)values[0] - (double)values[1];
+            return result;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -146,7 +146,7 @@ namespace Nodify
         public Transform ViewportTransform => (Transform)GetValue(ViewportTransformProperty);
 
         /// <summary>
-        /// Gets the size of the viewport.
+        /// Gets the size of the viewport in graph space (scaled by the <see cref="ViewportZoom"/>).
         /// </summary>
         public Size ViewportSize
         {
@@ -162,7 +162,6 @@ namespace Nodify
             get => (Point)GetValue(ViewportLocationProperty);
             set => SetValue(ViewportLocationProperty, value);
         }
-
 
         /// <summary>
         /// Gets or sets the zoom factor of the viewport.

--- a/Nodify/Themes/Brushes.xaml
+++ b/Nodify/Themes/Brushes.xaml
@@ -216,4 +216,25 @@
                      o:Freeze="True"
                      Color="{DynamicResource PendingConnection.BackgroundColor}" />
 
+    <!--MINIMAP-->
+
+    <SolidColorBrush x:Key="Minimap.BackgroundBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource Minimap.BackgroundColor}"
+                     Opacity="0.7" />
+
+    <SolidColorBrush x:Key="Minimap.ViewportStrokeBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource Minimap.ViewportStrokeColor}" />
+
+    <SolidColorBrush x:Key="Minimap.ViewportBackgroundBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource Minimap.ViewportBackgroundColor}"
+                     Opacity="0.2" />
+
+    <SolidColorBrush x:Key="MinimapItem.BackgroundBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource MinimapItem.BackgroundColor}"
+                     Opacity="0.8" />
+
 </ResourceDictionary>

--- a/Nodify/Themes/Controls.xaml
+++ b/Nodify/Themes/Controls.xaml
@@ -200,4 +200,36 @@
                 Value="{StaticResource PendingConnection.BackgroundBrush}" />
     </Style>
 
+    <!--MINIMAP-->
+
+    <Style x:Key="Minimap.ViewportStyle"
+           TargetType="Rectangle">
+        <Setter Property="Stroke"
+                Value="{StaticResource Minimap.ViewportStrokeBrush}" />
+        <Setter Property="StrokeThickness"
+                Value="3" />
+        <Setter Property="Fill"
+                Value="{StaticResource Minimap.ViewportBackgroundBrush}" />
+        <Setter Property="StrokeLineJoin"
+                Value="Round" />
+        <Setter Property="StrokeEndLineCap"
+                Value="Round" />
+        <Setter Property="StrokeStartLineCap"
+                Value="Round" />
+    </Style>
+
+    <Style TargetType="{x:Type local:Minimap}"
+           BasedOn="{StaticResource {x:Type local:Minimap}}">
+        <Setter Property="Background"
+                Value="{StaticResource Minimap.BackgroundBrush}" />
+        <Setter Property="ViewportStyle" 
+                Value="{StaticResource Minimap.ViewportStyle}"/>
+    </Style>
+
+    <Style TargetType="{x:Type local:MinimapItem}"
+           BasedOn="{StaticResource {x:Type local:MinimapItem}}">
+        <Setter Property="Background"
+                Value="{StaticResource MinimapItem.BackgroundBrush}" />
+    </Style>
+
 </ResourceDictionary>

--- a/Nodify/Themes/Dark.xaml
+++ b/Nodify/Themes/Dark.xaml
@@ -75,4 +75,10 @@
     <Color x:Key="PendingConnection.ForegroundColor">White</Color>
     <Color x:Key="PendingConnection.BackgroundColor">#121212</Color>
 
+    <!--MINIMAP-->
+    <Color x:Key="Minimap.BackgroundColor">#121212</Color>
+    <Color x:Key="Minimap.ViewportStrokeColor">DodgerBlue</Color>
+    <Color x:Key="Minimap.ViewportBackgroundColor">DodgerBlue</Color>
+    <Color x:Key="MinimapItem.BackgroundColor">#2D2D30</Color>
+    
 </ResourceDictionary>

--- a/Nodify/Themes/Light.xaml
+++ b/Nodify/Themes/Light.xaml
@@ -75,4 +75,10 @@
     <Color x:Key="PendingConnection.ForegroundColor">White</Color>
     <Color x:Key="PendingConnection.BackgroundColor">#5C6A98</Color>
 
+    <!--MINIMAP-->
+    <Color x:Key="Minimap.BackgroundColor">#f2f3f5</Color>
+    <Color x:Key="Minimap.ViewportStrokeColor">DodgerBlue</Color>
+    <Color x:Key="Minimap.ViewportBackgroundColor">DodgerBlue</Color>
+    <Color x:Key="MinimapItem.BackgroundColor">#5C6A98</Color>
+    
 </ResourceDictionary>

--- a/Nodify/Themes/Nodify.xaml
+++ b/Nodify/Themes/Nodify.xaml
@@ -75,4 +75,10 @@
     <Color x:Key="PendingConnection.ForegroundColor">#E8E1F3</Color>
     <Color x:Key="PendingConnection.BackgroundColor">#2A1B47</Color>
 
+    <!--MINIMAP-->
+    <Color x:Key="Minimap.BackgroundColor">#2A1B47</Color>
+    <Color x:Key="Minimap.ViewportStrokeColor">#FD5618</Color>
+    <Color x:Key="Minimap.ViewportBackgroundColor">#FD5618</Color>
+    <Color x:Key="MinimapItem.BackgroundColor">#662D91</Color>
+
 </ResourceDictionary>

--- a/Nodify/Themes/Styles/Controls.xaml
+++ b/Nodify/Themes/Styles/Controls.xaml
@@ -15,5 +15,8 @@
         <ResourceDictionary Source="ItemContainer.xaml" />
         <ResourceDictionary Source="DecoratorContainer.xaml" />
         <ResourceDictionary Source="NodifyEditor.xaml" />
+        
+        <!--WIDGETS-->
+        <ResourceDictionary Source="Minimap.xaml" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/Nodify/Themes/Styles/DecoratorContainer.xaml
+++ b/Nodify/Themes/Styles/DecoratorContainer.xaml
@@ -16,7 +16,6 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             Padding="{TemplateBinding Padding}"
-                            x:Name="Border"
                             CornerRadius="3">
                         <ContentPresenter />
                     </Border>

--- a/Nodify/Themes/Styles/Minimap.xaml
+++ b/Nodify/Themes/Styles/Minimap.xaml
@@ -1,0 +1,99 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:Nodify">
+
+    <local:SubtractConverter x:Key="SubtractConverter" />
+
+    <SolidColorBrush x:Key="MinimapBackground"
+                     Color="Black"
+                     Opacity="0.3" />
+    <SolidColorBrush x:Key="MinimapItemBackground"
+                     Color="White"
+                     Opacity="0.8" />
+
+    <Style x:Key="ViewportRectStyle"
+           TargetType="Rectangle">
+        <Setter Property="Stroke"
+                Value="White" />
+        <Setter Property="StrokeThickness"
+                Value="3" />
+        <Setter Property="Fill">
+            <Setter.Value>
+                <SolidColorBrush Color="White"
+                                 Opacity="0.2" />
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type local:Minimap}">
+        <Setter Property="Padding"
+                Value="10" />
+        <Setter Property="Background"
+                Value="{StaticResource MinimapBackground}" />
+        <Setter Property="ViewportStyle"
+                Value="{StaticResource ViewportRectStyle}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type local:Minimap}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            CornerRadius="3">
+                        <Viewbox Stretch="Uniform"
+                                 Margin="{TemplateBinding Padding}">
+                            <Grid>
+                                <local:MinimapPanel ViewportSize="{TemplateBinding ViewportSize}"
+                                                    ViewportLocation="{TemplateBinding ViewportLocation}"
+                                                    Extent="{Binding Extent, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWayToSource}"
+                                                    IsItemsHost="True"
+                                                    x:Name="PART_ItemsHost" />
+
+                                <Canvas>
+                                    <Rectangle  Style="{TemplateBinding ViewportStyle}"
+                                                Width="{Binding ViewportSize.Width, RelativeSource={RelativeSource TemplatedParent}}"
+                                                Height="{Binding ViewportSize.Height, RelativeSource={RelativeSource TemplatedParent}}">
+                                        <Canvas.Top>
+                                            <MultiBinding Converter="{StaticResource SubtractConverter}">
+                                                <Binding Path="ViewportLocation.Y"
+                                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                                <Binding Path="Extent.Location.Y"
+                                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                            </MultiBinding>
+                                        </Canvas.Top>
+                                        <Canvas.Left>
+                                            <MultiBinding Converter="{StaticResource SubtractConverter}">
+                                                <Binding Path="ViewportLocation.X"
+                                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                                <Binding Path="Extent.Location.X"
+                                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                            </MultiBinding>
+                                        </Canvas.Left>
+                                    </Rectangle>
+                                </Canvas>
+                            </Grid>
+                        </Viewbox>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type local:MinimapItem}">
+        <Setter Property="Background"
+                Value="{StaticResource MinimapItemBackground}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type local:MinimapItem}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            Padding="{TemplateBinding Padding}"
+                            CornerRadius="3">
+                        <ContentPresenter />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>


### PR DESCRIPTION
### 📝 Description of the Change

This PR adds a Minimap control to Nodify and how to use examples in Shapes and Playground apps.

Please note that for real-time movement of nodes inside the minimap, it's best to set `NodifyEditor.EnableDraggingContainersOptimizations` to false.

![minimap](https://github.com/user-attachments/assets/7a8887bf-f3f4-44d7-8311-6d9ba7869d78)

TODO: 
- Add a way to limit the dragging of the viewport (new MaxViewportOffset dependency property?)
- Add documentation

Closes #123
Related #32
