### PR TITLE
Smooth connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > - Breaking Changes:
 > - Features:
 >	- Added InputGroupStyle and OutputGroupStyle to Node
+>	- Added CornerRadius dependency property to LineConnection, CircuitConnection and StepConnection
 > - Bugfixes:
 
 #### **Version 6.5.0**

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -178,22 +178,25 @@
         </Style>
 
         <DataTemplate x:Key="CircuitConnectionTemplate">
-            <nodify:CircuitConnection Angle="{Binding CircuitConnectionAngle, Source={x:Static local:EditorSettings.Instance}}"
-                                      Style="{StaticResource ConnectionStyle}" />
+            <nodify:CircuitConnection Style="{StaticResource ConnectionStyle}"
+                                      Angle="{Binding CircuitConnectionAngle, Source={x:Static local:EditorSettings.Instance}}"
+                                      CornerRadius="{Binding ConnectionCornerRadius, Source={x:Static local:EditorSettings.Instance}}" />
         </DataTemplate>
 
         <DataTemplate x:Key="StepConnectionTemplate">
             <nodify:StepConnection Style="{StaticResource ConnectionStyle}"
+                                   CornerRadius="{Binding ConnectionCornerRadius, Source={x:Static local:EditorSettings.Instance}}"
                                    SourcePosition="{Binding ., Converter={StaticResource FlowToConnectorPositionConverter}, ConverterParameter=Output}"
                                    TargetPosition="{Binding ., Converter={StaticResource FlowToConnectorPositionConverter}, ConverterParameter=Input}" />
         </DataTemplate>
 
-        <DataTemplate x:Key="ConnectionTemplate">
-            <nodify:Connection Style="{StaticResource ConnectionStyle}" />
+        <DataTemplate x:Key="LineConnectionTemplate">
+            <nodify:LineConnection Style="{StaticResource ConnectionStyle}"
+                                   CornerRadius="{Binding ConnectionCornerRadius, Source={x:Static local:EditorSettings.Instance}}" />
         </DataTemplate>
 
-        <DataTemplate x:Key="LineConnectionTemplate">
-            <nodify:LineConnection Style="{StaticResource ConnectionStyle}" />
+        <DataTemplate x:Key="ConnectionTemplate">
+            <nodify:Connection Style="{StaticResource ConnectionStyle}" />
         </DataTemplate>
 
         <ControlTemplate x:Key="SquareConnector"

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -127,6 +127,11 @@ namespace Nodify.Playground
                     "Connection angle: ",
                     "Applies to circuit connection style"),
                 new ProxySettingViewModel<double>(
+                    () => Instance.ConnectionCornerRadius,
+                    val => Instance.ConnectionCornerRadius = val,
+                    "Connection corner radius: ",
+                    "The corner radius between the line segments."),
+                new ProxySettingViewModel<double>(
                     () => Instance.ConnectionSpacing,
                     val => Instance.ConnectionSpacing = val,
                     "Connection spacing: ",
@@ -455,6 +460,13 @@ namespace Nodify.Playground
         {
             get => _circuitConnectionAngle;
             set => SetProperty(ref _circuitConnectionAngle, value);
+        }
+
+        private double _connectionCornerRadius = 10;
+        public double ConnectionCornerRadius
+        {
+            get => _connectionCornerRadius;
+            set => SetProperty(ref _connectionCornerRadius, value);
         }
 
         private double _connectionSpacing = 20;

--- a/Nodify/Connections/CircuitConnection.cs
+++ b/Nodify/Connections/CircuitConnection.cs
@@ -34,9 +34,18 @@ namespace Nodify
             var (p0, p1, p2) = GetLinePoints(source, target);
 
             context.BeginFigure(source, false, false);
-            context.LineTo(p0, true, true);
-            context.LineTo(p1, true, true);
-            context.LineTo(p2, true, true);
+            if (CornerRadius > 0)
+            {
+                AddSmoothCorner(context, source, p0, p1, CornerRadius);
+                AddSmoothCorner(context, p0, p1, p2, CornerRadius);
+                AddSmoothCorner(context, p1, p2, target, CornerRadius);
+            }
+            else
+            {
+                context.LineTo(p0, true, true);
+                context.LineTo(p1, true, true);
+                context.LineTo(p2, true, true);
+            }
             context.LineTo(target, true, true);
 
             if (Spacing < 1d)

--- a/Nodify/Connections/StepConnection.cs
+++ b/Nodify/Connections/StepConnection.cs
@@ -80,12 +80,14 @@ namespace Nodify
         {
             var (p0, p1, p2, p3) = GetLinePoints(source, target);
 
-            context.BeginFigure(source, false, false);
-            context.LineTo(p0, true, true);
-            context.LineTo(p1, true, true);
-            context.LineTo(p2, true, true);
-            context.LineTo(p3, true, true);
-            context.LineTo(target, true, true);
+            if (CornerRadius > 0)
+            {
+                DrawSmoothLine(context);
+            }
+            else
+            {
+                DrawDefaultLine(context);
+            }
 
             if (Spacing < 1d)
             {
@@ -93,6 +95,36 @@ namespace Nodify
             }
 
             return ((target, source), (source, target));
+
+            void DrawDefaultLine(StreamGeometryContext context)
+            {
+                context.BeginFigure(source, false, false);
+                context.LineTo(p0, true, true);
+                context.LineTo(p1, true, true);
+                context.LineTo(p2, true, true);
+                context.LineTo(p3, true, true);
+                context.LineTo(target, true, true);
+            }
+
+            void DrawSmoothLine(StreamGeometryContext context)
+            {
+                context.BeginFigure(source, false, false);
+                AddSmoothCorner(context, source, p0, p1, CornerRadius);
+
+                if (p1 == p2)
+                {
+                    // skip p1 or p2 because they overlap
+                    AddSmoothCorner(context, p0, p1, p3, CornerRadius);
+                }
+                else
+                {
+                    AddSmoothCorner(context, p0, p1, p2, CornerRadius);
+                    AddSmoothCorner(context, p1, p2, p3, CornerRadius);
+                }
+
+                AddSmoothCorner(context, p2, p3, target, CornerRadius);
+                context.LineTo(target, true, true);
+            }
         }
 
         protected override Point GetTextPosition(FormattedText text, Point source, Point target)


### PR DESCRIPTION
### 📝 Description of the Change

Added `CornerRadius` to Line, Circuit and Step connections to allow smoothing the corners between line segments. Also added a `Connection Corner Radius` setting in the Playground app.

![image](https://github.com/user-attachments/assets/ebae3c01-145c-43f4-aa27-445e6771f341)

Closes #148

### 🐛 Possible Drawbacks

Directional arrows will not interpolate correctly (may not be noticeable with a small radius).
May have a small impact on performance when `CornerRadius` is greater than 0.