### PR TITLE
Add support for ScrollViewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 >	- Added IsSelected and IsSelectable attached dependency properties to BaseConnection
 >	- Added PrioritizeBaseConnectionForSelection static field to BaseConnection
 >	- Added EditorGestures.Connection.Selection
+>	- Added support for ScrollViewer in NodifyEditor (implements IScrollInfo)
+>	- Added NodifyEditor.ScrollIncrement dependency property
 > - Bugfixes:
 
 #### **Version 6.4.0**

--- a/Examples/Nodify.Calculator/EditorView.xaml
+++ b/Examples/Nodify.Calculator/EditorView.xaml
@@ -1,15 +1,16 @@
 ﻿<UserControl x:Class="Nodify.Calculator.EditorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:Nodify.Calculator"
              xmlns:nodify="https://miroiu.github.io/nodify"
-             xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared" 
+             xmlns:shared="clr-namespace:Nodify;assembly=Nodify.Shared"
              xmlns:sys="clr-namespace:System;assembly=System.Runtime"
              d:DataContext="{d:DesignInstance Type=local:EditorViewModel}"
              mc:Ignorable="d"
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="450"
+             d:DesignWidth="800">
     <UserControl.Resources>
         <GeometryDrawing x:Key="SmallGridGeometry"
                          Geometry="M0,0 L0,1 0.03,1 0.03,0.03 1,0.03 1,0 Z"
@@ -34,38 +35,59 @@
                       Transform="{Binding ViewportTransform, ElementName=Editor}"
                       Drawing="{StaticResource LargeGridGeometry}" />
 
-        <LinearGradientBrush x:Key="AnimatedBrush" StartPoint="0 0" EndPoint="1 0">
-            <GradientStop Color="#6366f1" Offset="0" />
-            <GradientStop Color="#a855f7" Offset="0.5" />
-            <GradientStop Color="#ec4899" Offset="1" />
+        <LinearGradientBrush x:Key="AnimatedBrush"
+                             StartPoint="0 0"
+                             EndPoint="1 0">
+            <GradientStop Color="#6366f1"
+                          Offset="0" />
+            <GradientStop Color="#a855f7"
+                          Offset="0.5" />
+            <GradientStop Color="#ec4899"
+                          Offset="1" />
         </LinearGradientBrush>
-        <Border x:Key="AnimatedBorderPlaceholder" BorderBrush="{StaticResource AnimatedBrush}" />
+        <Border x:Key="AnimatedBorderPlaceholder"
+                BorderBrush="{StaticResource AnimatedBrush}" />
 
-        <Storyboard x:Key="AnimateBorder" RepeatBehavior="Forever">
+        <Storyboard x:Key="AnimateBorder"
+                    RepeatBehavior="Forever">
             <PointAnimation Storyboard.TargetProperty="BorderBrush.(LinearGradientBrush.StartPoint)"
-                                                    Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}"
-                                    Duration="0:0:2" To="1 0" />
+                            Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}"
+                            Duration="0:0:2"
+                            To="1 0" />
             <PointAnimation Storyboard.TargetProperty="BorderBrush.(LinearGradientBrush.StartPoint)"
-                                                    Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}" 
-                                    Duration="0:0:2" To="1 1" BeginTime="0:0:2" />
+                            Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}"
+                            Duration="0:0:2"
+                            To="1 1"
+                            BeginTime="0:0:2" />
             <PointAnimation Storyboard.TargetProperty="BorderBrush.(LinearGradientBrush.StartPoint)"
-                                                    Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}" 
-                                    Duration="0:0:2" To="0 1" BeginTime="0:0:4" />
+                            Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}"
+                            Duration="0:0:2"
+                            To="0 1"
+                            BeginTime="0:0:4" />
             <PointAnimation Storyboard.TargetProperty="BorderBrush.(LinearGradientBrush.StartPoint)"
-                                                    Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}" 
-                                    Duration="0:0:2" To="0 0" BeginTime="0:0:6" />
+                            Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}"
+                            Duration="0:0:2"
+                            To="0 0"
+                            BeginTime="0:0:6" />
             <PointAnimation Storyboard.TargetProperty="BorderBrush.(LinearGradientBrush.EndPoint)"
-                                                    Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}" 
-                                    Duration="0:0:2" To="1 1" />
-            <PointAnimation Storyboard.TargetProperty="BorderBrush.(LinearGradientBrush.EndPoint)" 
-                                                    Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}"
-                                    Duration="0:0:2" To="0 1" BeginTime="0:0:2" />
+                            Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}"
+                            Duration="0:0:2"
+                            To="1 1" />
             <PointAnimation Storyboard.TargetProperty="BorderBrush.(LinearGradientBrush.EndPoint)"
-                                                    Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}" 
-                                    Duration="0:0:2" To="0 0" BeginTime="0:0:4" />
+                            Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}"
+                            Duration="0:0:2"
+                            To="0 1"
+                            BeginTime="0:0:2" />
             <PointAnimation Storyboard.TargetProperty="BorderBrush.(LinearGradientBrush.EndPoint)"
-                                                    Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}" 
-                                    Duration="0:0:2" To="1 0" BeginTime="0:0:6" />
+                            Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}"
+                            Duration="0:0:2"
+                            To="0 0"
+                            BeginTime="0:0:4" />
+            <PointAnimation Storyboard.TargetProperty="BorderBrush.(LinearGradientBrush.EndPoint)"
+                            Storyboard.Target="{StaticResource AnimatedBorderPlaceholder}"
+                            Duration="0:0:2"
+                            To="1 0"
+                            BeginTime="0:0:6" />
         </Storyboard>
 
         <local:ItemToListConverter x:Key="ItemToListConverter" />
@@ -95,8 +117,10 @@
                     Value="{Binding IsSelected}" />
             <Setter Property="ActualSize"
                     Value="{Binding Size, Mode=OneWayToSource}" />
-            <Setter Property="BorderBrush" Value="{Binding BorderBrush, Source={StaticResource AnimatedBorderPlaceholder}}" />
-            <Setter Property="BorderThickness" Value="2" />
+            <Setter Property="BorderBrush"
+                    Value="{Binding BorderBrush, Source={StaticResource AnimatedBorderPlaceholder}}" />
+            <Setter Property="BorderThickness"
+                    Value="2" />
         </Style>
     </UserControl.Resources>
 
@@ -184,37 +208,39 @@
                             </DataTemplate>
                         </nodify:GroupingNode.HeaderTemplate>
                         <Grid>
-                            <nodify:NodifyEditor Tag="{Binding DataContext, RelativeSource={RelativeSource Self}}"
-                                                 DataContext="{Binding InnerCalculator}"
-                                                 ItemsSource="{Binding Operations}"
-                                                 Connections="{Binding Connections}"
-                                                 SelectedItems="{Binding SelectedOperations}"
-                                                 DisconnectConnectorCommand="{Binding DisconnectConnectorCommand}"
-                                                 PendingConnection="{Binding PendingConnection}"
-                                                 PendingConnectionTemplate="{StaticResource PendingConnectionTemplate}"
-                                                 ConnectionTemplate="{StaticResource ConnectionTemplate}"
-                                                 ItemContainerStyle="{StaticResource ItemContainerStyle}"
-                                                 Background="Transparent"
-                                                 GridCellSize="15"                    
-                                                 AllowDrop="True"
-                                                 Drop="OnDropNode"
-                                                 Visibility="{Binding DataContext.IsExpanded, RelativeSource={RelativeSource AncestorType=nodify:GroupingNode}, Converter={shared:BooleanToVisibilityConverter}}">
+                            <ScrollViewer CanContentScroll="True">
+                                <nodify:NodifyEditor Tag="{Binding DataContext, RelativeSource={RelativeSource Self}}"
+                                                     DataContext="{Binding InnerCalculator}"
+                                                     ItemsSource="{Binding Operations}"
+                                                     Connections="{Binding Connections}"
+                                                     SelectedItems="{Binding SelectedOperations}"
+                                                     DisconnectConnectorCommand="{Binding DisconnectConnectorCommand}"
+                                                     PendingConnection="{Binding PendingConnection}"
+                                                     PendingConnectionTemplate="{StaticResource PendingConnectionTemplate}"
+                                                     ConnectionTemplate="{StaticResource ConnectionTemplate}"
+                                                     ItemContainerStyle="{StaticResource ItemContainerStyle}"
+                                                     Background="Transparent"
+                                                     GridCellSize="15"
+                                                     AllowDrop="True"
+                                                     Drop="OnDropNode"
+                                                     Visibility="{Binding DataContext.IsExpanded, RelativeSource={RelativeSource AncestorType=nodify:GroupingNode}, Converter={shared:BooleanToVisibilityConverter}}">
 
-                                <nodify:NodifyEditor.InputBindings>
-                                    <KeyBinding Key="Delete"
-                                                Command="{Binding DeleteSelectionCommand}" />
-                                    <KeyBinding Key="C"
-                                                Command="{Binding GroupSelectionCommand}" />
-                                </nodify:NodifyEditor.InputBindings>
+                                    <nodify:NodifyEditor.InputBindings>
+                                        <KeyBinding Key="Delete"
+                                                    Command="{Binding DeleteSelectionCommand}" />
+                                        <KeyBinding Key="C"
+                                                    Command="{Binding GroupSelectionCommand}" />
+                                    </nodify:NodifyEditor.InputBindings>
 
-                                <CompositeCollection>
-                                    <nodify:DecoratorContainer DataContext="{Binding OperationsMenu}"
-                                                               Location="{Binding Location}">
-                                        <local:OperationsMenuView />
-                                    </nodify:DecoratorContainer>
-                                </CompositeCollection>
-                            </nodify:NodifyEditor>
-
+                                    <CompositeCollection>
+                                        <nodify:DecoratorContainer DataContext="{Binding OperationsMenu}"
+                                                                   Location="{Binding Location}">
+                                            <local:OperationsMenuView />
+                                        </nodify:DecoratorContainer>
+                                    </CompositeCollection>
+                                </nodify:NodifyEditor>
+                            </ScrollViewer>
+                            
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
@@ -344,7 +370,8 @@
 
             <nodify:NodifyEditor.Triggers>
                 <EventTrigger RoutedEvent="FrameworkElement.Loaded">
-                    <BeginStoryboard Name="AnimateBorder" Storyboard="{StaticResource AnimateBorder}" />
+                    <BeginStoryboard Name="AnimateBorder"
+                                     Storyboard="{StaticResource AnimateBorder}" />
                 </EventTrigger>
             </nodify:NodifyEditor.Triggers>
 
@@ -359,7 +386,7 @@
         <Grid Background="{StaticResource LargeGridLinesDrawingBrush}"
               Panel.ZIndex="-2" />
 
-        <Border HorizontalAlignment="Right" 
+        <Border HorizontalAlignment="Right"
                 MinWidth="200"
                 MaxWidth="300"
                 Padding="7"
@@ -374,19 +401,23 @@
                 <ItemsControl ItemsSource="{Binding Calculator.OperationsMenu.AvailableOperations}">
                     <ItemsControl.ItemContainerStyle>
                         <Style>
-                            <Setter Property="FrameworkElement.Margin" Value="5"/>
-                            <Setter Property="FrameworkElement.HorizontalAlignment" Value="Left"/>
-                            <Setter Property="FrameworkElement.Cursor" Value="Hand"/>
-                            <Setter Property="FrameworkElement.ToolTip" Value="Drag and drop into the editor"/>
+                            <Setter Property="FrameworkElement.Margin"
+                                    Value="5" />
+                            <Setter Property="FrameworkElement.HorizontalAlignment"
+                                    Value="Left" />
+                            <Setter Property="FrameworkElement.Cursor"
+                                    Value="Hand" />
+                            <Setter Property="FrameworkElement.ToolTip"
+                                    Value="Drag and drop into the editor" />
                         </Style>
                     </ItemsControl.ItemContainerStyle>
                     <ItemsControl.ItemTemplate>
                         <DataTemplate DataType="{x:Type local:OperationViewModel}">
                             <nodify:Node Content="{Binding Title}"
-                                     Input="{Binding Input}"
-                                     BorderBrush="{StaticResource AnimatedBrush}"
-                                     BorderThickness="2"
-                                     MouseMove="OnNodeDrag">
+                                         Input="{Binding Input}"
+                                         BorderBrush="{StaticResource AnimatedBrush}"
+                                         BorderThickness="2"
+                                         MouseMove="OnNodeDrag">
                                 <nodify:Node.Output>
                                     <CompositeCollection>
                                         <sys:String>Output</sys:String>

--- a/Examples/Nodify.Shapes/App.xaml.cs
+++ b/Examples/Nodify.Shapes/App.xaml.cs
@@ -10,6 +10,9 @@ namespace Nodify.Shapes
     {
         public App()
         {
+            NodifyEditor.EnableDraggingContainersOptimizations = false;
+            NodifyEditor.EnableCuttingLinePreview = true;
+
             EditorGestures.Mappings.Connection.Disconnect.Value = new AnyGesture(new MouseGesture(MouseAction.LeftClick, ModifierKeys.Alt), new MouseGesture(MouseAction.RightClick));
         }
     }

--- a/Examples/Nodify.Shapes/Canvas/CanvasView.xaml
+++ b/Examples/Nodify.Shapes/Canvas/CanvasView.xaml
@@ -47,6 +47,9 @@
                              ItemsSelectStartedCommand="{Binding SelectShapesStartedCommand}"
                              ItemsSelectCompletedCommand="{Binding SelectShapesCompletedCommand}"
                              RemoveConnectionCommand="{Binding RemoveConnectionCommand}"
+                             MouseDown="Editor_MouseDown"
+                             MouseMove="Editor_MouseMove"
+                             MouseUp="Editor_MouseUp"
                              GridCellSize="5"
                              x:Name="Editor">
             <nodify:NodifyEditor.Style>
@@ -156,10 +159,12 @@
                                 <Setter Property="OutlineBrush"
                                         Value="Transparent" />
                                 <Style.Triggers>
-                                    <Trigger Property="IsMouseOver" Value="True">
+                                    <Trigger Property="IsMouseOver"
+                                             Value="True">
                                         <Setter Property="OutlineBrush">
                                             <Setter.Value>
-                                                <SolidColorBrush Color="White" Opacity="0.15" />
+                                                <SolidColorBrush Color="White"
+                                                                 Opacity="0.15" />
                                             </Setter.Value>
                                         </Setter>
                                     </Trigger>
@@ -475,8 +480,7 @@
                 HorizontalAlignment="Center"
                 Margin="0 0 0 20"
                 CornerRadius="3"
-                Background="#1e293b"
-                MouseDown="Toolbar_MouseDown">
+                Background="#1e293b">
             <Border.Effect>
                 <DropShadowEffect ShadowDepth="1" />
             </Border.Effect>
@@ -594,8 +598,7 @@
                 HorizontalAlignment="Left"
                 Margin="20 0 0 20"
                 CornerRadius="3"
-                Background="#1e293b"
-                MouseDown="Toolbar_MouseDown">
+                Background="#1e293b">
             <Border.Effect>
                 <DropShadowEffect ShadowDepth="1" />
             </Border.Effect>
@@ -649,8 +652,7 @@
                 HorizontalAlignment="Right"
                 Margin="0 0 20 20"
                 Height="38"
-                CornerRadius="3"
-                MouseDown="Toolbar_MouseDown">
+                CornerRadius="3">
 
             <ItemsControl ItemsSource="{Binding Cursors}">
                 <ItemsControl.ItemsPanel>

--- a/Examples/Nodify.Shapes/Canvas/CanvasView.xaml.cs
+++ b/Examples/Nodify.Shapes/Canvas/CanvasView.xaml.cs
@@ -63,7 +63,7 @@ namespace Nodify.Shapes.Canvas
         private ShapeViewModel? _drawingShape;
         private Point _initialLocation;
 
-        protected override void OnMouseDown(MouseButtonEventArgs e)
+        private void Editor_MouseDown(object sender, MouseButtonEventArgs e)
         {
             var toolbarVm = ((CanvasViewModel)DataContext).CanvasToolbar;
             if (toolbarVm.SelectedTool != CanvasTool.None && DrawingGesturesMappings.Instance.Draw.Matches(this, e))
@@ -73,7 +73,7 @@ namespace Nodify.Shapes.Canvas
             }
         }
 
-        protected override void OnMouseMove(MouseEventArgs e)
+        private void Editor_MouseMove(object sender, MouseEventArgs e)
         {
             if (_drawingShape != null)
             {
@@ -92,15 +92,9 @@ namespace Nodify.Shapes.Canvas
             }
         }
 
-        protected override void OnMouseUp(MouseButtonEventArgs e)
+        private void Editor_MouseUp(object sender, MouseButtonEventArgs e)
         {
             _drawingShape = null;
-        }
-
-        private void Toolbar_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            // prevent creating shape by clicking on the toolbar
-            e.Handled = true;
         }
 
         #endregion

--- a/Examples/Nodify.Shapes/MainWindow.xaml.cs
+++ b/Examples/Nodify.Shapes/MainWindow.xaml.cs
@@ -10,9 +10,6 @@ namespace Nodify.Shapes
         public MainWindow()
         {
             InitializeComponent();
-
-            NodifyEditor.EnableDraggingContainersOptimizations = false;
-            NodifyEditor.EnableCuttingLinePreview = true;
         }
     }
 }

--- a/Examples/Nodify.StateMachine/MainWindow.xaml
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml
@@ -29,193 +29,197 @@
             <ColumnDefinition />
         </Grid.ColumnDefinitions>
 
-        <nodify:NodifyEditor x:Name="Editor"
-                             ItemsSource="{Binding States}"
-                             SelectedItem="{Binding SelectedState}"
-                             SelectedItems="{Binding SelectedStates}"
-                             Connections="{Binding Transitions}"
-                             PendingConnection="{Binding PendingTransition}"
-                             DisconnectConnectorCommand="{Binding DisconnectStateCommand}"
-                             ConnectionCompletedCommand="{Binding CreateTransitionCommand}"
-                             RemoveConnectionCommand="{Binding DeleteTransitionCommand}"
-                             Grid.Column="1">
-            <nodify:NodifyEditor.PendingConnectionTemplate>
-                <DataTemplate DataType="{x:Type local:TransitionViewModel}">
-                    <nodify:PendingConnection Source="{Binding Source, Mode=OneWayToSource}"
-                                              Target="{Binding Target, Mode=OneWayToSource}"
-                                              StrokeDashArray=""
-                                              EnablePreview="True">
-                        <nodify:PendingConnection.Template>
-                            <ControlTemplate TargetType="{x:Type nodify:PendingConnection}">
-                                <nodify:LineConnection Source="{TemplateBinding SourceAnchor}"
-                                                              Target="{TemplateBinding TargetAnchor}"
-                                                              StrokeThickness="{TemplateBinding StrokeThickness}"
-                                                              StrokeDashArray="{TemplateBinding StrokeDashArray}"
-                                                              SourceOffset="{Binding Source.Size, Converter={StaticResource ConnectorOffsetConverter}, ConverterParameter=5}"
-                                                              Spacing="0"
-                                                              SourceOffsetMode="Edge"
-                                                              TargetOffsetMode="None" />
-                            </ControlTemplate>
-                        </nodify:PendingConnection.Template>
-                    </nodify:PendingConnection>
-                </DataTemplate>
-            </nodify:NodifyEditor.PendingConnectionTemplate>
+        <ScrollViewer CanContentScroll="True"
+                      PreviewMouseWheel="ScrollViewer_MouseWheel"
+                      PreviewKeyDown="ScrollViewer_PreviewKeyDown"
+                      Grid.Column="1">
+            <nodify:NodifyEditor x:Name="Editor"
+                                 ItemsSource="{Binding States}"
+                                 SelectedItem="{Binding SelectedState}"
+                                 SelectedItems="{Binding SelectedStates}"
+                                 Connections="{Binding Transitions}"
+                                 PendingConnection="{Binding PendingTransition}"
+                                 DisconnectConnectorCommand="{Binding DisconnectStateCommand}"
+                                 ConnectionCompletedCommand="{Binding CreateTransitionCommand}"
+                                 RemoveConnectionCommand="{Binding DeleteTransitionCommand}">
+                <nodify:NodifyEditor.PendingConnectionTemplate>
+                    <DataTemplate DataType="{x:Type local:TransitionViewModel}">
+                        <nodify:PendingConnection Source="{Binding Source, Mode=OneWayToSource}"
+                                                  Target="{Binding Target, Mode=OneWayToSource}"
+                                                  StrokeDashArray=""
+                                                  EnablePreview="True">
+                            <nodify:PendingConnection.Template>
+                                <ControlTemplate TargetType="{x:Type nodify:PendingConnection}">
+                                    <nodify:LineConnection Source="{TemplateBinding SourceAnchor}"
+                                                           Target="{TemplateBinding TargetAnchor}"
+                                                           StrokeThickness="{TemplateBinding StrokeThickness}"
+                                                           StrokeDashArray="{TemplateBinding StrokeDashArray}"
+                                                           SourceOffset="{Binding Source.Size, Converter={StaticResource ConnectorOffsetConverter}, ConverterParameter=5}"
+                                                           Spacing="0"
+                                                           SourceOffsetMode="Edge"
+                                                           TargetOffsetMode="None" />
+                                </ControlTemplate>
+                            </nodify:PendingConnection.Template>
+                        </nodify:PendingConnection>
+                    </DataTemplate>
+                </nodify:NodifyEditor.PendingConnectionTemplate>
 
-            <nodify:NodifyEditor.ConnectionTemplate>
-                <DataTemplate DataType="{x:Type local:TransitionViewModel}">
-                    <nodify:LineConnection Source="{Binding Source.Anchor}"
-                                                  Target="{Binding Target.Anchor}"
-                                                  SourceOffset="{Binding Source.Size, Converter={StaticResource ConnectorOffsetConverter}, ConverterParameter=5}"
-                                                  TargetOffset="{Binding Target.Size, Converter={StaticResource ConnectorOffsetConverter}, ConverterParameter=5}"
-                                                  Spacing="0"
-                                                  SourceOffsetMode="Edge"
-                                                  TargetOffsetMode="Edge"
-                                                  Tag="{Binding}">
-                        <nodify:LineConnection.Style>
-                            <Style TargetType="{x:Type nodify:LineConnection}"
-                                   BasedOn="{StaticResource {x:Type nodify:LineConnection}}">
-                                <Setter Property="StrokeThickness"
-                                        Value="3" />
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsActive}"
-                                                 Value="True">
-                                        <Setter Property="Stroke"
-                                                Value="{DynamicResource ActiveStateBrush}" />
-                                        <Setter Property="StrokeThickness"
-                                                Value="6" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </nodify:LineConnection.Style>
-                        <nodify:LineConnection.ContextMenu>
-                            <ContextMenu DataContext="{Binding DataContext, Source={StaticResource EditorProxy}}">
-                                <MenuItem Header="_Delete"
-                                          Icon="{StaticResource DeleteIcon}"
-                                          Command="{Binding DeleteTransitionCommand}"
-                                          CommandParameter="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" />
-                            </ContextMenu>
-                        </nodify:LineConnection.ContextMenu>
-                    </nodify:LineConnection>
-                </DataTemplate>
-            </nodify:NodifyEditor.ConnectionTemplate>
+                <nodify:NodifyEditor.ConnectionTemplate>
+                    <DataTemplate DataType="{x:Type local:TransitionViewModel}">
+                        <nodify:LineConnection Source="{Binding Source.Anchor}"
+                                               Target="{Binding Target.Anchor}"
+                                               SourceOffset="{Binding Source.Size, Converter={StaticResource ConnectorOffsetConverter}, ConverterParameter=5}"
+                                               TargetOffset="{Binding Target.Size, Converter={StaticResource ConnectorOffsetConverter}, ConverterParameter=5}"
+                                               Spacing="0"
+                                               SourceOffsetMode="Edge"
+                                               TargetOffsetMode="Edge"
+                                               Tag="{Binding}">
+                            <nodify:LineConnection.Style>
+                                <Style TargetType="{x:Type nodify:LineConnection}"
+                                       BasedOn="{StaticResource {x:Type nodify:LineConnection}}">
+                                    <Setter Property="StrokeThickness"
+                                            Value="3" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsActive}"
+                                                     Value="True">
+                                            <Setter Property="Stroke"
+                                                    Value="{DynamicResource ActiveStateBrush}" />
+                                            <Setter Property="StrokeThickness"
+                                                    Value="6" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </nodify:LineConnection.Style>
+                            <nodify:LineConnection.ContextMenu>
+                                <ContextMenu DataContext="{Binding DataContext, Source={StaticResource EditorProxy}}">
+                                    <MenuItem Header="_Delete"
+                                              Icon="{StaticResource DeleteIcon}"
+                                              Command="{Binding DeleteTransitionCommand}"
+                                              CommandParameter="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" />
+                                </ContextMenu>
+                            </nodify:LineConnection.ContextMenu>
+                        </nodify:LineConnection>
+                    </DataTemplate>
+                </nodify:NodifyEditor.ConnectionTemplate>
 
-            <nodify:NodifyEditor.ItemTemplate>
-                <DataTemplate DataType="{x:Type local:StateViewModel}">
-                    <!--If IsConnected is false, Anchor won't be updated-->
-                    <nodify:StateNode Content="{Binding}"
-                                      IsConnected="True"
-                                      Anchor="{Binding Anchor, Mode=OneWayToSource}">
-                        <nodify:StateNode.ContentTemplate>
-                            <DataTemplate DataType="{x:Type local:StateViewModel}">
-                                <shared:EditableTextBlock Text="{Binding Name}"
-                                                          IsEditing="{Binding IsRenaming}"
-                                                          IsEditable="{Binding IsEditable}"
-                                                          MaxLength="30" />
-                            </DataTemplate>
-                        </nodify:StateNode.ContentTemplate>
-                        <nodify:StateNode.Style>
-                            <Style TargetType="{x:Type nodify:StateNode}"
-                                   BasedOn="{StaticResource {x:Type nodify:StateNode}}">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsEditable}"
-                                                 Value="False">
-                                        <Setter Property="BorderBrush"
-                                                Value="{DynamicResource ReadOnlyStateBrush}" />
-                                    </DataTrigger>
-                                    <DataTrigger Binding="{Binding IsActive}"
-                                                 Value="True">
-                                        <Setter Property="BorderBrush"
-                                                Value="{DynamicResource ActiveStateBrush}" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </nodify:StateNode.Style>
-                    </nodify:StateNode>
-                </DataTemplate>
-            </nodify:NodifyEditor.ItemTemplate>
+                <nodify:NodifyEditor.ItemTemplate>
+                    <DataTemplate DataType="{x:Type local:StateViewModel}">
+                        <!--If IsConnected is false, Anchor won't be updated-->
+                        <nodify:StateNode Content="{Binding}"
+                                          IsConnected="True"
+                                          Anchor="{Binding Anchor, Mode=OneWayToSource}">
+                            <nodify:StateNode.ContentTemplate>
+                                <DataTemplate DataType="{x:Type local:StateViewModel}">
+                                    <shared:EditableTextBlock Text="{Binding Name}"
+                                                              IsEditing="{Binding IsRenaming}"
+                                                              IsEditable="{Binding IsEditable}"
+                                                              MaxLength="30" />
+                                </DataTemplate>
+                            </nodify:StateNode.ContentTemplate>
+                            <nodify:StateNode.Style>
+                                <Style TargetType="{x:Type nodify:StateNode}"
+                                       BasedOn="{StaticResource {x:Type nodify:StateNode}}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsEditable}"
+                                                     Value="False">
+                                            <Setter Property="BorderBrush"
+                                                    Value="{DynamicResource ReadOnlyStateBrush}" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding IsActive}"
+                                                     Value="True">
+                                            <Setter Property="BorderBrush"
+                                                    Value="{DynamicResource ActiveStateBrush}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </nodify:StateNode.Style>
+                        </nodify:StateNode>
+                    </DataTemplate>
+                </nodify:NodifyEditor.ItemTemplate>
 
-            <nodify:NodifyEditor.ItemContainerStyle>
-                <Style TargetType="{x:Type nodify:ItemContainer}"
-                       BasedOn="{StaticResource {x:Type nodify:ItemContainer}}">
-                    <Setter Property="BorderBrush"
-                            Value="Transparent" />
-                    <Setter Property="Location"
-                            Value="{Binding Location}" />
-                    <Setter Property="ActualSize"
-                            Value="{Binding Size, Mode=OneWayToSource}" />
-                    <Setter Property="ContextMenu">
-                        <Setter.Value>
-                            <ContextMenu DataContext="{Binding DataContext, Source={StaticResource EditorProxy}}">
-                                <MenuItem Header="_Delete"
-                                          Icon="{StaticResource DeleteIcon}"
-                                          Command="{Binding DeleteSelectionCommand}" />
-                                <MenuItem Header="Di_sconnect"
-                                          Icon="{StaticResource DisconnectIcon}"
-                                          Command="{Binding DisconnectSelectionCommand}" />
-                                <MenuItem Header="_Rename"
-                                          Icon="{StaticResource RenameIcon}"
-                                          Command="{Binding RenameStateCommand}" />
-                                <MenuItem Header="_Alignment"
-                                          Icon="{StaticResource AlignTopIcon}">
-                                    <MenuItem Header="_Top"
-                                              Icon="{StaticResource AlignTopIcon}"
-                                              Command="{x:Static nodify:EditorCommands.Align}"
-                                              CommandParameter="Top" />
-                                    <MenuItem Header="_Left"
-                                              Icon="{StaticResource AlignLeftIcon}"
-                                              Command="{x:Static nodify:EditorCommands.Align}"
-                                              CommandParameter="Left" />
-                                    <MenuItem Header="_Bottom"
-                                              Icon="{StaticResource AlignBottomIcon}"
-                                              Command="{x:Static nodify:EditorCommands.Align}"
-                                              CommandParameter="Bottom" />
-                                    <MenuItem Header="_Right"
-                                              Icon="{StaticResource AlignRightIcon}"
-                                              Command="{x:Static nodify:EditorCommands.Align}"
-                                              CommandParameter="Right" />
-                                    <MenuItem Header="_Middle"
-                                              Icon="{StaticResource AlignMiddleIcon}"
-                                              Command="{x:Static nodify:EditorCommands.Align}"
-                                              CommandParameter="Middle" />
-                                    <MenuItem Header="_Center"
-                                              Icon="{StaticResource AlignCenterIcon}"
-                                              Command="{x:Static nodify:EditorCommands.Align}"
-                                              CommandParameter="Center" />
-                                </MenuItem>
-                            </ContextMenu>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </nodify:NodifyEditor.ItemContainerStyle>
+                <nodify:NodifyEditor.ItemContainerStyle>
+                    <Style TargetType="{x:Type nodify:ItemContainer}"
+                           BasedOn="{StaticResource {x:Type nodify:ItemContainer}}">
+                        <Setter Property="BorderBrush"
+                                Value="Transparent" />
+                        <Setter Property="Location"
+                                Value="{Binding Location}" />
+                        <Setter Property="ActualSize"
+                                Value="{Binding Size, Mode=OneWayToSource}" />
+                        <Setter Property="ContextMenu">
+                            <Setter.Value>
+                                <ContextMenu DataContext="{Binding DataContext, Source={StaticResource EditorProxy}}">
+                                    <MenuItem Header="_Delete"
+                                              Icon="{StaticResource DeleteIcon}"
+                                              Command="{Binding DeleteSelectionCommand}" />
+                                    <MenuItem Header="Di_sconnect"
+                                              Icon="{StaticResource DisconnectIcon}"
+                                              Command="{Binding DisconnectSelectionCommand}" />
+                                    <MenuItem Header="_Rename"
+                                              Icon="{StaticResource RenameIcon}"
+                                              Command="{Binding RenameStateCommand}" />
+                                    <MenuItem Header="_Alignment"
+                                              Icon="{StaticResource AlignTopIcon}">
+                                        <MenuItem Header="_Top"
+                                                  Icon="{StaticResource AlignTopIcon}"
+                                                  Command="{x:Static nodify:EditorCommands.Align}"
+                                                  CommandParameter="Top" />
+                                        <MenuItem Header="_Left"
+                                                  Icon="{StaticResource AlignLeftIcon}"
+                                                  Command="{x:Static nodify:EditorCommands.Align}"
+                                                  CommandParameter="Left" />
+                                        <MenuItem Header="_Bottom"
+                                                  Icon="{StaticResource AlignBottomIcon}"
+                                                  Command="{x:Static nodify:EditorCommands.Align}"
+                                                  CommandParameter="Bottom" />
+                                        <MenuItem Header="_Right"
+                                                  Icon="{StaticResource AlignRightIcon}"
+                                                  Command="{x:Static nodify:EditorCommands.Align}"
+                                                  CommandParameter="Right" />
+                                        <MenuItem Header="_Middle"
+                                                  Icon="{StaticResource AlignMiddleIcon}"
+                                                  Command="{x:Static nodify:EditorCommands.Align}"
+                                                  CommandParameter="Middle" />
+                                        <MenuItem Header="_Center"
+                                                  Icon="{StaticResource AlignCenterIcon}"
+                                                  Command="{x:Static nodify:EditorCommands.Align}"
+                                                  CommandParameter="Center" />
+                                    </MenuItem>
+                                </ContextMenu>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </nodify:NodifyEditor.ItemContainerStyle>
 
-            <nodify:NodifyEditor.ContextMenu>
-                <ContextMenu DataContext="{Binding DataContext, Source={StaticResource EditorProxy}}">
-                    <MenuItem Header="_Add State"
-                              Icon="{StaticResource AddStateIcon}"
-                              InputGestureText="Shift+A"
-                              Command="{Binding AddStateCommand}"
-                              CommandParameter="{Binding PlacementTarget.MouseLocation, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" />
-                    <MenuItem Header="_Delete"
-                              Icon="{StaticResource DeleteIcon}"
-                              InputGestureText="Delete"
-                              Command="{Binding DeleteSelectionCommand}" />
-                    <Separator Background="{DynamicResource BorderBrush}" />
-                    <MenuItem Header="_Select All"
-                              Icon="{StaticResource SelectAllIcon}"
-                              InputGestureText="Ctrl+A"
-                              Command="{x:Static nodify:EditorCommands.SelectAll}" />
-                </ContextMenu>
-            </nodify:NodifyEditor.ContextMenu>
+                <nodify:NodifyEditor.ContextMenu>
+                    <ContextMenu DataContext="{Binding DataContext, Source={StaticResource EditorProxy}}">
+                        <MenuItem Header="_Add State"
+                                  Icon="{StaticResource AddStateIcon}"
+                                  InputGestureText="Shift+A"
+                                  Command="{Binding AddStateCommand}"
+                                  CommandParameter="{Binding PlacementTarget.MouseLocation, RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}}" />
+                        <MenuItem Header="_Delete"
+                                  Icon="{StaticResource DeleteIcon}"
+                                  InputGestureText="Delete"
+                                  Command="{Binding DeleteSelectionCommand}" />
+                        <Separator Background="{DynamicResource BorderBrush}" />
+                        <MenuItem Header="_Select All"
+                                  Icon="{StaticResource SelectAllIcon}"
+                                  InputGestureText="Ctrl+A"
+                                  Command="{x:Static nodify:EditorCommands.SelectAll}" />
+                    </ContextMenu>
+                </nodify:NodifyEditor.ContextMenu>
 
-            <nodify:NodifyEditor.InputBindings>
-                <KeyBinding Key="Delete"
-                            Command="{Binding DeleteSelectionCommand}" />
-                <KeyBinding Key="A"
-                            Modifiers="Shift"
-                            Command="{Binding AddStateCommand}"
-                            CommandParameter="{Binding MouseLocation, RelativeSource={RelativeSource AncestorType={x:Type nodify:NodifyEditor}}}" />
-            </nodify:NodifyEditor.InputBindings>
-        </nodify:NodifyEditor>
+                <nodify:NodifyEditor.InputBindings>
+                    <KeyBinding Key="Delete"
+                                Command="{Binding DeleteSelectionCommand}" />
+                    <KeyBinding Key="A"
+                                Modifiers="Shift"
+                                Command="{Binding AddStateCommand}"
+                                CommandParameter="{Binding MouseLocation, RelativeSource={RelativeSource AncestorType={x:Type nodify:NodifyEditor}}}" />
+                </nodify:NodifyEditor.InputBindings>
+            </nodify:NodifyEditor>
+        </ScrollViewer>
 
         <!--TOOLBAR-->
         <Border CornerRadius="2"

--- a/Examples/Nodify.StateMachine/MainWindow.xaml.cs
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace Nodify.StateMachine
 {
@@ -12,6 +14,45 @@ namespace Nodify.StateMachine
             NodifyEditor.EnableCuttingLinePreview = true;
 
             EditorGestures.Mappings.Connection.Disconnect.Value = MultiGesture.None;
+            EditorGestures.Mappings.Editor.ZoomModifierKey = ModifierKeys.Control;
+        }
+
+        private void ScrollViewer_MouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            if (Keyboard.Modifiers != ModifierKeys.Shift)
+                return;
+
+            var scrollViewer = (ScrollViewer)sender;
+
+            if (e.Delta < 0)
+            {
+                scrollViewer.LineRight();
+            }
+            else
+            {
+                scrollViewer.LineLeft();
+            }
+
+            e.Handled = true;
+        }
+
+        private void ScrollViewer_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (Keyboard.Modifiers != ModifierKeys.Shift)
+                return;
+
+            var scrollViewer = (ScrollViewer)sender;
+
+            if (e.Key == Key.PageUp)
+            {
+                scrollViewer.PageLeft();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.PageDown)
+            {
+                scrollViewer.PageRight();
+                e.Handled = true;
+            }
         }
     }
 }

--- a/Nodify/NodifyEditor.Scrolling.cs
+++ b/Nodify/NodifyEditor.Scrolling.cs
@@ -1,0 +1,134 @@
+﻿using System.Windows.Controls;
+using System.Windows;
+using System;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Input;
+
+namespace Nodify
+{
+    public partial class NodifyEditor : IScrollInfo
+    {
+        public static double ScrollIncrement { get; set; } = Mouse.MouseWheelDeltaForOneLine / 2;
+
+        bool IScrollInfo.CanHorizontallyScroll { get; set; }
+        bool IScrollInfo.CanVerticallyScroll { get; set; }
+
+        private double _extentWidth;
+        double IScrollInfo.ExtentWidth => _extentWidth;
+
+        private double _extentHeight;
+        double IScrollInfo.ExtentHeight => _extentHeight;
+
+        private double _horizontalOffset;
+        double IScrollInfo.HorizontalOffset => _horizontalOffset;
+
+        private double _verticalOffset;
+        double IScrollInfo.VerticalOffset => _verticalOffset;
+
+        double IScrollInfo.ViewportWidth => ViewportSize.Width;
+        double IScrollInfo.ViewportHeight => ViewportSize.Height;
+
+        ScrollViewer? IScrollInfo.ScrollOwner { get; set; }
+
+        private IScrollInfo ScrollInfo => this;
+        private Point? _viewportLocationBeforeScrolling;
+        private bool _isScrolling;
+
+        void IScrollInfo.LineUp()
+            => ViewportLocation -= new Vector(0, ScrollIncrement / ViewportZoom);
+
+        void IScrollInfo.LineDown()
+            => ViewportLocation += new Vector(0, ScrollIncrement / ViewportZoom);
+
+        void IScrollInfo.LineLeft()
+            => ViewportLocation -= new Vector(ScrollIncrement / ViewportZoom, 0);
+
+        void IScrollInfo.LineRight()
+            => ViewportLocation += new Vector(ScrollIncrement / ViewportZoom, 0);
+
+        void IScrollInfo.MouseWheelUp() => ScrollInfo.LineUp();
+        void IScrollInfo.MouseWheelDown() => ScrollInfo.LineDown();
+        void IScrollInfo.MouseWheelLeft() => ScrollInfo.LineLeft();
+        void IScrollInfo.MouseWheelRight() => ScrollInfo.LineRight();
+
+        void IScrollInfo.PageUp()
+            => ViewportLocation = new Point(ViewportLocation.X, ViewportLocation.Y - ViewportSize.Height);
+
+        void IScrollInfo.PageDown()
+            => ViewportLocation = new Point(ViewportLocation.X, ViewportLocation.Y + ViewportSize.Height);
+
+        void IScrollInfo.PageLeft()
+            => ViewportLocation = new Point(ViewportLocation.X - ViewportSize.Width, ViewportLocation.Y);
+
+        void IScrollInfo.PageRight()
+            => ViewportLocation = new Point(ViewportLocation.X + ViewportSize.Width, ViewportLocation.Y);
+
+        Rect IScrollInfo.MakeVisible(Visual visual, Rect rectangle)
+        {
+            // This is called when clicking on an item container. Uncomment to automatically scroll to the selected item container.
+            //if (visual is ItemContainer container)
+            //{
+            //    var containerBounds = new Rect(container.Location, container.RenderSize);
+            //    if (!new Rect(ViewportLocation, ViewportSize).Contains(containerBounds))
+            //    {
+            //        BringIntoView(containerBounds);
+            //        return containerBounds;
+            //    }
+            //}
+
+            return rectangle;
+        }
+
+        void IScrollInfo.SetHorizontalOffset(double offset)
+        {
+            _horizontalOffset = offset;
+            UpdateViewportLocationOnScroll();
+        }
+
+        void IScrollInfo.SetVerticalOffset(double offset)
+        {
+            _verticalOffset = offset;
+            UpdateViewportLocationOnScroll();
+        }
+
+        private void UpdateViewportLocationOnScroll()
+        {
+            if (!_viewportLocationBeforeScrolling.HasValue)
+            {
+                _viewportLocationBeforeScrolling = ViewportLocation;
+            }
+
+            _isScrolling = true;
+
+            double locationX = Math.Min(ItemsExtent.Left, _viewportLocationBeforeScrolling.Value.X) + ScrollInfo.HorizontalOffset;
+            double locationY = Math.Min(ItemsExtent.Top, _viewportLocationBeforeScrolling.Value.Y) + ScrollInfo.VerticalOffset;
+            ViewportLocation = new Point(locationX, locationY);
+
+            ScrollInfo.ScrollOwner?.InvalidateScrollInfo();
+            _isScrolling = false;
+        }
+
+        private void UpdateScrollbars()
+        {
+            // setting the ViewportLocation when manually scrolling triggers the ViewportUpdatedEvent which in turn calls this method, hence the !_isScrolling check
+            if (ScrollInfo.ScrollOwner != null && !_isScrolling)
+            {
+                _viewportLocationBeforeScrolling = null;
+
+                var extent = ItemsExtent;
+                extent.Union(new Rect(ViewportLocation, ViewportSize));
+
+                _extentHeight = extent.Height;
+                _extentWidth = extent.Width;
+
+                var scrollOffset = ViewportLocation - ItemsExtent.Location;
+
+                _horizontalOffset = Math.Max(0, scrollOffset.X);
+                _verticalOffset = Math.Max(0, scrollOffset.Y);
+
+                ScrollInfo.ScrollOwner.InvalidateScrollInfo();
+            }
+        }
+    }
+}

--- a/Nodify/NodifyEditor.Scrolling.cs
+++ b/Nodify/NodifyEditor.Scrolling.cs
@@ -9,6 +9,9 @@ namespace Nodify
 {
     public partial class NodifyEditor : IScrollInfo
     {
+        /// <summary>
+        /// The number of units the mouse wheel is rotated to scroll one line.
+        /// </summary>
         public static double ScrollIncrement { get; set; } = Mouse.MouseWheelDeltaForOneLine / 2;
 
         bool IScrollInfo.CanHorizontallyScroll { get; set; }

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -25,7 +25,7 @@ namespace Nodify
     [StyleTypedProperty(Property = nameof(CuttingLineStyle), StyleTargetType = typeof(CuttingLine))]
     [ContentProperty(nameof(Decorators))]
     [DefaultProperty(nameof(Decorators))]
-    public class NodifyEditor : MultiSelector
+    public partial class NodifyEditor : MultiSelector
     {
         protected const string ElementItemsHost = "PART_ItemsHost";
         protected const string ElementConnectionsHost = "PART_ConnectionsHost";
@@ -127,7 +127,11 @@ namespace Nodify
         /// Updates the <see cref="ViewportSize"/> and raises the <see cref="ViewportUpdatedEvent"/>.
         /// Called when the <see cref="UIElement.RenderSize"/> or <see cref="ViewportZoom"/> is changed.
         /// </summary>
-        protected void OnViewportUpdated() => RaiseEvent(new RoutedEventArgs(ViewportUpdatedEvent, this));
+        protected void OnViewportUpdated()
+        {
+            UpdateScrollbars();
+            RaiseEvent(new RoutedEventArgs(ViewportUpdatedEvent, this));
+        }
 
         #endregion
 

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -37,13 +37,19 @@ namespace Nodify
         public static readonly DependencyProperty MaxViewportZoomProperty = DependencyProperty.Register(nameof(MaxViewportZoom), typeof(double), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Double2, OnMaxViewportZoomChanged, CoerceMaxViewportZoom));
         public static readonly DependencyProperty ViewportLocationProperty = DependencyProperty.Register(nameof(ViewportLocation), typeof(Point), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Point, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnViewportLocationChanged));
         public static readonly DependencyProperty ViewportSizeProperty = DependencyProperty.Register(nameof(ViewportSize), typeof(Size), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Size));
-        public static readonly DependencyProperty ItemsExtentProperty = DependencyProperty.Register(nameof(ItemsExtent), typeof(Rect), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Rect));
+        public static readonly DependencyProperty ItemsExtentProperty = DependencyProperty.Register(nameof(ItemsExtent), typeof(Rect), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Rect, OnItemsExtentChanged));
         public static readonly DependencyProperty DecoratorsExtentProperty = DependencyProperty.Register(nameof(DecoratorsExtent), typeof(Rect), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Rect));
 
         protected internal static readonly DependencyPropertyKey ViewportTransformPropertyKey = DependencyProperty.RegisterReadOnly(nameof(ViewportTransform), typeof(Transform), typeof(NodifyEditor), new FrameworkPropertyMetadata(new TransformGroup()));
         public static readonly DependencyProperty ViewportTransformProperty = ViewportTransformPropertyKey.DependencyProperty;
 
         #region Callbacks
+
+        private static void OnItemsExtentChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var editor = (NodifyEditor)d;
+            editor.UpdateScrollbars();
+        }
 
         private static void OnViewportLocationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -5437,12 +5437,14 @@ protected override Size MeasureOverride(Size constraint);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl) → [Selector](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.Selector) → [MultiSelector](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.MultiSelector) → [NodifyEditor](#nodifyeditor-class)  
   
+**Implements:** [IScrollInfo](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.IScrollInfo)  
+  
 **References:** [ContainerState](#containerstate-class), [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorSelectingState](#editorselectingstate-class), [EditorState](#editorstate-class), [SelectionHelper](#selectionhelper-class), [ItemContainer](#itemcontainer-class), [PendingConnection](#pendingconnection-class), [GroupingNode](#groupingnode-class), [Connector](#connector-class), [CuttingLine](#cuttingline-class), [DecoratorContainer](#decoratorcontainer-class), [EditorCommands](#editorcommands-class), [EditorGestures](#editorgestures-class), [Minimap](#minimap-class), [Connection](#connection-class), [BaseConnection](#baseconnection-class)  
   
 Groups [ItemContainer](#itemcontainer-class)s and [Connection](#connection-class)s in an area that you can drag, zoom and select.  
   
 ```csharp  
-public class NodifyEditor : MultiSelector  
+public class NodifyEditor : MultiSelector, IScrollInfo  
 ```  
   
 ### Constructors  
@@ -6193,6 +6195,18 @@ public ICommand RemoveConnectionCommand { get; set; }
 **Property Value**  
   
 [ICommand](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.ICommand)  
+  
+#### ScrollIncrement  
+  
+The number of units the mouse wheel is rotated to scroll one line.  
+  
+```csharp  
+public static double ScrollIncrement { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double)  
   
 #### SelectedArea  
   

--- a/docs/Editor-Overview.md
+++ b/docs/Editor-Overview.md
@@ -1,102 +1,128 @@
 ## Table of contents
-* [Moving the viewport](#panning)
-* [Zooming](#zooming)
-* [Selecting items](#selecting)
-  * [Selection API](#selection-api)
-* [Snapping to grid](#snapping)
-* [Commands](#commands)
-* [Editor API](#editor-api)
+
+- [Moving the viewport](#panning)
+- [Zooming](#zooming)
+- [Scrolling](#scrolling)
+- [Selecting items](#selecting)
+  - [Selection API](#selection-api)
+- [Snapping to grid](#snapping)
+- [Commands](#commands)
+- [Editor API](#editor-api)
 
 ## Panning
 
-Panning is done by holding right-click and moving the mouse and can be disabled by setting the ```DisablePanning``` dependency property to ```true```.
-> Note: It can be programmatically changed by setting the ```ViewportLocation``` dependency property.
+Panning is done by holding right-click and moving the mouse and can be disabled by setting the `DisablePanning` dependency property to `true`.
 
-While panning, the ```IsPanning``` dependency property will be set to ```true``` and the ```ViewportSize```, ```ViewportLocation``` and ```ViewportTransform``` dependency properties will be updated.
+> Note: It can be programmatically changed by setting the `ViewportLocation` dependency property.
 
-Automatic panning is also enabled by default and can be disabled by setting the ```DisableAutoPanning``` dependency property to ```true```. The behavior is to pan the viewport when selecting or dragging a selection or a pending connection near the edges of the viewport. 
+While panning, the `IsPanning` dependency property will be set to `true` and the `ViewportSize`, `ViewportLocation` and `ViewportTransform` dependency properties will be updated.
 
-The auto panning speed can be changed using the ```AutoPanSpeed``` dependency property and the distance from the edge to trigger the panning can be changed using the ```AutoPanEdgeDistance``` dependency property.
+Automatic panning is also enabled by default and can be disabled by setting the `DisableAutoPanning` dependency property to `true`. The behavior is to pan the viewport when selecting or dragging a selection or a pending connection near the edges of the viewport.
+
+The auto panning speed can be changed using the `AutoPanSpeed` dependency property and the distance from the edge to trigger the panning can be changed using the `AutoPanEdgeDistance` dependency property.
 
 Panning can also be used in combination with selecting and zooming while auto panning can be used with both selecting and zooming and also with dragging a selection or a pending connection.
 
-Default values: 
+Default values:
 
-* ```DisablePanning```: false
-* ```DisableAutoPanning```: false
-* ```AutoPanSpeed```: 10 pixels per tick
-* ```AutoPanEdgeDistance```: 15 pixels
-* ```AutoPanningTickRate```: 1 millisecond
+- `DisablePanning`: false
+- `DisableAutoPanning`: false
+- `AutoPanSpeed`: 10 pixels per tick
+- `AutoPanEdgeDistance`: 15 pixels
+- `AutoPanningTickRate`: 1 millisecond
 
-## Zooming 
+## Zooming
 
-Zooming is done by using the mouse wheel or by pressing ```CTRL +``` to zoom in or ```CTRL -``` to zoom out and can be disabled by setting the ```DisableZooming``` dependency property to ```true```. 
-> Note: It can be programmatically changed by setting the ```ViewportZoom``` dependency property to a value between ```MinViewportZoom``` and ```MaxViewportZoom```.
+Zooming is done by using the mouse wheel or by pressing `CTRL +` to zoom in or `CTRL -` to zoom out and can be disabled by setting the `DisableZooming` dependency property to `true`.
 
-While zooming, the ```ViewportLocation```, ```ViewportSize``` and ```ViewportTransform``` dependency properties will be updated.
+> Note: It can be programmatically changed by setting the `ViewportZoom` dependency property to a value between `MinViewportZoom` and `MaxViewportZoom`.
 
-Zooming can also be used in combination with panning, dragging a selection, or a pending connection. 
+While zooming, the `ViewportLocation`, `ViewportSize` and `ViewportTransform` dependency properties will be updated.
+
+Zooming can also be used in combination with panning, dragging a selection, or a pending connection.
 
 Default values:
-* ```ViewportZoom```: 1
-* ```MinViewportZoom```: 0.1
-* ```MaxViewportZoom```: 2
+
+- `ViewportZoom`: 1
+- `MinViewportZoom`: 0.1
+- `MaxViewportZoom`: 2
+
+## Scrolling
+
+Wrap the `NodifyEditor` inside a `ScrollViewer` to enable scrolling:
+
+```xml
+<ScrollViewer CanContentScroll="True">
+    <nodify:NodifyEditor ... />
+<ScrollViewer>
+```
+
+The scroll sensitivity can be adjusted by setting the `ScrollIncrement` static field.
+
+Default values:
+
+- `ScrollIncrement`: `Mouse.MouseWheelDeltaForOneLine` / 2
 
 ## Selecting
 
-Selecting items is done by holding the left mouse button and moving the mouse. When a selection operation is in progress, the ```IsSelecting``` dependency property is set to ```true``` and the ```SelectedArea``` dependency property is updated with each move.
-> Note: Selected items can also be set programmatically by binding a collection to the ```SelectedItems``` dependency property.
+Selecting items is done by holding the left mouse button and moving the mouse. When a selection operation is in progress, the `IsSelecting` dependency property is set to `true` and the `SelectedArea` dependency property is updated with each move.
 
-If real-time selection is enabled (```EnableRealtimeSelection```: true), the items will be selected and deselected while you resize the selection rectangle. Otherwise, the items contained in the ```SelectedArea``` will only be selected after the selection operation is finished.
+> Note: Selected items can also be set programmatically by binding a collection to the `SelectedItems` dependency property.
 
-When an ```ItemContainer``` is selected, its ```IsSelected``` dependency property is set to ```true```.
+If real-time selection is enabled (`EnableRealtimeSelection`: true), the items will be selected and deselected while you resize the selection rectangle. Otherwise, the items contained in the `SelectedArea` will only be selected after the selection operation is finished.
 
-Different behavior is used depending on the ```ModifierKeys``` held when starting a selection:
-* ```Replace``` - no modifier key (default behavior, clears the selected items and starts a new selection)
-* ```Append``` - shift key (adds selection to the currently selected items)
-* ```Remove``` - alt key (removes selection from the currently selected items)
-* ```Invert``` - control key (removes selected items and adds unselected items)
+When an `ItemContainer` is selected, its `IsSelected` dependency property is set to `true`.
 
-Selecting items can also be used in combination with panning and zooming. 
+Different behavior is used depending on the `ModifierKeys` held when starting a selection:
+
+- `Replace` - no modifier key (default behavior, clears the selected items and starts a new selection)
+- `Append` - shift key (adds selection to the currently selected items)
+- `Remove` - alt key (removes selection from the currently selected items)
+- `Invert` - control key (removes selected items and adds unselected items)
+
+Selecting items can also be used in combination with panning and zooming.
 
 Default values:
-* ```EnableRealtimeSelection```: true
 
-### Selection API:
+- `EnableRealtimeSelection`: true
+
+### Selection API
 
 The following methods can be called on a NodifyEditor instance.
 
-* SelectArea
-* InvertSelection
-* UnselectArea
+- SelectArea
+- InvertSelection
+- UnselectArea
 
 ## Snapping
 
-When a selection is moved the ```GridCellSize``` dependency property will be used to determine where to snap the selected items.
+When a selection is moved the `GridCellSize` dependency property will be used to determine where to snap the selected items.
 The snapping is relative to the position of the selected item and not the virtual grid.
 
-If the selected items are not snapped to the grid when they are initially created or if the ```GridCellSize``` is changed at runtime, the final position will be corrected after moving the selection if the ```EnableSnappingCorrection``` dependency property is ```true```.
+If the selected items are not snapped to the grid when they are initially created or if the `GridCellSize` is changed at runtime, the final position will be corrected after moving the selection if the `EnableSnappingCorrection` dependency property is `true`.
 
 Default values:
-* ```GridCellSize```: 1
-* ```EnableSnappingCorrection```: true
+
+- `GridCellSize`: 1
+- `EnableSnappingCorrection`: true
 
 ## Commands
 
-The following ```RoutedUICommand```s are found in the ```EditorCommands``` class:
-* ```ZoomIn``` - ```CTRL +``` (zoom in relative to the viewport's center)
-* ```ZoomOut``` - ```CTRL -``` (zoom out relative to the viewport's center)
-* ```SelectAll``` - ```CTRL A``` (select all items)
-* ```BringIntoView``` - Moves the viewport to the specified location, defaults to [0,0]. (```CommandParameter``` is the location of type ```Point``` or ```string```)
-* ```Align``` - Aligns the selected items using the specified alignment method, defaults to Top. (```CommandParameter``` is of type ```Alignment``` or ```string```. Possible alignment: Top, Left, Bottom, Right, Middle, Center)
-* ```FitToScreen``` - Scales and moves the `Viewport` to display as many items as possible
- 
+The following `RoutedUICommand`s are found in the `EditorCommands` class:
+
+- `ZoomIn` - `CTRL +` (zoom in relative to the viewport's center)
+- `ZoomOut` - `CTRL -` (zoom out relative to the viewport's center)
+- `SelectAll` - `CTRL A` (select all items)
+- `BringIntoView` - Moves the viewport to the specified location, defaults to [0,0]. (`CommandParameter` is the location of type `Point` or `string`)
+- `Align` - Aligns the selected items using the specified alignment method, defaults to Top. (`CommandParameter` is of type `Alignment` or `string`. Possible alignment: Top, Left, Bottom, Right, Middle, Center)
+- `FitToScreen` - Scales and moves the `Viewport` to display as many items as possible
+
 ## Editor API
 
-You can programmatically call the corresponding methods of these commands on an instance of a `NodifyEditor`. 
+You can programmatically call the corresponding methods of these commands on an instance of a `NodifyEditor`.
 
-* FitToScreen
-* BringIntoView
-* ZoomAtPosition
-* ZoomIn
-* ZoomOut
+- FitToScreen
+- BringIntoView
+- ZoomAtPosition
+- ZoomIn
+- ZoomOut

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -18,6 +18,7 @@
 
 - [Moving the viewport](Editor-Overview#panning)
 - [Zooming](Editor-Overview#zooming)
+- [Scrolling](Editor-Overview#scrolling)
 - [Selecting items](Editor-Overview#selecting)
 - [Snapping to grid](Editor-Overview#snapping)
 - [Commands](Editor-Overview#commands)


### PR DESCRIPTION
### 📝 Description of the Change

Make the `NodifyEditor` scrollable when it is inside a `ScrollViewer`.

Dependency properties:
- ScrollIncrement

Example:

```xml
 <ScrollViewer CanContentScroll="True">
     <nodify:NodifyEditor ... />
 <ScrollViewer>
```

Examples can be seen in the StateMachine and Calculator apps:

![scrollable](https://github.com/user-attachments/assets/a9f6c074-a613-4a04-91b1-f572adab6e55)
![scrollable2](https://github.com/user-attachments/assets/1f17f4e0-81bf-4b57-b6bf-08cffe4b2836)

### 🐛 Possible Drawbacks

None that I can think of.

Closes #141