### PR TITLE
Add OutlineBrush and OutlineThickness to BaseConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 > - Breaking Changes:
 > - Features:
+>	- Added OutlineBrush and OutlineThickness dependency properties to BaseConnection to support increasing the selection area without increasing the stroke thickness
 > - Bugfixes:
 
 #### **Version 6.3.0**

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -43,45 +43,76 @@
                       Transform="{Binding ViewportTransform, ElementName=Editor}"
                       Drawing="{StaticResource LargeGridGeometry}" />
 
-        <SolidColorBrush x:Key="SquareConnectorColor" Color="MediumSlateBlue" />
-        <SolidColorBrush x:Key="TriangleConnectorColor" Color="MediumVioletRed" />
+        <SolidColorBrush x:Key="SquareConnectorColor"
+                         Color="MediumSlateBlue" />
+        <SolidColorBrush x:Key="TriangleConnectorColor"
+                         Color="MediumVioletRed" />
+        <SolidColorBrush x:Key="SquareConnectorOutline"
+                         Color="MediumSlateBlue"
+                         Opacity="0.15" />
+        <SolidColorBrush x:Key="TriangleConnectorOutline"
+                         Color="MediumVioletRed"
+                         Opacity="0.15" />
 
-        <UIElement x:Key="ConnectionAnimationPlaceholder" Opacity="1" />
+        <UIElement x:Key="ConnectionAnimationPlaceholder"
+                   Opacity="1" />
 
         <Storyboard x:Key="HighlightConnection">
-            <DoubleAnimation Storyboard.TargetProperty="StrokeThickness" 
-                             Duration="0:0:0.3" From="3" To="6"  />
             <DoubleAnimation Storyboard.Target="{StaticResource ConnectionAnimationPlaceholder}"
-                             Storyboard.TargetProperty="(UIElement.Opacity)" 
-                             Duration="0:0:0.3" From="1" To="0.3"  />
+                             Storyboard.TargetProperty="(UIElement.Opacity)"
+                             Duration="0:0:0.3"
+                             From="1"
+                             To="0.3" />
         </Storyboard>
 
         <Style x:Key="ConnectionStyle" TargetType="{x:Type nodify:BaseConnection}"
                BasedOn="{StaticResource {x:Type nodify:BaseConnection}}">
             <Style.Triggers>
-                <DataTrigger Binding="{Binding Input.Shape}" 
+                <DataTrigger Binding="{Binding Input.Shape}"
                              Value="{x:Static local:ConnectorShape.Square}">
-                    <Setter Property="Stroke" Value="{StaticResource SquareConnectorColor}"/>
-                    <Setter Property="Fill" Value="{StaticResource SquareConnectorColor}"/>
+                    <Setter Property="Stroke"
+                            Value="{StaticResource SquareConnectorColor}" />
+                    <Setter Property="Fill"
+                            Value="{StaticResource SquareConnectorColor}" />
+                    <Setter Property="OutlineBrush"
+                            Value="{StaticResource SquareConnectorOutline}" />
                 </DataTrigger>
-                <DataTrigger Binding="{Binding Input.Shape}" 
+                <DataTrigger Binding="{Binding Input.Shape}"
                              Value="{x:Static local:ConnectorShape.Triangle}">
-                    <Setter Property="Stroke" Value="{StaticResource TriangleConnectorColor}"/>
-                    <Setter Property="Fill" Value="{StaticResource TriangleConnectorColor}"/>
+                    <Setter Property="Stroke"
+                            Value="{StaticResource TriangleConnectorColor}" />
+                    <Setter Property="Fill"
+                            Value="{StaticResource TriangleConnectorColor}" />
+                    <Setter Property="OutlineBrush"
+                            Value="{StaticResource TriangleConnectorOutline}" />
                 </DataTrigger>
-                <Trigger Property="IsMouseDirectlyOver" Value="True">
+                <Trigger Property="IsMouseDirectlyOver"
+                         Value="True">
                     <Trigger.EnterActions>
-                        <BeginStoryboard Name="HighlightConnection" Storyboard="{StaticResource HighlightConnection}" />
+                        <BeginStoryboard Name="HighlightConnection"
+                                         Storyboard="{StaticResource HighlightConnection}" />
                     </Trigger.EnterActions>
                     <Trigger.ExitActions>
                         <RemoveStoryboard BeginStoryboardName="HighlightConnection" />
                     </Trigger.ExitActions>
-                    <Setter Property="Opacity" Value="1" />
+                    <Setter Property="Opacity"
+                            Value="1" />
+                </Trigger>
+                <Trigger Property="IsMouseDirectlyOver"
+                         Value="False">
+                    <Setter Property="OutlineBrush"
+                            Value="Transparent" />
                 </Trigger>
             </Style.Triggers>
             <Setter Property="Opacity" Value="{Binding Source={StaticResource ConnectionAnimationPlaceholder}, Path=Opacity}" />
             <Setter Property="Stroke" Value="{DynamicResource Connection.StrokeBrush}"/>
             <Setter Property="Fill" Value="{DynamicResource Connection.StrokeBrush}"/>
+            <Setter Property="OutlineBrush">
+                <Setter.Value>
+                    <SolidColorBrush Color="{DynamicResource Connection.StrokeColor}"
+                                     Opacity="0.15" />
+                </Setter.Value>
+            </Setter>
             <Setter Property="Cursor" Value="Hand"/>
             <Setter Property="ToolTip" Value="Double click to split"/>
             <Setter Property="Source" Value="{Binding Output.Anchor}" />

--- a/Examples/Nodify.Shapes/Canvas/CanvasView.xaml
+++ b/Examples/Nodify.Shapes/Canvas/CanvasView.xaml
@@ -150,6 +150,21 @@
                             <SolidColorBrush Color="White"
                                              Opacity="0.7" />
                         </nodify:StepConnection.Stroke>
+                        <nodify:StepConnection.Style>
+                            <Style TargetType="{x:Type nodify:StepConnection}">
+                                <Setter Property="OutlineBrush"
+                                        Value="Transparent" />
+                                <Style.Triggers>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter Property="OutlineBrush">
+                                            <Setter.Value>
+                                                <SolidColorBrush Color="White" Opacity="0.15" />
+                                            </Setter.Value>
+                                        </Setter>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </nodify:StepConnection.Style>
                     </nodify:StepConnection>
                 </DataTemplate>
             </nodify:NodifyEditor.ConnectionTemplate>
@@ -358,7 +373,8 @@
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="{x:Type shared:Resizer}">
-                                <Grid Margin="-3 -6 -6 -3" Background="Transparent">
+                                <Grid Margin="-3 -6 -6 -3"
+                                      Background="Transparent">
                                     <Rectangle Height="12"
                                                Width="3"
                                                Fill="#d2d4d7"

--- a/Nodify/Helpers/BoxValue.cs
+++ b/Nodify/Helpers/BoxValue.cs
@@ -13,6 +13,7 @@ namespace Nodify
         public static readonly object Double0 = 0d;
         public static readonly object Double1 = 1d;
         public static readonly object Double2 = 2d;
+        public static readonly object Double5 = 5d;
         public static readonly object Double45 = 45d;
         public static readonly object Double1000 = 1000d;
         public static readonly object Int0 = 0;


### PR DESCRIPTION
### 📝 Description of the Change

Add an outline to all connections that specify an `OutlineBrush`.

New dependency properties for `BaseConnection`:

- OutlineBrush
- OutlineThickness

> To only widen the connection clickable range you can just set the `OutlineBrush` to `Transparent`.

![connection-outline](https://github.com/user-attachments/assets/e3a2b40b-1715-4de0-b357-483f07283c5f)

Fixes #131

### 🐛 Possible Drawbacks

It affects rendering performance for connections that have a custom OutlineBrush.