### PR TITLE
Pan using mouse wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > - Breaking Changes:
 > - Features:
 >	- Added InputGroupStyle and OutputGroupStyle to Node
+>	- Added PanWithMouseWheel, PanHorizontalModifierKey and PanVerticalModifierKey to EditorGestures.Editor
 > - Bugfixes:
 
 #### **Version 6.5.0**

--- a/Nodify/EditorGestures.cs
+++ b/Nodify/EditorGestures.cs
@@ -118,6 +118,9 @@ namespace Nodify
                 ResetViewportLocation = new KeyGesture(Key.Home);
                 FitToScreen = new KeyGesture(Key.Home, ModifierKeys.Shift);
                 CancelAction = new AnyGesture(new MouseGesture(MouseAction.RightClick), new KeyGesture(Key.Escape));
+                PanWithMouseWheel = false;
+                PanHorizontalModifierKey = ModifierKeys.Shift;
+                PanVerticalModifierKey = ModifierKeys.None;
             }
 
             /// <summary>Gesture used to start selecting using a <see cref="SelectionGestures"/> strategy.</summary>
@@ -130,7 +133,19 @@ namespace Nodify
             /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or <see cref="MouseAction.MiddleClick"/>.</remarks>
             public InputGestureRef Pan { get; }
 
-            /// <summary>The key modifier required to start zooming by mouse wheel.</summary>
+            /// <summary>Whether panning using mouse wheel is allowed.</summary>
+            /// <remarks>Set the <see cref="ZoomModifierKey"/> to allow zooming using the mouse wheel.</remarks>
+            public bool PanWithMouseWheel { get; set; }
+
+            /// <summary>The modifier key required to start panning vertically with the mouse wheel (see <see cref="PanWithMouseWheel"/>)</summary>
+            /// <remarks>Defaults to <see cref="ModifierKeys.None"/>.</remarks>
+            public ModifierKeys PanVerticalModifierKey { get; set; }
+
+            /// <summary>The modifier key required to start panning horizontally with the mouse wheel (see <see cref="PanWithMouseWheel"/>)</summary>
+            /// <remarks>Defaults to <see cref="ModifierKeys.Shift"/>.</remarks>
+            public ModifierKeys PanHorizontalModifierKey { get; set; }
+
+            /// <summary>The modifier key required to start zooming with the mouse wheel.</summary>
             /// <remarks>Defaults to <see cref="ModifierKeys.None"/>.</remarks>
             public ModifierKeys ZoomModifierKey { get; set; }
 
@@ -167,6 +182,9 @@ namespace Nodify
                 ResetViewportLocation.Value = gestures.ResetViewportLocation.Value;
                 FitToScreen.Value = gestures.FitToScreen.Value;
                 CancelAction.Value = gestures.CancelAction.Value;
+                PanWithMouseWheel = gestures.PanWithMouseWheel;
+                PanHorizontalModifierKey = gestures.PanHorizontalModifierKey;
+                PanVerticalModifierKey = gestures.PanVerticalModifierKey;
             }
         }
 

--- a/Nodify/EditorStates/EditorDefaultState.cs
+++ b/Nodify/EditorStates/EditorDefaultState.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿using System.Windows;
+using System.Windows.Input;
 using static Nodify.SelectionHelper;
 
 namespace Nodify
@@ -44,6 +45,24 @@ namespace Nodify
             else if (!Editor.DisablePanning && gestures.Pan.Matches(e.Source, e))
             {
                 PushState(new EditorPanningState(Editor));
+            }
+        }
+
+        public override void HandleMouseWheel(MouseWheelEventArgs e)
+        {
+            EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
+            if (gestures.PanWithMouseWheel)
+            {
+                if (Keyboard.Modifiers == gestures.PanHorizontalModifierKey)
+                {
+                    Editor.ViewportLocation = new Point(Editor.ViewportLocation.X - e.Delta / Editor.ViewportZoom, Editor.ViewportLocation.Y);
+                    e.Handled = true;
+                }
+                else if (Keyboard.Modifiers == gestures.PanVerticalModifierKey)
+                {
+                    Editor.ViewportLocation = new Point(Editor.ViewportLocation.X, Editor.ViewportLocation.Y - e.Delta / Editor.ViewportZoom);
+                    e.Handled = true;
+                }
             }
         }
     }

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -2877,6 +2877,16 @@ public override void HandleMouseDown(MouseButtonEventArgs e);
   
 `e` [MouseButtonEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.MouseButtonEventArgs)  
   
+#### HandleMouseWheel(MouseWheelEventArgs)  
+  
+```csharp  
+public override void HandleMouseWheel(MouseWheelEventArgs e);  
+```  
+  
+**Parameters**  
+  
+`e` [MouseWheelEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.MouseWheelEventArgs)  
+  
 ## EditorGestures Class  
   
 **Namespace:** Nodify  
@@ -5059,6 +5069,28 @@ public class Node : HeaderedContentControl
 public Node();  
 ```  
   
+### Fields  
+  
+#### ElementInputItemsControl  
+  
+```csharp  
+protected const string ElementInputItemsControl = "PART_Input";  
+```  
+  
+**Field Value**  
+  
+[String](https://docs.microsoft.com/en-us/dotnet/api/System.String)  
+  
+#### ElementOutputItemsControl  
+  
+```csharp  
+protected const string ElementOutputItemsControl = "PART_Output";  
+```  
+  
+**Field Value**  
+  
+[String](https://docs.microsoft.com/en-us/dotnet/api/System.String)  
+  
 ### Properties  
   
 #### ContentBrush  
@@ -5193,6 +5225,26 @@ public DataTemplate InputConnectorTemplate { get; set; }
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
   
+#### InputGroupStyle  
+  
+```csharp  
+public ObservableCollection<GroupStyle> InputGroupStyle { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ObservableCollection<GroupStyle>](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.ObjectModel.ObservableCollection)  
+  
+#### InputItemsControl  
+  
+```csharp  
+protected ItemsControl InputItemsControl { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl)  
+  
 #### Output  
   
 Gets or sets the data for the output [Connector](#connector-class)s of this control.  
@@ -5216,6 +5268,34 @@ public DataTemplate OutputConnectorTemplate { get; set; }
 **Property Value**  
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
+  
+#### OutputGroupStyle  
+  
+```csharp  
+public ObservableCollection<GroupStyle> OutputGroupStyle { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ObservableCollection<GroupStyle>](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.ObjectModel.ObservableCollection)  
+  
+#### OutputItemsControl  
+  
+```csharp  
+protected ItemsControl OutputItemsControl { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl)  
+  
+### Methods  
+  
+#### OnApplyTemplate()  
+  
+```csharp  
+public override void OnApplyTemplate();  
+```  
   
 ## NodeInput Class  
   
@@ -6778,6 +6858,36 @@ public InputGestureRef Pan { get; set; }
 **Property Value**  
   
 [InputGestureRef](#inputgestureref-class)  
+  
+#### PanHorizontalModifierKey  
+  
+```csharp  
+public ModifierKeys PanHorizontalModifierKey { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ModifierKeys](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.ModifierKeys)  
+  
+#### PanVerticalModifierKey  
+  
+```csharp  
+public ModifierKeys PanVerticalModifierKey { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ModifierKeys](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.ModifierKeys)  
+  
+#### PanWithMouseWheel  
+  
+```csharp  
+public bool PanWithMouseWheel { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean)  
   
 #### ResetViewportLocation  
   

--- a/docs/localization/zh-CN/API-Reference.md
+++ b/docs/localization/zh-CN/API-Reference.md
@@ -2877,6 +2877,16 @@ public override void HandleMouseDown(MouseButtonEventArgs e);
   
 `e` [MouseButtonEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.MouseButtonEventArgs)  
   
+#### HandleMouseWheel(MouseWheelEventArgs)  
+  
+```csharp  
+public override void HandleMouseWheel(MouseWheelEventArgs e);  
+```  
+  
+**Parameters**  
+  
+`e` [MouseWheelEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.MouseWheelEventArgs)  
+  
 ## EditorGestures Class  
   
 **Namespace:** Nodify  
@@ -5059,6 +5069,28 @@ public class Node : HeaderedContentControl
 public Node();  
 ```  
   
+### Fields  
+  
+#### ElementInputItemsControl  
+  
+```csharp  
+protected const string ElementInputItemsControl = "PART_Input";  
+```  
+  
+**Field Value**  
+  
+[String](https://docs.microsoft.com/en-us/dotnet/api/System.String)  
+  
+#### ElementOutputItemsControl  
+  
+```csharp  
+protected const string ElementOutputItemsControl = "PART_Output";  
+```  
+  
+**Field Value**  
+  
+[String](https://docs.microsoft.com/en-us/dotnet/api/System.String)  
+  
 ### Properties  
   
 #### ContentBrush  
@@ -5193,6 +5225,26 @@ public DataTemplate InputConnectorTemplate { get; set; }
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
   
+#### InputGroupStyle  
+  
+```csharp  
+public ObservableCollection<GroupStyle> InputGroupStyle { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ObservableCollection<GroupStyle>](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.ObjectModel.ObservableCollection)  
+  
+#### InputItemsControl  
+  
+```csharp  
+protected ItemsControl InputItemsControl { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl)  
+  
 #### Output  
   
 Gets or sets the data for the output [Connector](#connector-class)s of this control.  
@@ -5216,6 +5268,34 @@ public DataTemplate OutputConnectorTemplate { get; set; }
 **Property Value**  
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
+  
+#### OutputGroupStyle  
+  
+```csharp  
+public ObservableCollection<GroupStyle> OutputGroupStyle { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ObservableCollection<GroupStyle>](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.ObjectModel.ObservableCollection)  
+  
+#### OutputItemsControl  
+  
+```csharp  
+protected ItemsControl OutputItemsControl { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl)  
+  
+### Methods  
+  
+#### OnApplyTemplate()  
+  
+```csharp  
+public override void OnApplyTemplate();  
+```  
   
 ## NodeInput Class  
   
@@ -5437,12 +5517,14 @@ protected override Size MeasureOverride(Size constraint);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl) → [Selector](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.Selector) → [MultiSelector](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.MultiSelector) → [NodifyEditor](#nodifyeditor-class)  
   
+**Implements:** [IScrollInfo](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.IScrollInfo)  
+  
 **References:** [ContainerState](#containerstate-class), [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorSelectingState](#editorselectingstate-class), [EditorState](#editorstate-class), [SelectionHelper](#selectionhelper-class), [ItemContainer](#itemcontainer-class), [PendingConnection](#pendingconnection-class), [GroupingNode](#groupingnode-class), [Connector](#connector-class), [CuttingLine](#cuttingline-class), [DecoratorContainer](#decoratorcontainer-class), [EditorCommands](#editorcommands-class), [EditorGestures](#editorgestures-class), [Minimap](#minimap-class), [Connection](#connection-class), [BaseConnection](#baseconnection-class)  
   
 Groups [ItemContainer](#itemcontainer-class)s and [Connection](#connection-class)s in an area that you can drag, zoom and select.  
   
 ```csharp  
-public class NodifyEditor : MultiSelector  
+public class NodifyEditor : MultiSelector, IScrollInfo  
 ```  
   
 ### Constructors  
@@ -6194,6 +6276,18 @@ public ICommand RemoveConnectionCommand { get; set; }
   
 [ICommand](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.ICommand)  
   
+#### ScrollIncrement  
+  
+The number of units the mouse wheel is rotated to scroll one line.  
+  
+```csharp  
+public static double ScrollIncrement { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double)  
+  
 #### SelectedArea  
   
 Gets the currently selected area while [NodifyEditor.IsSelecting](#nodifyeditor-class#isselecting) is true.  
@@ -6764,6 +6858,36 @@ public InputGestureRef Pan { get; set; }
 **Property Value**  
   
 [InputGestureRef](#inputgestureref-class)  
+  
+#### PanHorizontalModifierKey  
+  
+```csharp  
+public ModifierKeys PanHorizontalModifierKey { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ModifierKeys](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.ModifierKeys)  
+  
+#### PanVerticalModifierKey  
+  
+```csharp  
+public ModifierKeys PanVerticalModifierKey { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ModifierKeys](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.ModifierKeys)  
+  
+#### PanWithMouseWheel  
+  
+```csharp  
+public bool PanWithMouseWheel { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean)  
   
 #### ResetViewportLocation  
   


### PR DESCRIPTION
<!-- 
  ## Hello and welcome!

  Consider creating an issue or link to an existing one before submitting the pull request. Thanks!
-->

### 📝 Description of the Change

Allow panning using mouse wheel.

EditorGestures.Editor:
- PanWithMouseWheel
- PanHorizontalModifierKey
- PanVerticalModifierKey

> [!WARNING]
 Setting `PanWithMouseWheel` to true will not allow zooming using the mouse wheel unless the `ZoomModifierKey` is different than `ModifierKeys.None` or `PanVerticalModifierKey` and `PanHorizontalModifierKey` are both different than `ModifierKeys.None`.

### 🐛 Possible Drawbacks

None that I can think of.


Related: #146 
