### PR TITLE
Add CuttingLine control to Nodify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 > - Breaking Changes:
 > - Features:
+>	- Added a CuttingLine control that removes intersecting connections
+>	- Added CuttingLineStyle, CuttingStartedCommand, CuttingCompletedCommand, IsCutting, EnableCuttingLinePreview and CuttingConnectionTypes to NodifyEditor
+>	- Added EditorGestures.Editor.Cutting and EditorGestures.Editor.CancelAction
 > - Bugfixes:
+>	- Fixed connection styles not inheriting from the BaseConnection style
 
 #### **Version 6.2.0**
 

--- a/Examples/Nodify.Calculator/MainWindow.xaml.cs
+++ b/Examples/Nodify.Calculator/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows;
-using System.Windows.Input;
 
 namespace Nodify.Calculator
 {
@@ -8,6 +7,8 @@ namespace Nodify.Calculator
         public MainWindow()
         {
             InitializeComponent();
+
+            EditorGestures.Mappings.Editor.Cutting.Value = MultiGesture.None;
         }
     }
 }

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -56,7 +56,8 @@
                              Duration="0:0:0.3" From="1" To="0.3"  />
         </Storyboard>
 
-        <Style x:Key="ConnectionStyle" TargetType="{x:Type nodify:BaseConnection}">
+        <Style x:Key="ConnectionStyle" TargetType="{x:Type nodify:BaseConnection}"
+               BasedOn="{StaticResource {x:Type nodify:BaseConnection}}">
             <Style.Triggers>
                 <DataTrigger Binding="{Binding Input.Shape}" 
                              Value="{x:Static local:ConnectorShape.Square}">
@@ -165,6 +166,15 @@
                 </EventTrigger>
             </Style.Triggers>
         </Style>
+
+        <Style x:Key="CuttingLineStyle"
+               TargetType="{x:Type nodify:CuttingLine}"
+               BasedOn="{StaticResource {x:Type nodify:CuttingLine}}">
+            <Setter Property="StrokeDashArray"
+                    Value="1 1" />
+            <Setter Property="StrokeThickness"
+                    Value="2" />
+        </Style>
     </UserControl.Resources>
 
     <Grid>
@@ -189,7 +199,8 @@
                              DisplayConnectionsOnTop="{Binding DisplayConnectionsOnTop, Source={x:Static local:EditorSettings.Instance}}"
                              BringIntoViewSpeed="{Binding BringIntoViewSpeed, Source={x:Static local:EditorSettings.Instance}}"
                              BringIntoViewMaxDuration="{Binding BringIntoViewMaxDuration, Source={x:Static local:EditorSettings.Instance}}"
-                             SelectionRectangleStyle="{StaticResource SelectionRectangleStyle}">
+                             SelectionRectangleStyle="{StaticResource SelectionRectangleStyle}"
+                             CuttingLineStyle="{StaticResource CuttingLineStyle}">
             <nodify:NodifyEditor.Style>
                 <Style TargetType="{x:Type nodify:NodifyEditor}"
                        BasedOn="{StaticResource {x:Type nodify:NodifyEditor}}">

--- a/Examples/Nodify.Playground/EditorInputMode.cs
+++ b/Examples/Nodify.Playground/EditorInputMode.cs
@@ -6,7 +6,8 @@ namespace Nodify.Playground
     {
         Default,
         PanOnly,
-        SelectOnly
+        SelectOnly,
+        CutOnly
     }
 
     public enum EditorGesturesMappings
@@ -25,12 +26,22 @@ namespace Nodify.Playground
             {
                 case EditorInputMode.PanOnly:
                     mappings.Editor.Selection.Apply(EditorGestures.SelectionGestures.None);
+                    mappings.Editor.Cutting.Value = MultiGesture.None;
                     mappings.ItemContainer.Selection.Apply(EditorGestures.SelectionGestures.None);
                     mappings.ItemContainer.Drag.Value = MultiGesture.None;
                     mappings.Connector.Connect.Value = MultiGesture.None;
                     break;
                 case EditorInputMode.SelectOnly:
                     mappings.Editor.Pan.Value = MultiGesture.None;
+                    mappings.Editor.Cutting.Value = MultiGesture.None;
+                    mappings.ItemContainer.Drag.Value = MultiGesture.None;
+                    mappings.Connector.Connect.Value = MultiGesture.None;
+                    break;
+                case EditorInputMode.CutOnly:
+                    mappings.Editor.Cutting.Value = new MouseGesture(MouseAction.LeftClick);
+                    mappings.Editor.Selection.Apply(EditorGestures.SelectionGestures.None);
+                    mappings.Editor.Pan.Value = MultiGesture.None;
+                    mappings.ItemContainer.Selection.Apply(EditorGestures.SelectionGestures.None);
                     mappings.ItemContainer.Drag.Value = MultiGesture.None;
                     mappings.Connector.Connect.Value = MultiGesture.None;
                     break;

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -179,6 +179,11 @@ namespace Nodify.Playground
                     "Auto panning tick rate: ",
                     "How often is the new position calculated in milliseconds. Disable and enable auto panning for this to have effect."),
                 new ProxySettingViewModel<bool>(
+                    () => Instance.AllowCuttingCancellation,
+                    val => Instance.AllowCuttingCancellation = val,
+                    "Allow cutting cancellation: ",
+                    "Right click to cancel cutting."),
+                new ProxySettingViewModel<bool>(
                     () => Instance.AllowDraggingCancellation,
                     val => Instance.AllowDraggingCancellation = val,
                     "Allow dragging cancellation: ",
@@ -193,6 +198,11 @@ namespace Nodify.Playground
                     val => Instance.EnableSnappingCorrection = val,
                     "Enable snapping correction: ",
                     "Correct the final position when moving a selection"),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.EnableCuttingLinePreview,
+                    val => Instance.EnableCuttingLinePreview = val,
+                    "Enable cutting line preview: ",
+                    "Applies custom connection style on intersection (hurts performance due to hit testing)."),
                 new ProxySettingViewModel<bool>(
                     () => Instance.EnableConnectorOptimizations,
                     val => Instance.EnableConnectorOptimizations = val,
@@ -239,6 +249,8 @@ namespace Nodify.Playground
                     "Enable sticky connectors: ",
                     "The connection can be completed in two steps (e.g. click to create pending connection, click to connect)"),
             };
+
+            EnableCuttingLinePreview = true;
         }
 
         public static EditorSettings Instance { get; } = new EditorSettings();
@@ -478,6 +490,12 @@ namespace Nodify.Playground
             set => NodifyEditor.AutoPanningTickRate = value;
         }
 
+        public bool AllowCuttingCancellation
+        {
+            get => CuttingLine.AllowCuttingCancellation;
+            set => CuttingLine.AllowCuttingCancellation = value;
+        }
+
         public bool AllowDraggingCancellation
         {
             get => ItemContainer.AllowDraggingCancellation;
@@ -494,6 +512,12 @@ namespace Nodify.Playground
         {
             get => NodifyEditor.EnableSnappingCorrection;
             set => NodifyEditor.EnableSnappingCorrection = value;
+        }
+
+        public bool EnableCuttingLinePreview
+        {
+            get => NodifyEditor.EnableCuttingLinePreview;
+            set => NodifyEditor.EnableCuttingLinePreview = value;
         }
 
         public bool EnableConnectorOptimizations

--- a/Examples/Nodify.Shapes/MainWindow.xaml.cs
+++ b/Examples/Nodify.Shapes/MainWindow.xaml.cs
@@ -12,6 +12,7 @@ namespace Nodify.Shapes
             InitializeComponent();
 
             NodifyEditor.EnableDraggingContainersOptimizations = false;
+            NodifyEditor.EnableCuttingLinePreview = true;
         }
     }
 }

--- a/Examples/Nodify.StateMachine/MainWindow.xaml
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml
@@ -37,6 +37,7 @@
                              PendingConnection="{Binding PendingTransition}"
                              DisconnectConnectorCommand="{Binding DisconnectStateCommand}"
                              ConnectionCompletedCommand="{Binding CreateTransitionCommand}"
+                             RemoveConnectionCommand="{Binding DeleteTransitionCommand}"
                              Grid.Column="1">
             <nodify:NodifyEditor.PendingConnectionTemplate>
                 <DataTemplate DataType="{x:Type local:TransitionViewModel}">

--- a/Examples/Nodify.StateMachine/MainWindow.xaml.cs
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml.cs
@@ -9,6 +9,9 @@ namespace Nodify.StateMachine
             InitializeComponent();
 
             Connector.EnableStickyConnections = true;
+            NodifyEditor.EnableCuttingLinePreview = true;
+
+            EditorGestures.Mappings.Connection.Disconnect.Value = MultiGesture.None;
         }
     }
 }

--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -677,44 +677,52 @@ namespace Nodify
             if (gestures.Split.Matches(e.Source, e))
             {
                 Point splitLocation = e.GetPosition(this);
-                object? connection = DataContext;
-                var args = new ConnectionEventArgs(connection)
-                {
-                    RoutedEvent = SplitEvent,
-                    SplitLocation = splitLocation,
-                    Source = this
-                };
-
-                RaiseEvent(args);
-
-                // Raise SplitCommand if SplitEvent is not handled
-                if (!args.Handled && (SplitCommand?.CanExecute(splitLocation) ?? false))
-                {
-                    SplitCommand.Execute(splitLocation);
-                }
+                OnSplit(splitLocation);
 
                 e.Handled = true;
             }
             else if (gestures.Disconnect.Matches(e.Source, e))
             {
-                Point splitLocation = e.GetPosition(this);
-                object? connection = DataContext;
-                var args = new ConnectionEventArgs(connection)
-                {
-                    RoutedEvent = DisconnectEvent,
-                    SplitLocation = splitLocation,
-                    Source = this
-                };
-
-                RaiseEvent(args);
-
-                // Raise DisconnectCommand if DisconnectEvent is not handled
-                if (!args.Handled && (DisconnectCommand?.CanExecute(splitLocation) ?? false))
-                {
-                    DisconnectCommand.Execute(splitLocation);
-                }
+                OnDisconnect();
 
                 e.Handled = true;
+            }
+        }
+
+        protected internal void OnSplit(Point splitLocation)
+        {
+            object? connection = DataContext;
+            var args = new ConnectionEventArgs(connection)
+            {
+                RoutedEvent = SplitEvent,
+                SplitLocation = splitLocation,
+                Source = this
+            };
+
+            RaiseEvent(args);
+
+            // Raise SplitCommand if SplitEvent is not handled
+            if (!args.Handled && (SplitCommand?.CanExecute(splitLocation) ?? false))
+            {
+                SplitCommand.Execute(splitLocation);
+            }
+        }
+
+        protected internal void OnDisconnect()
+        {
+            object? connection = DataContext;
+            var args = new ConnectionEventArgs(connection)
+            {
+                RoutedEvent = DisconnectEvent,
+                Source = this
+            };
+
+            RaiseEvent(args);
+
+            // Raise DisconnectCommand if DisconnectEvent is not handled
+            if (!args.Handled && (DisconnectCommand?.CanExecute(null) ?? false))
+            {
+                DisconnectCommand.Execute(null);
             }
         }
 

--- a/Nodify/Connections/CircuitConnection.cs
+++ b/Nodify/Connections/CircuitConnection.cs
@@ -26,6 +26,7 @@ namespace Nodify
         static CircuitConnection()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(CircuitConnection), new FrameworkPropertyMetadata(typeof(CircuitConnection)));
+            NodifyEditor.CuttingConnectionTypes.Add(typeof(CircuitConnection));
         }
 
         protected override ((Point ArrowStartSource, Point ArrowStartTarget), (Point ArrowEndSource, Point ArrowEndTarget)) DrawLineGeometry(StreamGeometryContext context, Point source, Point target)

--- a/Nodify/Connections/Connection.cs
+++ b/Nodify/Connections/Connection.cs
@@ -13,6 +13,7 @@ namespace Nodify
         static Connection()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(Connection), new FrameworkPropertyMetadata(typeof(Connection)));
+            NodifyEditor.CuttingConnectionTypes.Add(typeof(Connection));
         }
 
         private const double _baseOffset = 100d;

--- a/Nodify/Connections/CuttingLine.cs
+++ b/Nodify/Connections/CuttingLine.cs
@@ -1,0 +1,79 @@
+﻿using System.Windows;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace Nodify
+{
+    public class CuttingLine : Shape
+    {
+        public static readonly DependencyProperty StartPointProperty = DependencyProperty.Register(nameof(StartPoint), typeof(Point), typeof(CuttingLine), new FrameworkPropertyMetadata(BoxValue.Point, FrameworkPropertyMetadataOptions.AffectsRender));
+        public static readonly DependencyProperty EndPointProperty = DependencyProperty.Register(nameof(EndPoint), typeof(Point), typeof(CuttingLine), new FrameworkPropertyMetadata(BoxValue.Point, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        /// <summary>
+        /// Will be set for <see cref="BaseConnection"/>s and custom connections when the cutting line intersects with them if <see cref="NodifyEditor.EnableCuttingLinePreview"/> is true.
+        /// </summary>
+        public static readonly DependencyProperty IsOverElementProperty = PendingConnection.IsOverElementProperty.AddOwner(typeof(CuttingLine));
+
+        public static bool GetIsOverElement(UIElement elem)
+            => (bool)elem.GetValue(IsOverElementProperty);
+
+        public static void SetIsOverElement(UIElement elem, bool value)
+            => elem.SetValue(IsOverElementProperty, value);
+
+        /// <summary>
+        /// Gets or sets whether cancelling a cutting operation is allowed.
+        /// </summary>
+        public static bool AllowCuttingCancellation { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the start point.
+        /// </summary>
+        public Point StartPoint
+        {
+            get => (Point)GetValue(StartPointProperty);
+            set => SetValue(StartPointProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the end point.
+        /// </summary>
+        public Point EndPoint
+        {
+            get => (Point)GetValue(EndPointProperty);
+            set => SetValue(EndPointProperty, value);
+        }
+
+        private readonly StreamGeometry _geometry = new StreamGeometry
+        {
+            FillRule = FillRule.EvenOdd
+        };
+
+        protected override Geometry DefiningGeometry
+        {
+            get
+            {
+                using (StreamGeometryContext context = _geometry.Open())
+                {
+                    context.BeginFigure(StartPoint, false, false);
+                    context.LineTo(EndPoint, true, true);
+                }
+
+                return _geometry;
+            }
+        }
+
+        static CuttingLine()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(CuttingLine), new FrameworkPropertyMetadata(typeof(CuttingLine)));
+            IsHitTestVisibleProperty.OverrideMetadata(typeof(CuttingLine), new FrameworkPropertyMetadata(BoxValue.False));
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            base.OnRender(drawingContext);
+
+            drawingContext.DrawEllipse(Fill, null, StartPoint, StrokeThickness * 1.2, StrokeThickness * 1.2);
+            drawingContext.DrawEllipse(Fill, null, EndPoint, StrokeThickness * 1.2, StrokeThickness * 1.2);
+        }
+    }
+}

--- a/Nodify/Connections/LineConnection.cs
+++ b/Nodify/Connections/LineConnection.cs
@@ -13,6 +13,7 @@ namespace Nodify
         static LineConnection()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(LineConnection), new FrameworkPropertyMetadata(typeof(LineConnection)));
+            NodifyEditor.CuttingConnectionTypes.Add(typeof(LineConnection));
         }
 
         protected override ((Point ArrowStartSource, Point ArrowStartTarget), (Point ArrowEndSource, Point ArrowEndTarget)) DrawLineGeometry(StreamGeometryContext context, Point source, Point target)

--- a/Nodify/Connections/StepConnection.cs
+++ b/Nodify/Connections/StepConnection.cs
@@ -31,6 +31,7 @@ namespace Nodify
             SourceOrientationProperty.OverrideMetadata(typeof(StepConnection), new FrameworkPropertyMetadata(Orientation.Horizontal, null, CoerceSourceOrientation));
             TargetOrientationProperty.OverrideMetadata(typeof(StepConnection), new FrameworkPropertyMetadata(Orientation.Horizontal, null, CoerceTargetOrientation));
             DirectionProperty.OverrideMetadata(typeof(StepConnection), new FrameworkPropertyMetadata(ConnectionDirection.Forward, null, CoerceConnectionDirection));
+            NodifyEditor.CuttingConnectionTypes.Add(typeof(StepConnection));
         }
 
         private static object CoerceSourceOrientation(DependencyObject d, object baseValue)

--- a/Nodify/EditorGestures.cs
+++ b/Nodify/EditorGestures.cs
@@ -110,16 +110,21 @@ namespace Nodify
             public NodifyEditorGestures()
             {
                 Selection = new SelectionGestures();
+                Cutting = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Alt | ModifierKeys.Shift);
                 Pan = new AnyGesture(new MouseGesture(MouseAction.RightClick), new MouseGesture(MouseAction.MiddleClick));
                 ZoomModifierKey = ModifierKeys.None;
                 ZoomIn = new MultiGesture(MultiGesture.Match.Any, new KeyGesture(Key.OemPlus, ModifierKeys.Control), new KeyGesture(Key.Add, ModifierKeys.Control));
                 ZoomOut = new MultiGesture(MultiGesture.Match.Any, new KeyGesture(Key.OemMinus, ModifierKeys.Control), new KeyGesture(Key.Subtract, ModifierKeys.Control));
                 ResetViewportLocation = new KeyGesture(Key.Home);
                 FitToScreen = new KeyGesture(Key.Home, ModifierKeys.Shift);
+                CancelAction = new AnyGesture(new MouseGesture(MouseAction.RightClick), new KeyGesture(Key.Escape));
             }
 
             /// <summary>Gesture used to start selecting using a <see cref="SelectionGestures"/> strategy.</summary>
             public SelectionGestures Selection { get; }
+
+            /// <summary>Gesture used to start cutting connections.</summary>
+            public InputGestureRef Cutting { get; }
 
             /// <summary>Gesture used to start panning.</summary>
             /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or <see cref="MouseAction.MiddleClick"/>.</remarks>
@@ -145,17 +150,23 @@ namespace Nodify
             /// <remarks>Defaults to <see cref="ModifierKeys.Shift"/>+<see cref="Key.Home"/>.</remarks>
             public InputGestureRef FitToScreen { get; }
 
+            /// <summary>Gesture to cancel the current operation.</summary>
+            /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or <see cref="Key.Escape"/>.</remarks>
+            public InputGestureRef CancelAction { get; }
+
             /// <summary>Copies from the specified gestures.</summary>
             /// <param name="gestures">The gestures to copy.</param>
             public void Apply(NodifyEditorGestures gestures)
             {
                 Selection.Apply(gestures.Selection);
+                Cutting.Value = gestures.Cutting.Value;
                 Pan.Value = gestures.Pan.Value;
                 ZoomModifierKey = gestures.ZoomModifierKey;
                 ZoomIn.Value = gestures.ZoomIn.Value;
                 ZoomOut.Value = gestures.ZoomOut.Value;
                 ResetViewportLocation.Value = gestures.ResetViewportLocation.Value;
                 FitToScreen.Value = gestures.FitToScreen.Value;
+                CancelAction.Value = gestures.CancelAction.Value;
             }
         }
 

--- a/Nodify/EditorStates/EditorCuttingState.cs
+++ b/Nodify/EditorStates/EditorCuttingState.cs
@@ -1,0 +1,101 @@
+﻿using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Nodify
+{
+    public class EditorCuttingState : EditorState
+    {
+        private readonly LineGeometry _lineGeometry = new LineGeometry();
+        private List<FrameworkElement>? _previousConnections;
+
+        public bool Canceled { get; set; } = CuttingLine.AllowCuttingCancellation;
+
+        public EditorCuttingState(NodifyEditor editor) : base(editor)
+        {
+        }
+
+        public override void Enter(EditorState? from)
+        {
+            Canceled = false;
+
+            var startLocation = Editor.MouseLocation;
+            Editor.StartCutting(startLocation);
+
+            _lineGeometry.StartPoint = startLocation;
+            _lineGeometry.EndPoint = startLocation;
+        }
+
+        public override void Exit()
+        {
+            ResetConnectionStyle();
+
+            // TODO: This is not canceled on LostMouseCapture (add OnLostMouseCapture/OnCancel callback?)
+            if (Canceled)
+            {
+                Editor.CancelCutting();
+            }
+            else
+            {
+                Editor.EndCutting(Editor.MouseLocation);
+            }
+        }
+
+        public override void HandleMouseUp(MouseButtonEventArgs e)
+        {
+            EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
+            if (gestures.Cutting.Matches(e.Source, e))
+            {
+                PopState();
+            }
+            else if (CuttingLine.AllowCuttingCancellation && gestures.CancelAction.Matches(e.Source, e))
+            {
+                Canceled = true;
+                e.Handled = true;   // prevents opening context menu
+
+                PopState();
+            }
+        }
+
+        public override void HandleMouseMove(MouseEventArgs e)
+        {
+            Editor.CuttingLineEnd = Editor.MouseLocation;
+
+            if (NodifyEditor.EnableCuttingLinePreview)
+            {
+                ResetConnectionStyle();
+
+                _lineGeometry.EndPoint = Editor.MouseLocation;
+                var connections = Editor.ConnectionsHost.GetIntersectingElements(_lineGeometry, NodifyEditor.CuttingConnectionTypes);
+                foreach (var connection in connections)
+                {
+                    CuttingLine.SetIsOverElement(connection, true);
+                }
+
+                _previousConnections = connections;
+            }
+        }
+
+        private void ResetConnectionStyle()
+        {
+            if (_previousConnections != null)
+            {
+                foreach (var connection in _previousConnections)
+                {
+                    CuttingLine.SetIsOverElement(connection, false);
+                }
+            }
+        }
+
+        public override void HandleKeyUp(KeyEventArgs e)
+        {
+            EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
+            if (CuttingLine.AllowCuttingCancellation && gestures.CancelAction.Matches(e.Source, e))
+            {
+                Canceled = true;
+                PopState();
+            }
+        }
+    }
+}

--- a/Nodify/EditorStates/EditorDefaultState.cs
+++ b/Nodify/EditorStates/EditorDefaultState.cs
@@ -31,7 +31,11 @@ namespace Nodify
         public override void HandleMouseDown(MouseButtonEventArgs e)
         {
             EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
-            if (gestures.Selection.Select.Matches(e.Source, e))
+            if (gestures.Cutting.Matches(e.Source, e))
+            {
+                PushState(new EditorCuttingState(Editor));
+            }
+            else if (gestures.Selection.Select.Matches(e.Source, e))
             {
                 SelectionType selectionType = GetSelectionType(e);
                 var selecting = new EditorSelectingState(Editor, selectionType);

--- a/Nodify/Helpers/DependencyObjectExtensions.cs
+++ b/Nodify/Helpers/DependencyObjectExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -65,6 +67,31 @@ namespace Nodify
             }
 
             return false;
+        }
+
+        public static List<FrameworkElement> GetIntersectingElements(this UIElement container, Geometry geometry, IReadOnlyCollection<Type> supportedTypes)
+        {
+            var result = new List<FrameworkElement>();
+            VisualTreeHelper.HitTest(container, depObj =>
+            {
+                if (depObj is FrameworkElement elem && elem.IsHitTestVisible)
+                {
+                    if (supportedTypes.Contains(elem.GetType()))
+                    {
+                        return HitTestFilterBehavior.ContinueSkipChildren;
+                    }
+
+                    return HitTestFilterBehavior.ContinueSkipSelf;
+                }
+
+                return HitTestFilterBehavior.ContinueSkipSelfAndChildren;
+            }, hitResult =>
+            {
+                result.Add((FrameworkElement)hitResult.VisualHit);
+                return HitTestResultBehavior.Continue;
+            }, new GeometryHitTestParameters(geometry));
+
+            return result;
         }
 
         #region Animation

--- a/Nodify/Helpers/UnscaleTransformConverter.cs
+++ b/Nodify/Helpers/UnscaleTransformConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
 
@@ -19,11 +20,25 @@ namespace Nodify
         }
     }
 
-    internal class UnscaleDoubleConverter : IMultiValueConverter
+    internal class ScaleDoubleConverter : IMultiValueConverter
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             double result = (double)values[0] * (double)values[1];
+            return result;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    internal class ScalePointConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            Point result = (Point)((Vector)(Point)values[0] * (double)values[1]);
             return result;
         }
 

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -18,14 +18,17 @@ namespace Nodify
     /// Groups <see cref="ItemContainer"/>s and <see cref="Connection"/>s in an area that you can drag, zoom and select.
     /// </summary>
     [TemplatePart(Name = ElementItemsHost, Type = typeof(Panel))]
+    [TemplatePart(Name = ElementConnectionsHost, Type = typeof(FrameworkElement))]
     [StyleTypedProperty(Property = nameof(ItemContainerStyle), StyleTargetType = typeof(ItemContainer))]
     [StyleTypedProperty(Property = nameof(DecoratorContainerStyle), StyleTargetType = typeof(DecoratorContainer))]
     [StyleTypedProperty(Property = nameof(SelectionRectangleStyle), StyleTargetType = typeof(Rectangle))]
+    [StyleTypedProperty(Property = nameof(CuttingLineStyle), StyleTargetType = typeof(CuttingLine))]
     [ContentProperty(nameof(Decorators))]
     [DefaultProperty(nameof(Decorators))]
     public class NodifyEditor : MultiSelector
     {
         protected const string ElementItemsHost = "PART_ItemsHost";
+        protected const string ElementConnectionsHost = "PART_ConnectionsHost";
 
         #region Viewport
 
@@ -242,6 +245,7 @@ namespace Nodify
         public static readonly DependencyProperty DecoratorTemplateProperty = DependencyProperty.Register(nameof(DecoratorTemplate), typeof(DataTemplate), typeof(NodifyEditor));
         public static readonly DependencyProperty PendingConnectionTemplateProperty = DependencyProperty.Register(nameof(PendingConnectionTemplate), typeof(DataTemplate), typeof(NodifyEditor));
         public static readonly DependencyProperty SelectionRectangleStyleProperty = DependencyProperty.Register(nameof(SelectionRectangleStyle), typeof(Style), typeof(NodifyEditor));
+        public static readonly DependencyProperty CuttingLineStyleProperty = DependencyProperty.Register(nameof(CuttingLineStyle), typeof(Style), typeof(NodifyEditor));
         public static readonly DependencyProperty DecoratorContainerStyleProperty = DependencyProperty.Register(nameof(DecoratorContainerStyle), typeof(Style), typeof(NodifyEditor));
 
         private static void OnDisableAutoPanningChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -339,6 +343,15 @@ namespace Nodify
         }
 
         /// <summary>
+        /// Gets or sets the style to use for the cutting line.
+        /// </summary>
+        public Style CuttingLineStyle
+        {
+            get => (Style)GetValue(CuttingLineStyleProperty);
+            set => SetValue(CuttingLineStyleProperty, value);
+        }
+
+        /// <summary>
         /// Gets or sets the style to use for the <see cref="DecoratorContainer"/>.
         /// </summary>
         public Style DecoratorContainerStyle
@@ -357,6 +370,15 @@ namespace Nodify
         protected static readonly DependencyPropertyKey IsSelectingPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsSelecting), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False, OnIsSelectingChanged));
         public static readonly DependencyProperty IsSelectingProperty = IsSelectingPropertyKey.DependencyProperty;
 
+        protected static readonly DependencyPropertyKey CuttingLineStartPropertyKey = DependencyProperty.RegisterReadOnly(nameof(CuttingLineStart), typeof(Point), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Point));
+        public static readonly DependencyProperty CuttingLineStartProperty = CuttingLineStartPropertyKey.DependencyProperty;
+
+        protected static readonly DependencyPropertyKey CuttingLineEndPropertyKey = DependencyProperty.RegisterReadOnly(nameof(CuttingLineEnd), typeof(Point), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Point));
+        public static readonly DependencyProperty CuttingLineEndProperty = CuttingLineEndPropertyKey.DependencyProperty;
+
+        protected static readonly DependencyPropertyKey IsCuttingPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsCutting), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False, OnIsCuttingChanged));
+        public static readonly DependencyProperty IsCuttingProperty = IsCuttingPropertyKey.DependencyProperty;
+
         public static readonly DependencyPropertyKey IsPanningPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsPanning), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False));
         public static readonly DependencyProperty IsPanningProperty = IsPanningPropertyKey.DependencyProperty;
 
@@ -369,10 +391,10 @@ namespace Nodify
             if ((bool)e.NewValue == true)
                 editor.OnItemsSelectStarted();
             else
-                editor.OnItemSelectCompleted();
+                editor.OnItemsSelectCompleted();
         }
 
-        private void OnItemSelectCompleted()
+        private void OnItemsSelectCompleted()
         {
             if (ItemsSelectCompletedCommand?.CanExecute(DataContext) ?? false)
                 ItemsSelectCompletedCommand.Execute(DataContext);
@@ -382,6 +404,27 @@ namespace Nodify
         {
             if (ItemsSelectStartedCommand?.CanExecute(DataContext) ?? false)
                 ItemsSelectStartedCommand.Execute(DataContext);
+        }
+
+        private static void OnIsCuttingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var editor = (NodifyEditor)d;
+            if ((bool)e.NewValue == true)
+                editor.OnCuttingStarted();
+            else
+                editor.OnCuttingCompleted();
+        }
+
+        private void OnCuttingCompleted()
+        {
+            if (CuttingCompletedCommand?.CanExecute(DataContext) ?? false)
+                CuttingCompletedCommand.Execute(DataContext);
+        }
+
+        private void OnCuttingStarted()
+        {
+            if (CuttingStartedCommand?.CanExecute(DataContext) ?? false)
+                CuttingStartedCommand.Execute(DataContext);
         }
 
         /// <summary>
@@ -400,6 +443,33 @@ namespace Nodify
         {
             get => (bool)GetValue(IsSelectingProperty);
             internal set => SetValue(IsSelectingPropertyKey, value);
+        }
+
+        /// <summary>
+        /// Gets the start point of the <see cref="CuttingLine"/> while <see cref="IsCutting"/> is true.
+        /// </summary>
+        public Point CuttingLineStart
+        {
+            get => (Point)GetValue(CuttingLineStartProperty);
+            private set => SetValue(CuttingLineStartPropertyKey, value);
+        }
+
+        /// <summary>
+        /// Gets the end point of the <see cref="CuttingLine"/> while <see cref="IsCutting"/> is true.
+        /// </summary>
+        public Point CuttingLineEnd
+        {
+            get => (Point)GetValue(CuttingLineEndProperty);
+            protected internal set => SetValue(CuttingLineEndPropertyKey, value);
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether a cutting operation is in progress.
+        /// </summary>
+        public bool IsCutting
+        {
+            get => (bool)GetValue(IsCuttingProperty);
+            private set => SetValue(IsCuttingPropertyKey, value);
         }
 
         /// <summary>
@@ -532,6 +602,8 @@ namespace Nodify
         public static readonly DependencyProperty ItemsDragCompletedCommandProperty = DependencyProperty.Register(nameof(ItemsDragCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
         public static readonly DependencyProperty ItemsSelectStartedCommandProperty = DependencyProperty.Register(nameof(ItemsSelectStartedCommand), typeof(ICommand), typeof(NodifyEditor));
         public static readonly DependencyProperty ItemsSelectCompletedCommandProperty = DependencyProperty.Register(nameof(ItemsSelectCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
+        public static readonly DependencyProperty CuttingStartedCommandProperty = DependencyProperty.Register(nameof(CuttingStartedCommand), typeof(ICommand), typeof(NodifyEditor));
+        public static readonly DependencyProperty CuttingCompletedCommandProperty = DependencyProperty.Register(nameof(CuttingCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
 
         /// <summary>
         /// Invoked when the <see cref="Nodify.PendingConnection"/> is completed. <br />
@@ -609,6 +681,20 @@ namespace Nodify
             set => SetValue(ItemsSelectCompletedCommandProperty, value);
         }
 
+        /// <summary>Invoked when a cutting operation is started.</summary>
+        public ICommand? CuttingStartedCommand
+        {
+            get => (ICommand?)GetValue(CuttingStartedCommandProperty);
+            set => SetValue(CuttingStartedCommandProperty, value);
+        }
+
+        /// <summary>Invoked when a cutting operation is completed.</summary>
+        public ICommand? CuttingCompletedCommand
+        {
+            get => (ICommand?)GetValue(CuttingCompletedCommandProperty);
+            set => SetValue(CuttingCompletedCommandProperty, value);
+        }
+
         #endregion
 
         #region Fields
@@ -656,6 +742,19 @@ namespace Nodify
         public static bool EnableDraggingContainersOptimizations { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets whether the cutting line should apply the preview style to the interesected elements.
+        /// </summary>
+        /// <remarks>
+        /// This may hurt performance because intersection must be calculated on mouse move.
+        /// </remarks>
+        public static bool EnableCuttingLinePreview { get; set; } = false;
+
+        /// <summary>
+        /// The list of supported connection types for cutting. Type must be derived from <see cref="FrameworkElement">.
+        /// </summary>
+        public static readonly HashSet<Type> CuttingConnectionTypes = new HashSet<Type>();
+
+        /// <summary>
         /// Tells if the <see cref="NodifyEditor"/> is doing operations on multiple items at once.
         /// </summary>
         public bool IsBulkUpdatingItems { get; protected set; }
@@ -664,6 +763,11 @@ namespace Nodify
         /// Gets the panel that holds all the <see cref="ItemContainer"/>s.
         /// </summary>
         protected internal Panel ItemsHost { get; private set; } = default!;
+
+        /// <summary>
+        /// Gets the element that holds all the <see cref="BaseConnection"/>s and custom connections.
+        /// </summary>
+        protected internal UIElement ConnectionsHost { get; private set; } = default!;
 
         private IDraggingStrategy? _draggingStrategy;
         private DispatcherTimer? _autoPanningTimer;
@@ -732,7 +836,8 @@ namespace Nodify
         {
             base.OnApplyTemplate();
 
-            ItemsHost = GetTemplateChild(ElementItemsHost) as Panel ?? throw new InvalidOperationException("PART_ItemsHost is missing or is not of type Panel.");
+            ItemsHost = GetTemplateChild(ElementItemsHost) as Panel ?? throw new InvalidOperationException($"{ElementItemsHost} is missing or is not of type Panel.");
+            ConnectionsHost = GetTemplateChild(ElementConnectionsHost) as UIElement ?? throw new InvalidOperationException($"{ElementConnectionsHost} is missing or is not of type UIElement.");
 
             OnDisableAutoPanningChanged(DisableAutoPanning);
 
@@ -956,9 +1061,14 @@ namespace Nodify
 
         private void OnRemoveConnection(object sender, ConnectionEventArgs e)
         {
-            if (RemoveConnectionCommand?.CanExecute(e.Connection) ?? false)
+            OnRemoveConnection(e.Connection);
+        }
+        
+        protected void OnRemoveConnection(object? dataContext)
+        {
+            if (RemoveConnectionCommand?.CanExecute(dataContext) ?? false)
             {
-                RemoveConnectionCommand.Execute(e.Connection);
+                RemoveConnectionCommand.Execute(dataContext);
             }
         }
 
@@ -1351,6 +1461,77 @@ namespace Nodify
 
                 e.Handled = true;
             }
+        }
+
+        #endregion
+
+        #region Cutting
+
+        /// <summary>
+        /// Starts the cutting operation at the specified location. Call <see cref="EndCutting"/> to finish cutting.
+        /// </summary>
+        protected internal void StartCutting(Point location)
+        {
+            CuttingLineStart = location;
+            CuttingLineEnd = location;
+            IsCutting = true;
+
+            if (CuttingStartedCommand?.CanExecute(DataContext) ?? false)
+            {
+                CuttingStartedCommand.Execute(DataContext);
+            }
+        }
+
+        /// <summary>
+        /// Cancels the cutting operation.
+        /// </summary>
+        protected internal void CancelCutting()
+        {
+            if (IsCutting)
+            {
+                IsCutting = false;
+
+                if (CuttingCompletedCommand?.CanExecute(DataContext) ?? false)
+                {
+                    CuttingCompletedCommand.Execute(DataContext);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Ends the cutting operation at the specified location.
+        /// </summary>
+        protected internal void EndCutting(Point location)
+        {
+            CuttingLineEnd = location;
+
+            var lineGeometry = new LineGeometry(CuttingLineStart, CuttingLineEnd);
+            var connections = ConnectionsHost.GetIntersectingElements(lineGeometry, CuttingConnectionTypes);
+
+            if (RemoveConnectionCommand != null)
+            {
+                foreach (var connection in connections)
+                {
+                    OnRemoveConnection(connection.DataContext);
+                }
+            }
+            else
+            {
+                foreach (var connection in connections)
+                {
+                    if (connection is BaseConnection bc)
+                    {
+                        bc.OnDisconnect();
+                    }
+                }
+            }
+
+            if (CuttingCompletedCommand?.CanExecute(DataContext) ?? false)
+            {
+                CuttingCompletedCommand.Execute(DataContext);
+            }
+
+            IsCutting = false;
         }
 
         #endregion

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -1475,11 +1475,6 @@ namespace Nodify
             CuttingLineStart = location;
             CuttingLineEnd = location;
             IsCutting = true;
-
-            if (CuttingStartedCommand?.CanExecute(DataContext) ?? false)
-            {
-                CuttingStartedCommand.Execute(DataContext);
-            }
         }
 
         /// <summary>
@@ -1490,11 +1485,6 @@ namespace Nodify
             if (IsCutting)
             {
                 IsCutting = false;
-
-                if (CuttingCompletedCommand?.CanExecute(DataContext) ?? false)
-                {
-                    CuttingCompletedCommand.Execute(DataContext);
-                }
             }
         }
 
@@ -1524,11 +1514,6 @@ namespace Nodify
                         bc.OnDisconnect();
                     }
                 }
-            }
-
-            if (CuttingCompletedCommand?.CanExecute(DataContext) ?? false)
-            {
-                CuttingCompletedCommand.Execute(DataContext);
             }
 
             IsCutting = false;

--- a/Nodify/Themes/Brushes.xaml
+++ b/Nodify/Themes/Brushes.xaml
@@ -21,6 +21,14 @@
                      Opacity="0.1"
                      Color="{DynamicResource NodifyEditor.SelectionRectangleColor}" />
 
+    <SolidColorBrush x:Key="NodifyEditor.CuttingLineStrokeBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource NodifyEditor.CuttingLineColor}" />
+
+    <SolidColorBrush x:Key="NodifyEditor.CuttingLineBackgroundBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource NodifyEditor.CuttingLineColor}" />
+
     <!--ITEM CONTAINER-->
 
     <SolidColorBrush x:Key="ItemContainer.BorderBrush"

--- a/Nodify/Themes/Controls.xaml
+++ b/Nodify/Themes/Controls.xaml
@@ -200,6 +200,16 @@
                 Value="{StaticResource PendingConnection.BackgroundBrush}" />
     </Style>
 
+    <!--CUTTING LINE-->
+
+    <Style TargetType="{x:Type local:CuttingLine}"
+           BasedOn="{StaticResource {x:Type local:CuttingLine}}">
+        <Setter Property="Fill"
+                Value="{StaticResource NodifyEditor.CuttingLineBackgroundBrush}" />
+        <Setter Property="Stroke"
+                Value="{StaticResource NodifyEditor.CuttingLineStrokeBrush}" />
+    </Style>
+
     <!--MINIMAP-->
 
     <Style x:Key="Minimap.ViewportStyle"
@@ -222,8 +232,8 @@
            BasedOn="{StaticResource {x:Type local:Minimap}}">
         <Setter Property="Background"
                 Value="{StaticResource Minimap.BackgroundBrush}" />
-        <Setter Property="ViewportStyle" 
-                Value="{StaticResource Minimap.ViewportStyle}"/>
+        <Setter Property="ViewportStyle"
+                Value="{StaticResource Minimap.ViewportStyle}" />
     </Style>
 
     <Style TargetType="{x:Type local:MinimapItem}"

--- a/Nodify/Themes/Dark.xaml
+++ b/Nodify/Themes/Dark.xaml
@@ -10,6 +10,7 @@
     <Color x:Key="NodifyEditor.BackgroundColor">#1E1E1E</Color>
     <Color x:Key="NodifyEditor.ForegroundColor">White</Color>
     <Color x:Key="NodifyEditor.SelectionRectangleColor">DodgerBlue</Color>
+    <Color x:Key="NodifyEditor.CuttingLineColor">Red</Color>
 
     <!--ITEM CONTAINER-->
 

--- a/Nodify/Themes/Light.xaml
+++ b/Nodify/Themes/Light.xaml
@@ -10,6 +10,7 @@
     <Color x:Key="NodifyEditor.BackgroundColor">White</Color>
     <Color x:Key="NodifyEditor.ForegroundColor">Black</Color>
     <Color x:Key="NodifyEditor.SelectionRectangleColor">DodgerBlue</Color>
+    <Color x:Key="NodifyEditor.CuttingLineColor">Red</Color>
 
     <!--ITEM CONTAINER-->
 

--- a/Nodify/Themes/Nodify.xaml
+++ b/Nodify/Themes/Nodify.xaml
@@ -10,6 +10,7 @@
     <Color x:Key="NodifyEditor.BackgroundColor">#332155</Color>
     <Color x:Key="NodifyEditor.ForegroundColor">#E8E1F3</Color>
     <Color x:Key="NodifyEditor.SelectionRectangleColor">#FD5618</Color>
+    <Color x:Key="NodifyEditor.CuttingLineColor">Red</Color>
 
     <!--ITEM CONTAINER-->
 

--- a/Nodify/Themes/Styles/Connection.xaml
+++ b/Nodify/Themes/Styles/Connection.xaml
@@ -2,7 +2,17 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:Nodify">
 
-    <Style TargetType="{x:Type local:Connection}">
+    <Style TargetType="{x:Type local:BaseConnection}">
+        <Style.Triggers>
+            <Trigger Property="local:CuttingLine.IsOverElement" Value="True">
+                <Setter Property="Opacity"
+                        Value="0.4" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="{x:Type local:Connection}"
+           BasedOn="{StaticResource {x:Type local:BaseConnection}}">
         <Setter Property="StrokeThickness"
                 Value="3" />
         <Setter Property="Stroke"
@@ -13,7 +23,8 @@
                 Value="20" />
     </Style>
 
-    <Style TargetType="{x:Type local:LineConnection}">
+    <Style TargetType="{x:Type local:LineConnection}"
+           BasedOn="{StaticResource {x:Type local:BaseConnection}}">
         <Setter Property="StrokeThickness"
                 Value="3" />
         <Setter Property="Stroke"
@@ -24,7 +35,8 @@
                 Value="30" />
     </Style>
 
-    <Style TargetType="{x:Type local:CircuitConnection}">
+    <Style TargetType="{x:Type local:CircuitConnection}"
+           BasedOn="{StaticResource {x:Type local:BaseConnection}}">
         <Setter Property="StrokeThickness"
                 Value="3" />
         <Setter Property="Stroke"
@@ -35,7 +47,8 @@
                 Value="30" />
     </Style>
 
-    <Style TargetType="{x:Type local:StepConnection}">
+    <Style TargetType="{x:Type local:StepConnection}"
+           BasedOn="{StaticResource {x:Type local:BaseConnection}}">
         <Setter Property="StrokeThickness"
                 Value="3" />
         <Setter Property="Stroke"

--- a/Nodify/Themes/Styles/Controls.xaml
+++ b/Nodify/Themes/Styles/Controls.xaml
@@ -10,6 +10,7 @@
         <ResourceDictionary Source="NodeOutput.xaml" />
         <ResourceDictionary Source="Connection.xaml" />
         <ResourceDictionary Source="PendingConnection.xaml" />
+        <ResourceDictionary Source="CuttingLine.xaml" />
 
         <!--CORE-->
         <ResourceDictionary Source="ItemContainer.xaml" />

--- a/Nodify/Themes/Styles/CuttingLine.xaml
+++ b/Nodify/Themes/Styles/CuttingLine.xaml
@@ -1,0 +1,16 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:Nodify">
+
+    <Style TargetType="{x:Type local:CuttingLine}">
+        <Setter Property="StrokeThickness"
+                Value="3" />
+        <Setter Property="StrokeDashArray"
+                Value="2 1" />
+        <Setter Property="Stroke"
+                Value="Red" />
+        <Setter Property="Fill"
+                Value="Red" />
+    </Style>
+    
+</ResourceDictionary>

--- a/Nodify/Themes/Styles/NodifyEditor.xaml
+++ b/Nodify/Themes/Styles/NodifyEditor.xaml
@@ -4,7 +4,8 @@
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <local:UnscaleTransformConverter x:Key="UnscaleTransformConverter" />
-    <local:UnscaleDoubleConverter x:Key="UnscaleDoubleConverter" />
+    <local:ScaleDoubleConverter x:Key="ScaleDoubleConverter" />
+    <local:ScalePointConverter x:Key="ScalePointConverter" />
 
     <DataTemplate x:Key="ConnectionTemplate">
         <local:Connection Style="{DynamicResource {x:Type local:Connection}}" />
@@ -58,9 +59,10 @@
                                                 IsItemsHost="True"
                                                 Extent="{Binding ItemsExtent, Mode=OneWayToSource, RelativeSource={RelativeSource TemplatedParent}}" />
 
-                            <ItemsControl ItemsSource="{TemplateBinding Connections}"
-                                          ItemTemplate="{TemplateBinding ConnectionTemplate}"
-                                          IsTabStop="False">
+                            <ItemsControl  x:Name="PART_ConnectionsHost"
+                                           ItemsSource="{TemplateBinding Connections}"
+                                           ItemTemplate="{TemplateBinding ConnectionTemplate}"
+                                           IsTabStop="False">
                                 <ItemsControl.Style>
                                     <Style TargetType="ItemsControl">
                                         <Setter Property="Panel.ZIndex"
@@ -89,18 +91,43 @@
                                        Canvas.Left="{Binding SelectedArea.X, RelativeSource={RelativeSource TemplatedParent}}"
                                        Visibility="{TemplateBinding IsSelecting, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Rectangle.Width>
-                                    <MultiBinding Converter="{StaticResource UnscaleDoubleConverter}">
-                                        <Binding Path="SelectedArea.Width" RelativeSource="{RelativeSource TemplatedParent}" />
-                                        <Binding Path="ViewportZoom" RelativeSource="{RelativeSource TemplatedParent}" />
+                                    <MultiBinding Converter="{StaticResource ScaleDoubleConverter}">
+                                        <Binding Path="SelectedArea.Width"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Path="ViewportZoom"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
                                     </MultiBinding>
                                 </Rectangle.Width>
                                 <Rectangle.Height>
-                                    <MultiBinding Converter="{StaticResource UnscaleDoubleConverter}">
-                                        <Binding Path="SelectedArea.Height" RelativeSource="{RelativeSource TemplatedParent}" />
-                                        <Binding Path="ViewportZoom" RelativeSource="{RelativeSource TemplatedParent}" />
+                                    <MultiBinding Converter="{StaticResource ScaleDoubleConverter}">
+                                        <Binding Path="SelectedArea.Height"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Path="ViewportZoom"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
                                     </MultiBinding>
                                 </Rectangle.Height>
                             </Rectangle>
+
+                            <local:CuttingLine Style="{TemplateBinding CuttingLineStyle}"
+                                               Visibility="{TemplateBinding IsCutting, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                               RenderTransform="{Binding ViewportTransform, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource UnscaleTransformConverter}}">
+                                <local:CuttingLine.StartPoint>
+                                    <MultiBinding Converter="{StaticResource ScalePointConverter}">
+                                        <Binding Path="CuttingLineStart"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Path="ViewportZoom"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                    </MultiBinding>
+                                </local:CuttingLine.StartPoint>
+                                <local:CuttingLine.EndPoint>
+                                    <MultiBinding Converter="{StaticResource ScalePointConverter}">
+                                        <Binding Path="CuttingLineEnd"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Path="ViewportZoom"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                    </MultiBinding>
+                                </local:CuttingLine.EndPoint>
+                            </local:CuttingLine>
 
                             <local:DecoratorsControl ItemsSource="{TemplateBinding Decorators}"
                                                      ItemContainerStyle="{TemplateBinding DecoratorContainerStyle}"
@@ -108,7 +135,7 @@
                                                      IsTabStop="False">
                                 <local:DecoratorsControl.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <local:NodifyCanvas Extent="{Binding DecoratorsExtent, Mode=OneWayToSource, RelativeSource={RelativeSource AncestorType=local:NodifyEditor}}"/>
+                                        <local:NodifyCanvas Extent="{Binding DecoratorsExtent, Mode=OneWayToSource, RelativeSource={RelativeSource AncestorType=local:NodifyEditor}}" />
                                     </ItemsPanelTemplate>
                                 </local:DecoratorsControl.ItemsPanel>
                             </local:DecoratorsControl>

--- a/docs/CuttingLine-Overview.md
+++ b/docs/CuttingLine-Overview.md
@@ -1,0 +1,63 @@
+## Table of contents
+
+- [Enabling preview](#enabling-preview)
+- [Custom connections](#custom-connections)
+- [Customization](#customization)
+
+The `CuttingLine` control is a custom control used to remove intersecting connections.
+
+The default gesture to start cutting is `SHIFT+ALT+LeftClick` and can be configured by setting the `EditorGestures.Editor.Cutting` gesture. The cutting can be canceled by pressing the `Escape` key or the right mouse button which can be configured by setting the `EditorGestures.Editor.CancelAction` gesture.
+
+Relevant commands available in `NodifyEditor`:
+
+- CuttingStartedCommand
+- CuttingCompletedCommand
+- RemoveConnectionCommand - is called for each intersecting connection when the cutting operation is completed
+
+## Enabling preview
+
+For the connection style to change when intersecting with the cutting line, it's required to set `NodifyEditor.EnableCuttingLinePreview` to `true`.
+
+> [!WARNING]
+> Depending on the number of connections and the complexity of their geometry, this may have a great performance impact.
+
+![cutting](https://github.com/user-attachments/assets/22f705c8-3bf1-466b-8bbd-da007f30deb2)
+
+## Custom connections
+
+To enable cutting custom connections you must add the connection type to `NodifyEditor.CuttingConnectionTypes`:
+
+```csharp
+// example adding the Line shape to the connection types that can be cut
+NodifyEditor.CuttingConnectionTypes.Add(typeof(System.Windows.Shapes.Line));
+```
+
+The style of the intersecting custom connection can be customized as follows:
+
+```xml
+<Style TargetType="Line">
+    <Style.Triggers>
+        <Trigger Property="nodify:CuttingLine.IsOverElement" Value="True">
+            <Setter Property="Opacity"
+                    Value="0.4" />
+        </Trigger>
+    </Style.Triggers>
+</Style>
+```
+
+## Customization
+
+The `CuttingLineStyle` is used to customize the cutting line:
+
+```xml
+<Style x:Key="CuttingLineStyle"
+       TargetType="{x:Type nodify:CuttingLine}"
+       BasedOn="{StaticResource {x:Type nodify:CuttingLine}}">
+    <Setter Property="StrokeDashArray"
+            Value="1 1" />
+    <Setter Property="StrokeThickness"
+            Value="2" />
+</Style>
+
+<nodify:NodifyEditor CuttingLineStyle="{StaticResource CuttingLineStyle}" ... />
+```

--- a/docs/Minimap-Overview.md
+++ b/docs/Minimap-Overview.md
@@ -58,7 +58,7 @@ The `ViewportStyle` is used to customize the viewport rectangle.
     <Setter Property="StrokeThickness" Value="3"/>
 </Style>
 
-<local:Minimap ViewportStyle="{StaticResource MyViewportStyle}" ... />
+<nodify:Minimap ViewportStyle="{StaticResource MyViewportStyle}" ... />
 ```
 
 The `MaxViewportOffset` property is used to restrict how far the viewport can be moved away from the items when [panning](#panning).

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -47,6 +47,12 @@
 
 - [NodeInput and NodeOutput](Connectors-Overview#nodeinput-and-nodeoutput)
 
+[CuttingLine overview](CuttingLine-Overview)
+
+- [Enabling preview](CuttingLine-Overview#enabling-preview)
+- [Custom connections](CuttingLine-Overview#custom-connections)
+- [Customization](CuttingLine-Overview#customization)
+
 [Minimap overview](Minimap-Overview)
 
 - [Moving the viewport](Minimap-Overview#panning)


### PR DESCRIPTION
### 📝 Description of the Change

This PR adds a `CuttingLine` control to Nodify that removes intersecting connections. The default gesture to start cutting is `SHIFT+ALT+LeftClick`.

Please note that for the connection style to change when intersecting, it's required to set `NodifyEditor.EnableCuttingLinePreview` to `true`. However, this has a great performance impact when many connections are created.

To enable cutting custom connections you must add the connection type to `NodifyEditor.CuttingConnectionTypes`:

```csharp
// example adding the Line shape to the connection types that can be cut
NodifyEditor.CuttingConnectionTypes.Add(typeof(System.Windows.Shapes.Line));
```

![cutting](https://github.com/user-attachments/assets/22f705c8-3bf1-466b-8bbd-da007f30deb2)


