### PR TITLE
Add InputGroupStyle and OutputGroupStyle to Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 > - Breaking Changes:
 > - Features:
+>	- Added InputGroupStyle and OutputGroupStyle to Node
 > - Bugfixes:
 
 #### **Version 6.5.0**

--- a/Nodify/Nodes/Node.cs
+++ b/Nodify/Nodes/Node.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -8,8 +10,13 @@ namespace Nodify
     /// <summary>
     /// Represents a control that has a list of <see cref="Input"/> <see cref="Connector"/>s and a list of <see cref="Output"/> <see cref="Connector"/>s.
     /// </summary>
+    [TemplatePart(Name = ElementInputItemsControl, Type = typeof(ItemsControl))]
+    [TemplatePart(Name = ElementOutputItemsControl, Type = typeof(ItemsControl))]
     public class Node : HeaderedContentControl
     {
+        protected const string ElementInputItemsControl = "PART_Input";
+        protected const string ElementOutputItemsControl = "PART_Output";
+
         #region Dependency Properties
 
         public static readonly DependencyProperty ContentBrushProperty = DependencyProperty.Register(nameof(ContentBrush), typeof(Brush), typeof(Node));
@@ -53,7 +60,7 @@ namespace Nodify
             get => (Brush)GetValue(FooterBrushProperty);
             set => SetValue(FooterBrushProperty, value);
         }
-        
+
         /// <summary>
         /// Gets or sets the data for the footer of this control.
         /// </summary>
@@ -71,7 +78,7 @@ namespace Nodify
             get => (DataTemplate)GetValue(FooterTemplateProperty);
             set => SetValue(FooterTemplateProperty, value);
         }
-        
+
         /// <summary>
         /// Gets or sets the template used to display the content of the control's <see cref="Input"/> connectors.
         /// </summary>
@@ -80,7 +87,7 @@ namespace Nodify
             get => (DataTemplate)GetValue(InputConnectorTemplateProperty);
             set => SetValue(InputConnectorTemplateProperty, value);
         }
-        
+
         /// <summary>
         /// Gets or sets the template used to display the content of the control's <see cref="Output"/> connectors.
         /// </summary>
@@ -89,7 +96,7 @@ namespace Nodify
             get => (DataTemplate)GetValue(OutputConnectorTemplateProperty);
             set => SetValue(OutputConnectorTemplateProperty, value);
         }
-        
+
         /// <summary>
         /// Gets or sets the data for the input <see cref="Connector"/>s of this control.
         /// </summary>
@@ -98,7 +105,7 @@ namespace Nodify
             get => (IEnumerable)GetValue(InputProperty);
             set => SetValue(InputProperty, value);
         }
-        
+
         /// <summary>
         /// Gets or sets the data for the output <see cref="Connector"/>s of this control.
         /// </summary>
@@ -148,9 +155,97 @@ namespace Nodify
 
         #endregion
 
+        public ObservableCollection<GroupStyle> InputGroupStyle { get; } = new ObservableCollection<GroupStyle>();
+        public ObservableCollection<GroupStyle> OutputGroupStyle { get; } = new ObservableCollection<GroupStyle>();
+
+        protected ItemsControl? InputItemsControl { get; private set; }
+        protected ItemsControl? OutputItemsControl { get; private set; }
+
         static Node()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(Node), new FrameworkPropertyMetadata(typeof(Node)));
+        }
+
+        public Node()
+        {
+            InputGroupStyle.CollectionChanged += OnInputGroupStyleCollectionChanged;
+            OutputGroupStyle.CollectionChanged += OnOutputGroupStyleCollectionChanged;
+        }
+
+        public override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            InputItemsControl = GetTemplateChild(ElementInputItemsControl) as ItemsControl;
+            OutputItemsControl = GetTemplateChild(ElementOutputItemsControl) as ItemsControl;
+
+            if (InputItemsControl != null)
+            {
+                foreach (var style in InputGroupStyle)
+                {
+                    InputItemsControl.GroupStyle.Add(style);
+                }
+            }
+
+            if (OutputItemsControl != null)
+            {
+                foreach (var style in OutputGroupStyle)
+                {
+                    OutputItemsControl.GroupStyle.Add(style);
+                }
+            }
+        }
+
+        private void OnInputGroupStyleCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (InputItemsControl != null)
+            {
+                SynchronizeCollection(InputItemsControl.GroupStyle, e);
+            }
+        }
+
+        private void OnOutputGroupStyleCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (OutputItemsControl != null)
+            {
+                SynchronizeCollection(OutputItemsControl.GroupStyle, e);
+            }
+        }
+
+        private static void SynchronizeCollection(ObservableCollection<GroupStyle> collection, NotifyCollectionChangedEventArgs e)
+        {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    if (e.NewItems != null)
+                    {
+                        for (int i = 0; i < e.NewItems.Count; i++)
+                        {
+                            var item = (GroupStyle)e.NewItems[i]!;
+                            collection.Add(item);
+                        }
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Remove:
+                    if (e.OldItems != null)
+                    {
+                        for (int i = 0; i < e.OldItems.Count; i++)
+                        {
+                            var item = (GroupStyle)e.OldItems[i]!;
+                            collection.Remove(item);
+                        }
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Replace:
+                    collection[e.NewStartingIndex] = (GroupStyle)e.NewItems![0]!;
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    collection.Move(e.OldStartingIndex, e.NewStartingIndex);
+                    break;
+                case NotifyCollectionChangedAction.Reset:
+                    collection.Clear();
+                    break;
+            }
         }
     }
 }

--- a/Nodify/Nodes/Node.cs
+++ b/Nodify/Nodes/Node.cs
@@ -155,7 +155,9 @@ namespace Nodify
 
         #endregion
 
+        /// <inheritdoc cref="ItemsControl.GroupStyle"/>
         public ObservableCollection<GroupStyle> InputGroupStyle { get; } = new ObservableCollection<GroupStyle>();
+        /// <inheritdoc cref="ItemsControl.GroupStyle"/>
         public ObservableCollection<GroupStyle> OutputGroupStyle { get; } = new ObservableCollection<GroupStyle>();
 
         protected ItemsControl? InputItemsControl { get; private set; }

--- a/Nodify/Themes/Styles/Node.xaml
+++ b/Nodify/Themes/Styles/Node.xaml
@@ -95,7 +95,8 @@
                                     </Grid.ColumnDefinitions>
 
                                     <!--Data IN-->
-                                    <ItemsControl ItemsSource="{TemplateBinding Input}"
+                                    <ItemsControl x:Name="PART_Input"
+                                                  ItemsSource="{TemplateBinding Input}"
                                                   VerticalAlignment="{TemplateBinding VerticalAlignment}"
                                                   ItemTemplate="{TemplateBinding InputConnectorTemplate}"
                                                   Focusable="False" />
@@ -109,7 +110,8 @@
                                     </Border>
 
                                     <!--Data OUT-->
-                                    <ItemsControl ItemsSource="{TemplateBinding Output}"
+                                    <ItemsControl x:Name="PART_Output"
+                                                  ItemsSource="{TemplateBinding Output}"
                                                   ItemTemplate="{TemplateBinding OutputConnectorTemplate}"
                                                   VerticalAlignment="{TemplateBinding VerticalAlignment}"
                                                   HorizontalContentAlignment="Right"


### PR DESCRIPTION
### 📝 Description of the Change

Add support for grouping connectors in Node. 

Node properties:
- InputGroupStyle
- OutputGroupStyle

Example usage

```xml
<nodify:Node Input="{Binding Input, Converter={StaticResource GroupByShapeConverter}}"
             Output="{Binding Output, Converter={StaticResource GroupByShapeConverter}}"
             Header="{Binding Title}">
    <nodify:Node.InputGroupStyle>
        <GroupStyle />
    </nodify:Node.InputGroupStyle>
    <nodify:Node.OutputGroupStyle>
        <GroupStyle />
    </nodify:Node.OutputGroupStyle>
</nodify:Node>
```

![image](https://github.com/user-attachments/assets/2ae3b32d-525d-4878-9150-9f1effea92a6)

Closes #144