### PR TITLE
Move all items relative to the cursor by performing a drag gesture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 > - Features:
 >	- Added InputGroupStyle and OutputGroupStyle to Node
 >	- Added CornerRadius dependency property to LineConnection, CircuitConnection and StepConnection
+>	- Added EditorGestures.Editor.PushItems gesture used to start pushing ItemContainers vertically or horizontally
+>	- Added PushedAreaStyle, PushedAreaOrientation and IsPushingItems dependency properties to NodifyEditor
+>	- Added NodifyEditor.SnapToGrid utility function
 > - Bugfixes:
 
 #### **Version 6.5.0**

--- a/Nodify/Connections/ConnectionsMultiSelector.cs
+++ b/Nodify/Connections/ConnectionsMultiSelector.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Controls;
@@ -43,18 +42,6 @@ namespace Nodify
         {
             get => base.CanSelectMultipleItems;
             set => base.CanSelectMultipleItems = value;
-        }
-
-        /// <summary>
-        /// The <see cref="NodifyEditor"/> that owns this <see cref="ConnectionsMultiSelector"/>.
-        /// </summary>
-        public NodifyEditor Editor { get; private set; } = default!;
-
-        public override void OnApplyTemplate()
-        {
-            base.OnApplyTemplate();
-
-            Editor = this.GetParentOfType<NodifyEditor>() ?? throw new NotSupportedException($"{nameof(ConnectionsMultiSelector)} cannot be used outside the {nameof(NodifyEditor)}");
         }
 
         protected override DependencyObject GetContainerForItemOverride()

--- a/Nodify/EditorGestures.cs
+++ b/Nodify/EditorGestures.cs
@@ -111,6 +111,7 @@ namespace Nodify
             {
                 Selection = new SelectionGestures();
                 Cutting = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Alt | ModifierKeys.Shift);
+                PushItems = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Control | ModifierKeys.Shift);
                 Pan = new AnyGesture(new MouseGesture(MouseAction.RightClick), new MouseGesture(MouseAction.MiddleClick));
                 ZoomModifierKey = ModifierKeys.None;
                 ZoomIn = new MultiGesture(MultiGesture.Match.Any, new KeyGesture(Key.OemPlus, ModifierKeys.Control), new KeyGesture(Key.Add, ModifierKeys.Control));
@@ -129,6 +130,10 @@ namespace Nodify
             /// <summary>Gesture used to start panning.</summary>
             /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or <see cref="MouseAction.MiddleClick"/>.</remarks>
             public InputGestureRef Pan { get; }
+
+            /// <summary>Gesture used to start pushing.</summary>
+            /// <remarks>Defaults to <see cref="ModifierKeys.Control"/>+<see cref="ModifierKeys.Shift"/>+<see cref="MouseAction.LeftClick"/>.</remarks>
+            public InputGestureRef PushItems { get; }
 
             /// <summary>The key modifier required to start zooming by mouse wheel.</summary>
             /// <remarks>Defaults to <see cref="ModifierKeys.None"/>.</remarks>
@@ -167,6 +172,7 @@ namespace Nodify
                 ResetViewportLocation.Value = gestures.ResetViewportLocation.Value;
                 FitToScreen.Value = gestures.FitToScreen.Value;
                 CancelAction.Value = gestures.CancelAction.Value;
+                PushItems.Value = gestures.PushItems.Value;
             }
         }
 

--- a/Nodify/EditorStates/EditorDefaultState.cs
+++ b/Nodify/EditorStates/EditorDefaultState.cs
@@ -35,6 +35,10 @@ namespace Nodify
             {
                 PushState(new EditorCuttingState(Editor));
             }
+            else if (gestures.PushItems.Matches(e.Source, e))
+            {
+                PushState(new EditorPushingItemsState(Editor));
+            }
             else if (gestures.Selection.Select.Matches(e.Source, e))
             {
                 SelectionType selectionType = GetSelectionType(e);

--- a/Nodify/EditorStates/EditorPushingItemsState.cs
+++ b/Nodify/EditorStates/EditorPushingItemsState.cs
@@ -1,0 +1,58 @@
+﻿using System.Windows.Input;
+
+namespace Nodify
+{
+    public class EditorPushingItemsState : EditorState
+    {
+        private double _prevLocationX;
+        public bool Canceled { get; set; } = NodifyEditor.AllowPushItemsCancellation;
+
+        public EditorPushingItemsState(NodifyEditor editor) : base(editor)
+        {
+        }
+
+        public override void Enter(EditorState? from)
+        {
+            Canceled = false;
+
+            Editor.StartPushingItems(Editor.MouseLocation);
+            _prevLocationX = Editor.MouseLocation.X;
+        }
+
+        public override void Exit()
+        {
+            if (Canceled)
+            {
+                Editor.CancelPushingItems();
+            }
+            else
+            {
+                Editor.EndPushingItems(Editor.MouseLocation);
+            }
+        }
+
+        public override void HandleMouseMove(MouseEventArgs e)
+        {
+            var offset = Editor.MouseLocation.X - _prevLocationX;
+            _prevLocationX = Editor.MouseLocation.X;
+
+            Editor.PushItems(offset);
+        }
+
+        public override void HandleMouseUp(MouseButtonEventArgs e)
+        {
+            EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
+            if (gestures.PushItems.Matches(e.Source, e))
+            {
+                PopState();
+            }
+            else if (NodifyEditor.AllowPushItemsCancellation && gestures.CancelAction.Matches(e.Source, e))
+            {
+                Canceled = true;
+                e.Handled = true;   // prevents opening context menu
+
+                PopState();
+            }
+        }
+    }
+}

--- a/Nodify/Helpers/DraggingOptimized.cs
+++ b/Nodify/Helpers/DraggingOptimized.cs
@@ -10,17 +10,17 @@ namespace Nodify
     /// </summary>
     internal class DraggingOptimized : IDraggingStrategy
     {
-        private readonly NodifyEditor _editor;
-        private Vector _dragAccumulator;
+        private readonly uint _gridCellSize;
         private readonly List<ItemContainer> _selectedContainers;
+        private Vector _dragAccumulator = new Vector(0, 0);
 
-        public DraggingOptimized(NodifyEditor editor)
+        public DraggingOptimized(IEnumerable<ItemContainer> containers, uint gridCellSize)
         {
-            _editor = editor;
-            _selectedContainers = _editor.SelectedContainers.Where(c => c.IsDraggable).ToList();
+            _gridCellSize = gridCellSize;
+            _selectedContainers = containers.Where(c => c.IsDraggable).ToList();
         }
 
-        public void Abort(Vector change)
+        public void Abort()
         {
             for (var i = 0; i < _selectedContainers.Count; i++)
             {
@@ -36,7 +36,7 @@ namespace Nodify
             _selectedContainers.Clear();
         }
 
-        public void End(Vector change)
+        public void End()
         {
             for (var i = 0; i < _selectedContainers.Count; i++)
             {
@@ -48,8 +48,8 @@ namespace Nodify
                 // Correct the final position
                 if (NodifyEditor.EnableSnappingCorrection && (r.X != 0 || r.Y != 0))
                 {
-                    result.X = (int)result.X / _editor.GridCellSize * _editor.GridCellSize;
-                    result.Y = (int)result.Y / _editor.GridCellSize * _editor.GridCellSize;
+                    result.X = (int)result.X / _gridCellSize * _gridCellSize;
+                    result.Y = (int)result.Y / _gridCellSize * _gridCellSize;
                 }
 
                 container.Location = result;
@@ -61,15 +61,10 @@ namespace Nodify
             _selectedContainers.Clear();
         }
 
-        public void Start(Vector change)
-        {
-            _dragAccumulator = new Vector(0, 0);
-        }
-
         public void Update(Vector change)
         {
             _dragAccumulator += change;
-            var delta = new Vector((int)_dragAccumulator.X / _editor.GridCellSize * _editor.GridCellSize, (int)_dragAccumulator.Y / _editor.GridCellSize * _editor.GridCellSize);
+            var delta = new Vector((int)_dragAccumulator.X / _gridCellSize * _gridCellSize, (int)_dragAccumulator.Y / _gridCellSize * _gridCellSize);
             _dragAccumulator -= delta;
 
             if (delta.X != 0 || delta.Y != 0)

--- a/Nodify/Helpers/DraggingOptimized.cs
+++ b/Nodify/Helpers/DraggingOptimized.cs
@@ -8,7 +8,7 @@ namespace Nodify
     /// <summary>
     /// Commits the position changes at the end of the operation. Updates the RenderTransform to preview the container position.
     /// </summary>
-    internal class DraggingOptimized : IDraggingStrategy
+    internal sealed class DraggingOptimized : IDraggingStrategy
     {
         private readonly uint _gridCellSize;
         private readonly List<ItemContainer> _selectedContainers;

--- a/Nodify/Helpers/DraggingSimple.cs
+++ b/Nodify/Helpers/DraggingSimple.cs
@@ -11,7 +11,7 @@ namespace Nodify
         void Abort();
     }
 
-    internal class DraggingSimple : IDraggingStrategy
+    internal sealed class DraggingSimple : IDraggingStrategy
     {
         private readonly uint _gridCellSize;
         private readonly List<ItemContainer> _selectedContainers;

--- a/Nodify/Helpers/DraggingSimple.cs
+++ b/Nodify/Helpers/DraggingSimple.cs
@@ -6,26 +6,25 @@ namespace Nodify
 {
     internal interface IDraggingStrategy
     {
-        void Start(Vector change);
         void Update(Vector change);
-        void End(Vector change);
-        void Abort(Vector change);
+        void End();
+        void Abort();
     }
 
     internal class DraggingSimple : IDraggingStrategy
     {
-        private readonly NodifyEditor _editor;
-        private Vector _dragOffset;
-        private Vector _dragAccumulator;
-        private readonly IList<ItemContainer> _selectedContainers;
+        private readonly uint _gridCellSize;
+        private readonly List<ItemContainer> _selectedContainers;
+        private Vector _dragOffset = new Vector(0, 0);
+        private Vector _dragAccumulator = new Vector(0, 0);
 
-        public DraggingSimple(NodifyEditor editor)
+        public DraggingSimple(IEnumerable<ItemContainer> containers, uint gridCellSize)
         {
-            _editor = editor;
-            _selectedContainers = _editor.SelectedContainers.Where(c => c.IsDraggable).ToList();
+            _gridCellSize = gridCellSize;
+            _selectedContainers = containers.Where(c => c.IsDraggable).ToList();
         }
 
-        public void Abort(Vector change)
+        public void Abort()
         {
             for (var i = 0; i < _selectedContainers.Count; i++)
             {
@@ -36,7 +35,7 @@ namespace Nodify
             _selectedContainers.Clear();
         }
 
-        public void End(Vector change)
+        public void End()
         {
             for (var i = 0; i < _selectedContainers.Count; i++)
             {
@@ -46,8 +45,8 @@ namespace Nodify
                 // Correct the final position
                 if (NodifyEditor.EnableSnappingCorrection)
                 {
-                    result.X = (int)result.X / _editor.GridCellSize * _editor.GridCellSize;
-                    result.Y = (int)result.Y / _editor.GridCellSize * _editor.GridCellSize;
+                    result.X = (int)result.X / _gridCellSize * _gridCellSize;
+                    result.Y = (int)result.Y / _gridCellSize * _gridCellSize;
                 }
 
                 container.Location = result;
@@ -56,16 +55,10 @@ namespace Nodify
             _selectedContainers.Clear();
         }
 
-        public void Start(Vector change)
-        {
-            _dragOffset = new Vector(0, 0);
-            _dragAccumulator = new Vector(0, 0);
-        }
-
         public void Update(Vector change)
         {
             _dragAccumulator += change;
-            var delta = new Vector((int)_dragAccumulator.X / _editor.GridCellSize * _editor.GridCellSize, (int)_dragAccumulator.Y / _editor.GridCellSize * _editor.GridCellSize);
+            var delta = new Vector((int)_dragAccumulator.X / _gridCellSize * _gridCellSize, (int)_dragAccumulator.Y / _gridCellSize * _gridCellSize);
             _dragAccumulator -= delta;
 
             if (delta.X != 0 || delta.Y != 0)

--- a/Nodify/Helpers/PushItemsStrategy.cs
+++ b/Nodify/Helpers/PushItemsStrategy.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Linq;
+using System.Windows;
+
+namespace Nodify
+{
+    internal interface IPushStrategy
+    {
+        void Start(Point position);
+        void Push(Vector offset);
+        void End();
+        void Cancel();
+        void OnViewportChanged();
+    }
+
+    internal class HorizontalPushStrategy : IPushStrategy
+    {
+        private const int _offscreenOffsetY = 100;
+        private const int _minWidth = 2;
+        private double _initialPosition;
+        private double _actualWidth;
+
+        private readonly NodifyEditor _editor;
+        private IDraggingStrategy? _draggingStrategy;
+
+        public HorizontalPushStrategy(NodifyEditor editor)
+        {
+            _editor = editor;
+        }
+
+        public void Start(Point position)
+        {
+            _draggingStrategy = _editor.CreateDraggingStrategy(_editor.ItemContainers.Where(item => item.Location.X >= position.X));
+
+            _initialPosition = position.X;
+            _actualWidth = 0;
+            _editor.PushedArea = new Rect(position.X, _editor.ViewportLocation.Y - _offscreenOffsetY, 0d, _editor.ViewportSize.Height + _offscreenOffsetY * 2);
+        }
+
+        public void Push(Vector offset)
+        {
+            _draggingStrategy?.Update(new Vector(offset.X, 0));
+
+            _actualWidth += offset.X;
+
+            double newStart = _actualWidth >= 0 ? _initialPosition : _editor.SnapToGrid(_initialPosition + _actualWidth);
+            double newWidth = Math.Max(_minWidth, _editor.SnapToGrid(_actualWidth));
+
+            _editor.PushedArea = new Rect(newStart, _editor.ViewportLocation.Y - _offscreenOffsetY, newWidth, _editor.ViewportSize.Height + _offscreenOffsetY * 2);
+        }
+
+        public void End()
+        {
+            _draggingStrategy?.End();
+        }
+
+        public void Cancel()
+        {
+            _draggingStrategy?.Abort();
+        }
+
+        public void OnViewportChanged()
+        {
+            _editor.PushedArea = new Rect(_editor.PushedArea.X, _editor.ViewportLocation.Y - _offscreenOffsetY, _editor.PushedArea.Width, _editor.ViewportSize.Height + _offscreenOffsetY * 2);
+        }
+    }
+
+    internal class VerticalPushStrategy : IPushStrategy
+    {
+        private const int _offscreenOffsetX = 100;
+        private const int _minHeight = 2;
+        private double _initialPosition;
+        private double _actualHeight;
+
+        private readonly NodifyEditor _editor;
+        private IDraggingStrategy? _draggingStrategy;
+
+        public VerticalPushStrategy(NodifyEditor editor)
+        {
+            _editor = editor;
+        }
+
+        public void Start(Point position)
+        {
+            _draggingStrategy = _editor.CreateDraggingStrategy(_editor.ItemContainers.Where(item => item.Location.Y >= position.Y));
+
+            _initialPosition = position.Y;
+            _actualHeight = 0;
+            _editor.PushedArea = new Rect(_editor.ViewportLocation.X - _offscreenOffsetX, position.Y, _editor.ViewportSize.Width + _offscreenOffsetX * 2, 0d);
+        }
+
+        public void Push(Vector offset)
+        {
+            _draggingStrategy?.Update(new Vector(0, offset.Y));
+
+            _actualHeight += offset.Y;
+
+            double newStart = _actualHeight >= 0 ? _initialPosition : _editor.SnapToGrid(_initialPosition + _actualHeight);
+            double newHeight = Math.Max(_minHeight, _editor.SnapToGrid(_actualHeight));
+
+            _editor.PushedArea = new Rect(_editor.ViewportLocation.X - _offscreenOffsetX, newStart, _editor.ViewportSize.Width + _offscreenOffsetX * 2, newHeight);
+        }
+
+        public void End()
+        {
+            _draggingStrategy?.End();
+        }
+
+        public void Cancel()
+        {
+            _draggingStrategy?.Abort();
+        }
+
+        public void OnViewportChanged()
+        {
+            _editor.PushedArea = new Rect(_editor.ViewportLocation.X - _offscreenOffsetX, _editor.PushedArea.Y, _editor.ViewportSize.Width + _offscreenOffsetX * 2, _editor.PushedArea.Height);
+        }
+    }
+}

--- a/Nodify/NodifyEditor.PushingItems.cs
+++ b/Nodify/NodifyEditor.PushingItems.cs
@@ -52,7 +52,7 @@ namespace Nodify
         public Rect PushedArea
         {
             get => (Rect)GetValue(PushedAreaProperty);
-            internal set => SetValue(PushedAreaPropertyKey, value);
+            private set => SetValue(PushedAreaPropertyKey, value);
         }
 
         /// <summary>
@@ -94,16 +94,9 @@ namespace Nodify
             IsPushingItems = true;
             PushedAreaOrientation = orientation;
 
-            if (orientation == Orientation.Horizontal)
-            {
-                _pushStrategy = new HorizontalPushStrategy(this);
-            }
-            else
-            {
-                _pushStrategy = new VerticalPushStrategy(this);
-            }
+            _pushStrategy = CreatePushStrategy(orientation);
 
-            _pushStrategy.Start(position);
+            PushedArea = _pushStrategy.Start(position);
         }
 
         protected internal void CancelPushingItems()
@@ -114,17 +107,15 @@ namespace Nodify
             Debug.Assert(IsPushingItems);
             if (IsPushingItems)
             {
-                _pushStrategy?.Cancel();
+                PushedArea = _pushStrategy!.Cancel();
                 IsPushingItems = false;
             }
         }
 
         protected internal void PushItems(Vector offset)
         {
-            if (IsPushingItems)
-            {
-                _pushStrategy?.Push(offset);
-            }
+            Debug.Assert(IsPushingItems);
+            PushedArea = _pushStrategy!.Push(offset);
         }
 
         protected internal void EndPushingItems()
@@ -132,7 +123,8 @@ namespace Nodify
             Debug.Assert(IsPushingItems);
             if (IsPushingItems)
             {
-                _pushStrategy?.End();
+                PushedArea = _pushStrategy!.End();
+                _pushStrategy = null;
                 IsPushingItems = false;
             }
         }
@@ -141,8 +133,18 @@ namespace Nodify
         {
             if (IsPushingItems)
             {
-                _pushStrategy?.OnViewportChanged();
+                PushedArea = _pushStrategy!.OnViewportChanged();
             }
+        }
+
+        private IPushStrategy CreatePushStrategy(Orientation orientation)
+        {
+            if (orientation == Orientation.Horizontal)
+            {
+                return new HorizontalPushStrategy(this);
+            }
+
+            return new VerticalPushStrategy(this);
         }
     }
 }

--- a/Nodify/NodifyEditor.PushingItems.cs
+++ b/Nodify/NodifyEditor.PushingItems.cs
@@ -17,8 +17,8 @@ namespace Nodify
         protected static readonly DependencyPropertyKey IsPushingItemsPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsPushingItems), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False, OnIsPushingItemsChanged));
         public static readonly DependencyProperty IsPushingItemsProperty = IsPushingItemsPropertyKey.DependencyProperty;
 
-        protected static readonly DependencyPropertyKey PushOrientationPropertyKey = DependencyProperty.RegisterReadOnly(nameof(PushOrientation), typeof(Orientation), typeof(NodifyEditor), new FrameworkPropertyMetadata(Orientation.Horizontal));
-        public static readonly DependencyProperty PushOrientationProperty = PushOrientationPropertyKey.DependencyProperty;
+        protected static readonly DependencyPropertyKey PushedAreaOrientationPropertyKey = DependencyProperty.RegisterReadOnly(nameof(PushedAreaOrientation), typeof(Orientation), typeof(NodifyEditor), new FrameworkPropertyMetadata(Orientation.Horizontal));
+        public static readonly DependencyProperty PushedAreaOrientationProperty = PushedAreaOrientationPropertyKey.DependencyProperty;
 
         private static void OnIsPushingItemsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -67,10 +67,10 @@ namespace Nodify
         /// <summary>
         /// Gets the orientation of the <see cref="PushedArea"/>.
         /// </summary>
-        public Orientation PushOrientation
+        public Orientation PushedAreaOrientation
         {
-            get => (Orientation)GetValue(PushOrientationProperty);
-            private set => SetValue(PushOrientationPropertyKey, value);
+            get => (Orientation)GetValue(PushedAreaOrientationProperty);
+            private set => SetValue(PushedAreaOrientationPropertyKey, value);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace Nodify
         protected internal void StartPushingItems(Point position, Orientation orientation)
         {
             IsPushingItems = true;
-            PushOrientation = orientation;
+            PushedAreaOrientation = orientation;
 
             if (orientation == Orientation.Horizontal)
             {

--- a/Nodify/NodifyEditor.PushingItems.cs
+++ b/Nodify/NodifyEditor.PushingItems.cs
@@ -1,0 +1,138 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using System.Windows;
+using System;
+using System.Windows.Controls;
+
+namespace Nodify
+{
+    [StyleTypedProperty(Property = nameof(PushedAreaStyle), StyleTargetType = typeof(Border))]
+    public partial class NodifyEditor
+    {
+        public static readonly DependencyProperty PushedAreaStyleProperty = DependencyProperty.Register(nameof(PushedAreaStyle), typeof(Style), typeof(NodifyEditor));
+
+        protected static readonly DependencyPropertyKey PushedAreaPropertyKey = DependencyProperty.RegisterReadOnly(nameof(PushedArea), typeof(Rect), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Rect));
+        public static readonly DependencyProperty PushedAreaProperty = PushedAreaPropertyKey.DependencyProperty;
+
+        protected static readonly DependencyPropertyKey IsPushingItemsPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsPushingItems), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False, OnIsPushingItemsChanged));
+        public static readonly DependencyProperty IsPushingItemsProperty = IsPushingItemsPropertyKey.DependencyProperty;
+
+        private static void OnIsPushingItemsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var editor = (NodifyEditor)d;
+
+            if ((bool)e.NewValue == true)
+            {
+                editor.OnItemsPushStarted();
+            }
+            else
+            {
+                editor.OnItemsPushCompleted();
+            }
+        }
+
+        private void OnItemsPushCompleted()
+        {
+            if (ItemsDragCompletedCommand?.CanExecute(DataContext) ?? false)
+                ItemsDragCompletedCommand.Execute(DataContext);
+        }
+
+        private void OnItemsPushStarted()
+        {
+            if (ItemsDragStartedCommand?.CanExecute(DataContext) ?? false)
+                ItemsDragStartedCommand.Execute(DataContext);
+        }
+
+        /// <summary>
+        /// Gets the currently pushed area while <see cref="IsPushingItems"/> is true.
+        /// </summary>
+        public Rect PushedArea
+        {
+            get => (Rect)GetValue(PushedAreaProperty);
+            internal set => SetValue(PushedAreaPropertyKey, value);
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether a pushing operation is in progress.
+        /// </summary>
+        public bool IsPushingItems
+        {
+            get => (bool)GetValue(IsPushingItemsProperty);
+            internal set => SetValue(IsPushingItemsPropertyKey, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the style to use for the pushed area.
+        /// </summary>
+        public Style PushedAreaStyle
+        {
+            get => (Style)GetValue(PushedAreaStyleProperty);
+            set => SetValue(PushedAreaStyleProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether push items cancellation is allowed.
+        /// </summary>
+        public static bool AllowPushItemsCancellation { get; set; } = true;
+
+        private const int _pushAreaOffscreenOffsetY = 100;
+        private const int _pushAreaMinWidth = 2;
+        private double _pushAreaInitialX;
+        private double _pushedAreaWidth;
+
+        protected internal void StartPushingItems(Point location)
+        {
+            IsPushingItems = true;
+            PushedArea = new Rect(location.X, ViewportLocation.Y, 0d, ViewportSize.Height);
+
+            _draggingStrategy = CreateDraggingStrategy(ItemContainers.Where(item => item.Location.X >= location.X));
+            _pushAreaInitialX = PushedArea.X;
+            _pushedAreaWidth = 0;
+        }
+
+        protected internal void CancelPushingItems()
+        {
+            if (!AllowPushItemsCancellation)
+                throw new InvalidOperationException("Push items cancellation is not allowed");
+
+            Debug.Assert(IsPushingItems);
+            if (IsPushingItems)
+            {
+                _draggingStrategy?.Abort();
+                IsPushingItems = false;
+            }
+        }
+
+        protected internal void PushItems(double offset)
+        {
+            if (IsPushingItems)
+            {
+                _draggingStrategy?.Update(new Vector(offset, 0));
+                _pushedAreaWidth += offset;
+
+                double newStart = _pushedAreaWidth >= 0 ? _pushAreaInitialX : SnapToGrid(_pushAreaInitialX + _pushedAreaWidth);
+                double newWidth = Math.Max(_pushAreaMinWidth, SnapToGrid(_pushedAreaWidth));
+
+                PushedArea = new Rect(newStart, ViewportLocation.Y - _pushAreaOffscreenOffsetY, newWidth, ViewportSize.Height + _pushAreaOffscreenOffsetY * 2);
+            }
+        }
+
+        protected internal void EndPushingItems(Point location)
+        {
+            Debug.Assert(IsPushingItems);
+            if (IsPushingItems)
+            {
+                _draggingStrategy?.End();
+                IsPushingItems = false;
+            }
+        }
+
+        private void UpdatePushedArea()
+        {
+            if (IsPushingItems)
+            {
+                PushedArea = new Rect(PushedArea.X, ViewportLocation.Y - _pushAreaOffscreenOffsetY, PushedArea.Width, ViewportSize.Height + _pushAreaOffscreenOffsetY * 2);
+            }
+        }
+    }
+}

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -813,7 +813,7 @@ namespace Nodify
         public static bool EnableCuttingLinePreview { get; set; } = false;
 
         /// <summary>
-        /// The list of supported connection types for cutting. Type must be derived from <see cref="FrameworkElement">.
+        /// The list of supported connection types for cutting. Type must be derived from <see cref="FrameworkElement" />.
         /// </summary>
         public static readonly HashSet<Type> CuttingConnectionTypes = new HashSet<Type>();
 

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -1560,7 +1560,7 @@ namespace Nodify
             }
         }
 
-        private IDraggingStrategy CreateDraggingStrategy(IEnumerable<ItemContainer> containers)
+        internal IDraggingStrategy CreateDraggingStrategy(IEnumerable<ItemContainer> containers)
         {
             if (EnableDraggingContainersOptimizations)
             {

--- a/Nodify/Themes/Brushes.xaml
+++ b/Nodify/Themes/Brushes.xaml
@@ -21,7 +21,7 @@
                      Opacity="0.1"
                      Color="{DynamicResource NodifyEditor.SelectionRectangleColor}" />
 
-    <SolidColorBrush x:Key="NodifyEditor.PushedAreaBorderBrush"
+    <SolidColorBrush x:Key="NodifyEditor.PushedAreaStrokeBrush"
                      o:Freeze="True"
                      Color="{DynamicResource NodifyEditor.PushedAreaColor}" />
 

--- a/Nodify/Themes/Brushes.xaml
+++ b/Nodify/Themes/Brushes.xaml
@@ -21,6 +21,15 @@
                      Opacity="0.1"
                      Color="{DynamicResource NodifyEditor.SelectionRectangleColor}" />
 
+    <SolidColorBrush x:Key="NodifyEditor.PushedAreaBorderBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource NodifyEditor.PushedAreaColor}" />
+
+    <SolidColorBrush x:Key="NodifyEditor.PushedAreaBackgroundBrush"
+                     o:Freeze="True"
+                     Opacity="0.2"
+                     Color="{DynamicResource NodifyEditor.PushedAreaColor}" />
+
     <SolidColorBrush x:Key="NodifyEditor.CuttingLineStrokeBrush"
                      o:Freeze="True"
                      Color="{DynamicResource NodifyEditor.CuttingLineColor}" />

--- a/Nodify/Themes/Controls.xaml
+++ b/Nodify/Themes/Controls.xaml
@@ -10,12 +10,22 @@
 
     <Style x:Key="NodifyEditor.SelectionRectangleStyle"
            TargetType="Rectangle">
-        <Setter Property="Stroke"
-                Value="{StaticResource NodifyEditor.SelectionRectangleStrokeBrush}" />
         <Setter Property="StrokeThickness"
                 Value="1" />
+        <Setter Property="Stroke"
+                Value="{StaticResource NodifyEditor.SelectionRectangleStrokeBrush}" />
         <Setter Property="Fill"
                 Value="{StaticResource NodifyEditor.SelectionRectangleBackgroundBrush}" />
+    </Style>
+
+    <Style x:Key="NodifyEditor.PushedAreaStyle"
+           TargetType="Border">
+        <Setter Property="BorderThickness"
+                Value="2 0 0 0" />
+        <Setter Property="BorderBrush"
+                Value="{DynamicResource NodifyEditor.PushedAreaBorderBrush}" />
+        <Setter Property="Background"
+                Value="{StaticResource NodifyEditor.PushedAreaBackgroundBrush}" />
     </Style>
 
     <Style TargetType="{x:Type local:NodifyEditor}"
@@ -26,6 +36,8 @@
                 Value="{StaticResource NodifyEditor.ForegroundBrush}" />
         <Setter Property="SelectionRectangleStyle"
                 Value="{StaticResource NodifyEditor.SelectionRectangleStyle}" />
+        <Setter Property="PushedAreaStyle"
+                Value="{StaticResource NodifyEditor.PushedAreaStyle}" />
     </Style>
 
     <!--ITEM CONTAINER-->
@@ -35,7 +47,7 @@
         <Setter Property="HighlightBrush"
                 Value="{StaticResource ItemContainer.HighlightBrush}" />
         <Setter Property="BorderBrush"
-                Value="{StaticResource ItemContainer.BorderBrush}" />
+                Value="{DynamicResource ItemContainer.BorderBrush}" />
         <Setter Property="SelectedBrush"
                 Value="{StaticResource ItemContainer.SelectedBrush}" />
     </Style>

--- a/Nodify/Themes/Controls.xaml
+++ b/Nodify/Themes/Controls.xaml
@@ -23,7 +23,7 @@
         <Setter Property="StrokeThickness"
                 Value="1" />
         <Setter Property="Stroke"
-                Value="{DynamicResource NodifyEditor.PushedAreaStrokeBrush}" />
+                Value="{StaticResource NodifyEditor.PushedAreaStrokeBrush}" />
         <Setter Property="Fill"
                 Value="{StaticResource NodifyEditor.PushedAreaBackgroundBrush}" />
     </Style>
@@ -47,7 +47,7 @@
         <Setter Property="HighlightBrush"
                 Value="{StaticResource ItemContainer.HighlightBrush}" />
         <Setter Property="BorderBrush"
-                Value="{DynamicResource ItemContainer.BorderBrush}" />
+                Value="{StaticResource ItemContainer.BorderBrush}" />
         <Setter Property="SelectedBrush"
                 Value="{StaticResource ItemContainer.SelectedBrush}" />
     </Style>

--- a/Nodify/Themes/Controls.xaml
+++ b/Nodify/Themes/Controls.xaml
@@ -19,12 +19,12 @@
     </Style>
 
     <Style x:Key="NodifyEditor.PushedAreaStyle"
-           TargetType="Border">
-        <Setter Property="BorderThickness"
-                Value="2 0 0 0" />
-        <Setter Property="BorderBrush"
-                Value="{DynamicResource NodifyEditor.PushedAreaBorderBrush}" />
-        <Setter Property="Background"
+           TargetType="Rectangle">
+        <Setter Property="StrokeThickness"
+                Value="1" />
+        <Setter Property="Stroke"
+                Value="{DynamicResource NodifyEditor.PushedAreaStrokeBrush}" />
+        <Setter Property="Fill"
                 Value="{StaticResource NodifyEditor.PushedAreaBackgroundBrush}" />
     </Style>
 

--- a/Nodify/Themes/Dark.xaml
+++ b/Nodify/Themes/Dark.xaml
@@ -10,6 +10,7 @@
     <Color x:Key="NodifyEditor.BackgroundColor">#1E1E1E</Color>
     <Color x:Key="NodifyEditor.ForegroundColor">White</Color>
     <Color x:Key="NodifyEditor.SelectionRectangleColor">DodgerBlue</Color>
+    <Color x:Key="NodifyEditor.PushedAreaColor">#74747c</Color>
     <Color x:Key="NodifyEditor.CuttingLineColor">Red</Color>
 
     <!--ITEM CONTAINER-->

--- a/Nodify/Themes/Light.xaml
+++ b/Nodify/Themes/Light.xaml
@@ -10,6 +10,7 @@
     <Color x:Key="NodifyEditor.BackgroundColor">White</Color>
     <Color x:Key="NodifyEditor.ForegroundColor">Black</Color>
     <Color x:Key="NodifyEditor.SelectionRectangleColor">DodgerBlue</Color>
+    <Color x:Key="NodifyEditor.PushedAreaColor">#5c6a98</Color>
     <Color x:Key="NodifyEditor.CuttingLineColor">Red</Color>
 
     <!--ITEM CONTAINER-->

--- a/Nodify/Themes/Nodify.xaml
+++ b/Nodify/Themes/Nodify.xaml
@@ -10,6 +10,7 @@
     <Color x:Key="NodifyEditor.BackgroundColor">#332155</Color>
     <Color x:Key="NodifyEditor.ForegroundColor">#E8E1F3</Color>
     <Color x:Key="NodifyEditor.SelectionRectangleColor">#FD5618</Color>
+    <Color x:Key="NodifyEditor.PushedAreaColor">#9b44dd</Color>
     <Color x:Key="NodifyEditor.CuttingLineColor">Red</Color>
 
     <!--ITEM CONTAINER-->

--- a/Nodify/Themes/Styles/NodifyEditor.xaml
+++ b/Nodify/Themes/Styles/NodifyEditor.xaml
@@ -192,7 +192,7 @@
                 <MultiTrigger.Conditions>
                     <Condition Property="IsPushingItems"
                                Value="True" />
-                    <Condition Property="PushOrientation"
+                    <Condition Property="PushedAreaOrientation"
                                Value="Horizontal" />
                 </MultiTrigger.Conditions>
                 <Setter Property="Cursor"
@@ -202,7 +202,7 @@
                 <MultiTrigger.Conditions>
                     <Condition Property="IsPushingItems"
                                Value="True" />
-                    <Condition Property="PushOrientation"
+                    <Condition Property="PushedAreaOrientation"
                                Value="Vertical" />
                 </MultiTrigger.Conditions>
                 <Setter Property="Cursor"

--- a/Nodify/Themes/Styles/NodifyEditor.xaml
+++ b/Nodify/Themes/Styles/NodifyEditor.xaml
@@ -29,6 +29,20 @@
         </Setter>
     </Style>
 
+    <Style x:Key="PushedAreaStyle"
+           TargetType="Border">
+        <Setter Property="BorderBrush"
+                Value="#74747c" />
+        <Setter Property="BorderThickness"
+                Value="2 0 0 0" />
+        <Setter Property="Background">
+            <Setter.Value>
+                <SolidColorBrush Opacity="0.2"
+                                 Color="#74747c" />
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style TargetType="{x:Type local:NodifyEditor}">
         <Setter Property="ClipToBounds"
                 Value="True" />
@@ -44,6 +58,8 @@
                 Value="False" />
         <Setter Property="SelectionRectangleStyle"
                 Value="{StaticResource SelectionRectangleStyle}" />
+        <Setter Property="PushedAreaStyle"
+                Value="{StaticResource PushedAreaStyle}" />
         <Setter Property="ConnectionTemplate"
                 Value="{StaticResource ConnectionTemplate}" />
         <Setter Property="PendingConnectionTemplate"
@@ -111,6 +127,29 @@
                                 </Rectangle.Height>
                             </Rectangle>
 
+                            <Border Style="{TemplateBinding PushedAreaStyle}"
+                                    RenderTransform="{Binding ViewportTransform, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource UnscaleTransformConverter}}"
+                                    Canvas.Top="{Binding PushedArea.Y, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Canvas.Left="{Binding PushedArea.X, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Visibility="{TemplateBinding IsPushingItems, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <Border.Width>
+                                    <MultiBinding Converter="{StaticResource ScaleDoubleConverter}">
+                                        <Binding Path="PushedArea.Width"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Path="ViewportZoom"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                    </MultiBinding>
+                                </Border.Width>
+                                <Border.Height>
+                                    <MultiBinding Converter="{StaticResource ScaleDoubleConverter}">
+                                        <Binding Path="PushedArea.Height"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Path="ViewportZoom"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                    </MultiBinding>
+                                </Border.Height>
+                            </Border>
+
                             <local:CuttingLine Style="{TemplateBinding CuttingLineStyle}"
                                                Visibility="{TemplateBinding IsCutting, Converter={StaticResource BooleanToVisibilityConverter}}"
                                                RenderTransform="{Binding ViewportTransform, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource UnscaleTransformConverter}}">
@@ -147,6 +186,14 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+
+        <Style.Triggers>
+            <Trigger Property="IsPushingItems"
+                     Value="True">
+                <Setter Property="Cursor"
+                        Value="SizeWE" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
 </ResourceDictionary>

--- a/Nodify/Themes/Styles/NodifyEditor.xaml
+++ b/Nodify/Themes/Styles/NodifyEditor.xaml
@@ -30,12 +30,12 @@
     </Style>
 
     <Style x:Key="PushedAreaStyle"
-           TargetType="Border">
-        <Setter Property="BorderBrush"
+           TargetType="Rectangle">
+        <Setter Property="Stroke"
                 Value="#74747c" />
-        <Setter Property="BorderThickness"
-                Value="2 0 0 0" />
-        <Setter Property="Background">
+        <Setter Property="StrokeThickness"
+                Value="1" />
+        <Setter Property="Fill">
             <Setter.Value>
                 <SolidColorBrush Opacity="0.2"
                                  Color="#74747c" />
@@ -127,28 +127,28 @@
                                 </Rectangle.Height>
                             </Rectangle>
 
-                            <Border Style="{TemplateBinding PushedAreaStyle}"
+                            <Rectangle Style="{TemplateBinding PushedAreaStyle}"
                                     RenderTransform="{Binding ViewportTransform, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource UnscaleTransformConverter}}"
                                     Canvas.Top="{Binding PushedArea.Y, RelativeSource={RelativeSource TemplatedParent}}"
                                     Canvas.Left="{Binding PushedArea.X, RelativeSource={RelativeSource TemplatedParent}}"
                                     Visibility="{TemplateBinding IsPushingItems, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                <Border.Width>
+                                <Rectangle.Width>
                                     <MultiBinding Converter="{StaticResource ScaleDoubleConverter}">
                                         <Binding Path="PushedArea.Width"
                                                  RelativeSource="{RelativeSource TemplatedParent}" />
                                         <Binding Path="ViewportZoom"
                                                  RelativeSource="{RelativeSource TemplatedParent}" />
                                     </MultiBinding>
-                                </Border.Width>
-                                <Border.Height>
+                                </Rectangle.Width>
+                                <Rectangle.Height>
                                     <MultiBinding Converter="{StaticResource ScaleDoubleConverter}">
                                         <Binding Path="PushedArea.Height"
                                                  RelativeSource="{RelativeSource TemplatedParent}" />
                                         <Binding Path="ViewportZoom"
                                                  RelativeSource="{RelativeSource TemplatedParent}" />
                                     </MultiBinding>
-                                </Border.Height>
-                            </Border>
+                                </Rectangle.Height>
+                            </Rectangle>
 
                             <local:CuttingLine Style="{TemplateBinding CuttingLineStyle}"
                                                Visibility="{TemplateBinding IsCutting, Converter={StaticResource BooleanToVisibilityConverter}}"
@@ -188,11 +188,26 @@
         </Setter>
 
         <Style.Triggers>
-            <Trigger Property="IsPushingItems"
-                     Value="True">
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsPushingItems"
+                               Value="True" />
+                    <Condition Property="PushOrientation"
+                               Value="Horizontal" />
+                </MultiTrigger.Conditions>
                 <Setter Property="Cursor"
                         Value="SizeWE" />
-            </Trigger>
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsPushingItems"
+                               Value="True" />
+                    <Condition Property="PushOrientation"
+                               Value="Vertical" />
+                </MultiTrigger.Conditions>
+                <Setter Property="Cursor"
+                        Value="SizeNS" />
+            </MultiTrigger>
         </Style.Triggers>
     </Style>
 

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -27,6 +27,7 @@
 - [EditorDefaultState Class](#editordefaultstate-class)  
 - [EditorGestures Class](#editorgestures-class)  
 - [EditorPanningState Class](#editorpanningstate-class)  
+- [EditorPushingItemsState Class](#editorpushingitemsstate-class)  
 - [EditorSelectingState Class](#editorselectingstate-class)  
 - [EditorState Class](#editorstate-class)  
 - [GeneratedInternalTypeHelper Class](#generatedinternaltypehelper-class)  
@@ -3069,6 +3070,92 @@ public override void HandleMouseUp(MouseButtonEventArgs e);
   
 `e` [MouseButtonEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.MouseButtonEventArgs)  
   
+## EditorPushingItemsState Class  
+  
+**Namespace:** Nodify  
+  
+**Assembly:** Nodify  
+  
+**Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class) → [EditorPushingItemsState](#editorpushingitemsstate-class)  
+  
+**References:** [NodifyEditor](#nodifyeditor-class), [EditorState](#editorstate-class)  
+  
+```csharp  
+public class EditorPushingItemsState : EditorState  
+```  
+  
+### Constructors  
+  
+#### EditorPushingItemsState(NodifyEditor)  
+  
+```csharp  
+public EditorPushingItemsState(NodifyEditor editor);  
+```  
+  
+**Parameters**  
+  
+`editor` [NodifyEditor](#nodifyeditor-class)  
+  
+### Properties  
+  
+#### Canceled  
+  
+```csharp  
+public bool Canceled { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean)  
+  
+### Methods  
+  
+#### Enter(EditorState)  
+  
+```csharp  
+public override void Enter(EditorState from);  
+```  
+  
+**Parameters**  
+  
+`from` [EditorState](#editorstate-class)  
+  
+#### Exit()  
+  
+```csharp  
+public override void Exit();  
+```  
+  
+#### HandleKeyUp(KeyEventArgs)  
+  
+```csharp  
+public override void HandleKeyUp(KeyEventArgs e);  
+```  
+  
+**Parameters**  
+  
+`e` [KeyEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.KeyEventArgs)  
+  
+#### HandleMouseMove(MouseEventArgs)  
+  
+```csharp  
+public override void HandleMouseMove(MouseEventArgs e);  
+```  
+  
+**Parameters**  
+  
+`e` [MouseEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.MouseEventArgs)  
+  
+#### HandleMouseUp(MouseButtonEventArgs)  
+  
+```csharp  
+public override void HandleMouseUp(MouseButtonEventArgs e);  
+```  
+  
+**Parameters**  
+  
+`e` [MouseButtonEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.MouseButtonEventArgs)  
+  
 ## EditorSelectingState Class  
   
 **Namespace:** Nodify  
@@ -3191,9 +3278,9 @@ public override void HandleMouseUp(MouseButtonEventArgs e);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class)  
   
-**Derived:** [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorSelectingState](#editorselectingstate-class)  
+**Derived:** [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorPushingItemsState](#editorpushingitemsstate-class), [EditorSelectingState](#editorselectingstate-class)  
   
-**References:** [EditorCuttingState](#editorcuttingstate-class), [EditorPanningState](#editorpanningstate-class), [EditorSelectingState](#editorselectingstate-class), [NodifyEditor](#nodifyeditor-class)  
+**References:** [EditorCuttingState](#editorcuttingstate-class), [EditorPanningState](#editorpanningstate-class), [EditorPushingItemsState](#editorpushingitemsstate-class), [EditorSelectingState](#editorselectingstate-class), [NodifyEditor](#nodifyeditor-class)  
   
 The base class for editor states.  
   
@@ -4515,7 +4602,39 @@ public class LineConnection : BaseConnection
 public LineConnection();  
 ```  
   
+### Properties  
+  
+#### CornerRadius  
+  
+The radius of the corners between the line segments.  
+  
+```csharp  
+public double CornerRadius { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double)  
+  
 ### Methods  
+  
+#### AddSmoothCorner(StreamGeometryContext, Point, Point, Point, Double)  
+  
+```csharp  
+protected static void AddSmoothCorner(StreamGeometryContext context, Point start, Point corner, Point end, double radius);  
+```  
+  
+**Parameters**  
+  
+`context` [StreamGeometryContext](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.StreamGeometryContext)  
+  
+`start` [Point](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Point)  
+  
+`corner` [Point](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Point)  
+  
+`end` [Point](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Point)  
+  
+`radius` [Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double)  
   
 #### DrawDefaultArrowhead(StreamGeometryContext, Point, Point, ConnectionDirection, Orientation)  
   
@@ -5059,6 +5178,28 @@ public class Node : HeaderedContentControl
 public Node();  
 ```  
   
+### Fields  
+  
+#### ElementInputItemsControl  
+  
+```csharp  
+protected const string ElementInputItemsControl = "PART_Input";  
+```  
+  
+**Field Value**  
+  
+[String](https://docs.microsoft.com/en-us/dotnet/api/System.String)  
+  
+#### ElementOutputItemsControl  
+  
+```csharp  
+protected const string ElementOutputItemsControl = "PART_Output";  
+```  
+  
+**Field Value**  
+  
+[String](https://docs.microsoft.com/en-us/dotnet/api/System.String)  
+  
 ### Properties  
   
 #### ContentBrush  
@@ -5193,6 +5334,26 @@ public DataTemplate InputConnectorTemplate { get; set; }
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
   
+#### InputGroupStyle  
+  
+```csharp  
+public ObservableCollection<GroupStyle> InputGroupStyle { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ObservableCollection<GroupStyle>](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.ObjectModel.ObservableCollection)  
+  
+#### InputItemsControl  
+  
+```csharp  
+protected ItemsControl InputItemsControl { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl)  
+  
 #### Output  
   
 Gets or sets the data for the output [Connector](#connector-class)s of this control.  
@@ -5216,6 +5377,34 @@ public DataTemplate OutputConnectorTemplate { get; set; }
 **Property Value**  
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
+  
+#### OutputGroupStyle  
+  
+```csharp  
+public ObservableCollection<GroupStyle> OutputGroupStyle { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ObservableCollection<GroupStyle>](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.ObjectModel.ObservableCollection)  
+  
+#### OutputItemsControl  
+  
+```csharp  
+protected ItemsControl OutputItemsControl { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl)  
+  
+### Methods  
+  
+#### OnApplyTemplate()  
+  
+```csharp  
+public override void OnApplyTemplate();  
+```  
   
 ## NodeInput Class  
   
@@ -5439,7 +5628,7 @@ protected override Size MeasureOverride(Size constraint);
   
 **Implements:** [IScrollInfo](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.IScrollInfo)  
   
-**References:** [ContainerState](#containerstate-class), [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorSelectingState](#editorselectingstate-class), [EditorState](#editorstate-class), [SelectionHelper](#selectionhelper-class), [ItemContainer](#itemcontainer-class), [PendingConnection](#pendingconnection-class), [GroupingNode](#groupingnode-class), [Connector](#connector-class), [CuttingLine](#cuttingline-class), [DecoratorContainer](#decoratorcontainer-class), [EditorCommands](#editorcommands-class), [EditorGestures](#editorgestures-class), [Minimap](#minimap-class), [Connection](#connection-class), [BaseConnection](#baseconnection-class)  
+**References:** [ContainerState](#containerstate-class), [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorPushingItemsState](#editorpushingitemsstate-class), [EditorSelectingState](#editorselectingstate-class), [EditorState](#editorstate-class), [SelectionHelper](#selectionhelper-class), [ItemContainer](#itemcontainer-class), [PendingConnection](#pendingconnection-class), [GroupingNode](#groupingnode-class), [Connector](#connector-class), [CuttingLine](#cuttingline-class), [DecoratorContainer](#decoratorcontainer-class), [EditorCommands](#editorcommands-class), [EditorGestures](#editorgestures-class), [Minimap](#minimap-class), [Connection](#connection-class), [BaseConnection](#baseconnection-class)  
   
 Groups [ItemContainer](#itemcontainer-class)s and [Connection](#connection-class)s in an area that you can drag, zoom and select.  
   
@@ -5460,6 +5649,8 @@ public NodifyEditor();
 ### Fields  
   
 #### CuttingConnectionTypes  
+  
+The list of supported connection types for cutting. Type must be derived from [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement).  
   
 ```csharp  
 public static HashSet<Type> CuttingConnectionTypes;  
@@ -5529,6 +5720,16 @@ public static DependencyPropertyKey IsPanningPropertyKey;
   
 [DependencyPropertyKey](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyPropertyKey)  
   
+#### IsPushingItemsPropertyKey  
+  
+```csharp  
+protected static DependencyPropertyKey IsPushingItemsPropertyKey;  
+```  
+  
+**Field Value**  
+  
+[DependencyPropertyKey](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyPropertyKey)  
+  
 #### IsSelectingPropertyKey  
   
 ```csharp  
@@ -5543,6 +5744,26 @@ protected static DependencyPropertyKey IsSelectingPropertyKey;
   
 ```csharp  
 protected static DependencyPropertyKey MouseLocationPropertyKey;  
+```  
+  
+**Field Value**  
+  
+[DependencyPropertyKey](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyPropertyKey)  
+  
+#### PushedAreaOrientationPropertyKey  
+  
+```csharp  
+protected static DependencyPropertyKey PushedAreaOrientationPropertyKey;  
+```  
+  
+**Field Value**  
+  
+[DependencyPropertyKey](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyPropertyKey)  
+  
+#### PushedAreaPropertyKey  
+  
+```csharp  
+protected static DependencyPropertyKey PushedAreaPropertyKey;  
 ```  
   
 **Field Value**  
@@ -5584,6 +5805,18 @@ protected readonly TranslateTransform TranslateTransform;
 [TranslateTransform](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.TranslateTransform)  
   
 ### Properties  
+  
+#### AllowPushItemsCancellation  
+  
+Gets or sets whether push items cancellation is allowed.  
+  
+```csharp  
+public static bool AllowPushItemsCancellation { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean)  
   
 #### AutoPanEdgeDistance  
   
@@ -6025,6 +6258,18 @@ public bool IsPanning { get; set; }
   
 [Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean)  
   
+#### IsPushingItems  
+  
+Gets a value that indicates whether a pushing operation is in progress.  
+  
+```csharp  
+public bool IsPushingItems { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean)  
+  
 #### IsSelecting  
   
 Gets a value that indicates whether a selection operation is in progress.  
@@ -6181,6 +6426,42 @@ public DataTemplate PendingConnectionTemplate { get; set; }
 **Property Value**  
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
+  
+#### PushedArea  
+  
+Gets the currently pushed area while [NodifyEditor.IsPushingItems](#nodifyeditor-class#ispushingitems) is true.  
+  
+```csharp  
+public Rect PushedArea { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Rect](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Rect)  
+  
+#### PushedAreaOrientation  
+  
+Gets the orientation of the [NodifyEditor.PushedArea](#nodifyeditor-class#pushedarea).  
+  
+```csharp  
+public Orientation PushedAreaOrientation { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Orientation](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Orientation)  
+  
+#### PushedAreaStyle  
+  
+Gets or sets the style to use for the pushed area.  
+  
+```csharp  
+public Style PushedAreaStyle { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Style](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Style)  
   
 #### RemoveConnectionCommand  
   
@@ -6649,6 +6930,22 @@ public void SelectArea(Rect area, bool append = false, bool fit = false);
   
 `fit` [Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean): True to check if the area contains the [ItemContainer](#itemcontainer-class). False to check if area intersects the [ItemContainer](#itemcontainer-class).  
   
+#### SnapToGrid(Double)  
+  
+Snaps the given value down to the nearest multiple of the grid cell size.  
+  
+```csharp  
+public double SnapToGrid(double value);  
+```  
+  
+**Parameters**  
+  
+`value` [Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double): The value to be snapped to the grid.  
+  
+**Returns**  
+  
+[Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double): The largest multiple of the grid cell size less than or equal to the value.  
+  
 #### UnselectAllConnection()  
   
 Unselect all [NodifyEditor.Connections](#nodifyeditor-class#connections).  
@@ -6773,6 +7070,16 @@ public InputGestureRef FitToScreen { get; set; }
   
 ```csharp  
 public InputGestureRef Pan { get; set; }  
+```  
+  
+**Property Value**  
+  
+[InputGestureRef](#inputgestureref-class)  
+  
+#### PushItems  
+  
+```csharp  
+public InputGestureRef PushItems { get; set; }  
 ```  
   
 **Property Value**  

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -65,6 +65,7 @@
 - [ZoomEventArgs Class](#zoomeventargs-class)  
 - [ZoomEventHandler Delegate](#zoomeventhandler-delegate)  
   
+  
 ## Alignment Enum  
   
 **Namespace:** Nodify  
@@ -259,7 +260,7 @@ Rectangle = 2;
   
 **Derived:** [LineConnection](#lineconnection-class), [Connection](#connection-class)  
   
-**References:** [ConnectionEventHandler](#connectioneventhandler-delegate), [ConnectionDirection](#connectiondirection-enum), [ArrowHeadShape](#arrowheadshape-enum), [ConnectionOffsetMode](#connectionoffsetmode-enum), [ArrowHeadEnds](#arrowheadends-enum), [CuttingLine](#cuttingline-class), [LineConnection](#lineconnection-class), [ConnectionEventArgs](#connectioneventargs-class), [NodifyEditor](#nodifyeditor-class)  
+**References:** [ArrowHeadEnds](#arrowheadends-enum), [ArrowHeadShape](#arrowheadshape-enum), [ConnectionDirection](#connectiondirection-enum), [ConnectionEventArgs](#connectioneventargs-class), [ConnectionEventHandler](#connectioneventhandler-delegate), [ConnectionOffsetMode](#connectionoffsetmode-enum), [CuttingLine](#cuttingline-class), [NodifyEditor](#nodifyeditor-class)  
   
 Represents the base class for shapes that are drawn from a [BaseConnection.Source](#baseconnection-class#source) point to a [BaseConnection.Target](#baseconnection-class#target) point.  
   
@@ -1206,7 +1207,7 @@ protected override ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### GetTextPosition(FormattedText, Point, Point)  
   
@@ -1282,7 +1283,7 @@ protected override ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### GetTextPosition(FormattedText, Point, Point)  
   
@@ -1364,7 +1365,7 @@ Forward = 0;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.EventArgs) → [RoutedEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.RoutedEventArgs) → [ConnectionEventArgs](#connectioneventargs-class)  
   
-**References:** [ConnectionEventHandler](#connectioneventhandler-delegate), [BaseConnection](#baseconnection-class)  
+**References:** [BaseConnection](#baseconnection-class), [ConnectionEventHandler](#connectioneventhandler-delegate)  
   
 Provides data for [BaseConnection](#baseconnection-class) related routed events.  
   
@@ -1434,7 +1435,7 @@ protected override void InvokeEventHandler(Delegate genericHandler, object gener
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [Delegate](https://docs.microsoft.com/en-us/dotnet/api/System.Delegate) → [MulticastDelegate](https://docs.microsoft.com/en-us/dotnet/api/System.MulticastDelegate) → [ConnectionEventHandler](#connectioneventhandler-delegate)  
   
-**References:** [ConnectionEventArgs](#connectioneventargs-class), [BaseConnection](#baseconnection-class)  
+**References:** [BaseConnection](#baseconnection-class), [ConnectionEventArgs](#connectioneventargs-class)  
   
 Represents the method that will handle [BaseConnection](#baseconnection-class) related routed events.  
   
@@ -1580,7 +1581,7 @@ Static = 4;
   
 **Derived:** [NodeInput](#nodeinput-class), [NodeOutput](#nodeoutput-class), [StateNode](#statenode-class)  
   
-**References:** [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate), [ConnectorEventHandler](#connectoreventhandler-delegate), [ItemContainer](#itemcontainer-class), [PendingConnection](#pendingconnection-class), [Connection](#connection-class), [NodifyEditor](#nodifyeditor-class), [ConnectorEventArgs](#connectoreventargs-class), [PendingConnectionEventArgs](#pendingconnectioneventargs-class), [KnotNode](#knotnode-class), [Node](#node-class), [NodeInput](#nodeinput-class), [NodeOutput](#nodeoutput-class), [StateNode](#statenode-class)  
+**References:** [Connection](#connection-class), [ConnectorEventArgs](#connectoreventargs-class), [ConnectorEventHandler](#connectoreventhandler-delegate), [ItemContainer](#itemcontainer-class), [KnotNode](#knotnode-class), [Node](#node-class), [NodifyEditor](#nodifyeditor-class), [PendingConnection](#pendingconnection-class), [PendingConnectionEventArgs](#pendingconnectioneventargs-class), [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate)  
   
 Represents a connector control that can start and complete a [PendingConnection](#pendingconnection-class).
             Has a [Connector.ElementConnector](#connector-class#elementconnector) that the [Connector.Anchor](#connector-class#anchor) is calculated from for the [PendingConnection](#pendingconnection-class). Center of this control is used if missing.  
@@ -1935,7 +1936,7 @@ public event PendingConnectionEventHandler PendingConnectionStarted;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.EventArgs) → [RoutedEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.RoutedEventArgs) → [ConnectorEventArgs](#connectoreventargs-class)  
   
-**References:** [ConnectorEventHandler](#connectoreventhandler-delegate), [Connector](#connector-class)  
+**References:** [Connector](#connector-class), [ConnectorEventHandler](#connectoreventhandler-delegate)  
   
 Provides data for [Connector](#connector-class) related routed events.  
   
@@ -2005,7 +2006,7 @@ protected override void InvokeEventHandler(Delegate genericHandler, object gener
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [Delegate](https://docs.microsoft.com/en-us/dotnet/api/System.Delegate) → [MulticastDelegate](https://docs.microsoft.com/en-us/dotnet/api/System.MulticastDelegate) → [ConnectorEventHandler](#connectoreventhandler-delegate)  
   
-**References:** [ConnectorEventArgs](#connectoreventargs-class), [Connector](#connector-class)  
+**References:** [Connector](#connector-class), [ConnectorEventArgs](#connectoreventargs-class)  
   
 Represents the method that will handle [Connector](#connector-class) related routed events.  
   
@@ -2131,7 +2132,7 @@ Top = 0;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [ContainerState](#containerstate-class) → [ContainerDefaultState](#containerdefaultstate-class)  
   
-**References:** [ItemContainer](#itemcontainer-class), [ContainerState](#containerstate-class)  
+**References:** [ItemContainer](#itemcontainer-class)  
   
 The default state of the [ItemContainer](#itemcontainer-class).  
   
@@ -2203,7 +2204,7 @@ public override void ReEnter(ContainerState from);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [ContainerState](#containerstate-class) → [ContainerDraggingState](#containerdraggingstate-class)  
   
-**References:** [ItemContainer](#itemcontainer-class), [ContainerState](#containerstate-class)  
+**References:** [ItemContainer](#itemcontainer-class)  
   
 Dragging state of the container.  
   
@@ -2659,7 +2660,7 @@ public event RoutedEventHandler LocationChanged;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorCommands](#editorcommands-class)  
   
-**References:** [ItemContainer](#itemcontainer-class), [NodifyEditor](#nodifyeditor-class), [InputGestureRef](#inputgestureref-class)  
+**References:** [InputGestureRef](#inputgestureref-class), [ItemContainer](#itemcontainer-class), [NodifyEditor](#nodifyeditor-class)  
   
 ```csharp  
 public static class EditorCommands  
@@ -2749,7 +2750,7 @@ public static RoutedUICommand ZoomOut { get; set; }
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class) → [EditorCuttingState](#editorcuttingstate-class)  
   
-**References:** [NodifyEditor](#nodifyeditor-class), [EditorState](#editorstate-class)  
+**References:** [NodifyEditor](#nodifyeditor-class)  
   
 ```csharp  
 public class EditorCuttingState : EditorState  
@@ -2886,7 +2887,7 @@ public override void HandleMouseDown(MouseButtonEventArgs e);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorGestures](#editorgestures-class)  
   
-**References:** [NodifyEditorGestures](#nodifyeditorgestures-class), [ItemContainerGestures](#itemcontainergestures-class), [ConnectorGestures](#connectorgestures-class), [ConnectionGestures](#connectiongestures-class), [GroupingNodeGestures](#groupingnodegestures-class), [MinimapGestures](#minimapgestures-class), [NodifyEditor](#nodifyeditor-class)  
+**References:** [ConnectionGestures](#connectiongestures-class), [ConnectorGestures](#connectorgestures-class), [GroupingNodeGestures](#groupingnodegestures-class), [ItemContainerGestures](#itemcontainergestures-class), [MinimapGestures](#minimapgestures-class), [NodifyEditor](#nodifyeditor-class), [NodifyEditorGestures](#nodifyeditorgestures-class)  
   
 Gestures used by built-in controls inside the [NodifyEditor](#nodifyeditor-class).  
   
@@ -3010,7 +3011,7 @@ public void Apply(EditorGestures gestures);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class) → [EditorPanningState](#editorpanningstate-class)  
   
-**References:** [NodifyEditor](#nodifyeditor-class), [EditorState](#editorstate-class)  
+**References:** [NodifyEditor](#nodifyeditor-class)  
   
 The panning state of the editor.  
   
@@ -3078,7 +3079,7 @@ public override void HandleMouseUp(MouseButtonEventArgs e);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class) → [EditorPushingItemsState](#editorpushingitemsstate-class)  
   
-**References:** [NodifyEditor](#nodifyeditor-class), [EditorState](#editorstate-class)  
+**References:** [NodifyEditor](#nodifyeditor-class)  
   
 ```csharp  
 public class EditorPushingItemsState : EditorState  
@@ -3164,7 +3165,7 @@ public override void HandleMouseUp(MouseButtonEventArgs e);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class) → [EditorSelectingState](#editorselectingstate-class)  
   
-**References:** [NodifyEditor](#nodifyeditor-class), [SelectionType](#selectiontype-enum), [SelectionHelper](#selectionhelper-class), [EditorState](#editorstate-class)  
+**References:** [NodifyEditor](#nodifyeditor-class), [SelectionHelper](#selectionhelper-class), [SelectionType](#selectiontype-enum)  
   
 The selecting state of the editor.  
   
@@ -3598,7 +3599,7 @@ Self = 1;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [ContentControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ContentControl) → [HeaderedContentControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.HeaderedContentControl) → [GroupingNode](#groupingnode-class)  
   
-**References:** [ResizeEventHandler](#resizeeventhandler-delegate), [GroupingMovementMode](#groupingmovementmode-enum), [NodifyEditor](#nodifyeditor-class), [ItemContainer](#itemcontainer-class)  
+**References:** [GroupingMovementMode](#groupingmovementmode-enum), [ItemContainer](#itemcontainer-class), [NodifyEditor](#nodifyeditor-class), [ResizeEventHandler](#resizeeventhandler-delegate)  
   
 Defines a panel with a header that groups [ItemContainer](#itemcontainer-class)s inside it and can be resized.  
   
@@ -3938,7 +3939,7 @@ public virtual void Arrange(Rect rect);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [InputGesture](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.InputGesture) → [InputGestureRef](#inputgestureref-class)  
   
-**References:** [SelectionGestures](#selectiongestures-class), [ItemContainerGestures](#itemcontainergestures-class), [NodifyEditorGestures](#nodifyeditorgestures-class), [ConnectorGestures](#connectorgestures-class), [ConnectionGestures](#connectiongestures-class), [MinimapGestures](#minimapgestures-class), [EditorCommands](#editorcommands-class)  
+**References:** [ConnectionGestures](#connectiongestures-class), [ConnectorGestures](#connectorgestures-class), [EditorCommands](#editorcommands-class), [ItemContainerGestures](#itemcontainergestures-class), [MinimapGestures](#minimapgestures-class), [NodifyEditorGestures](#nodifyeditorgestures-class), [SelectionGestures](#selectiongestures-class)  
   
 An input gesture that allows changing its logic at runtime without changing its reference.
             Useful for classes that capture the object reference without the posibility of updating it. (e.g. [EditorCommands](#editorcommands-class))  
@@ -3989,7 +3990,7 @@ public override bool Matches(object targetElement, InputEventArgs inputEventArgs
   
 **Implements:** [INodifyCanvasItem](#inodifycanvasitem-interface)  
   
-**References:** [Connector](#connector-class), [ContainerDefaultState](#containerdefaultstate-class), [ContainerDraggingState](#containerdraggingstate-class), [ContainerState](#containerstate-class), [NodifyEditor](#nodifyeditor-class), [PreviewLocationChanged](#previewlocationchanged-delegate), [GroupingNode](#groupingnode-class), [PendingConnection](#pendingconnection-class), [EditorCommands](#editorcommands-class), [SelectionHelper](#selectionhelper-class)  
+**References:** [Connector](#connector-class), [ContainerDefaultState](#containerdefaultstate-class), [ContainerDraggingState](#containerdraggingstate-class), [ContainerState](#containerstate-class), [EditorCommands](#editorcommands-class), [GroupingNode](#groupingnode-class), [NodifyEditor](#nodifyeditor-class), [PendingConnection](#pendingconnection-class), [PreviewLocationChanged](#previewlocationchanged-delegate), [SelectionHelper](#selectionhelper-class)  
   
 The container for all the items generated by the [ItemsControl.ItemsSource](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl.itemssource) of the [NodifyEditor](#nodifyeditor-class).  
   
@@ -4494,7 +4495,7 @@ public event RoutedEventHandler Unselected;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [ItemContainerGestures](#itemcontainergestures-class)  
   
-**References:** [EditorGestures](#editorgestures-class), [SelectionGestures](#selectiongestures-class), [InputGestureRef](#inputgestureref-class)  
+**References:** [EditorGestures](#editorgestures-class), [InputGestureRef](#inputgestureref-class), [SelectionGestures](#selectiongestures-class)  
   
 ```csharp  
 public class ItemContainerGestures  
@@ -4586,7 +4587,7 @@ public KnotNode();
   
 **Derived:** [CircuitConnection](#circuitconnection-class), [StepConnection](#stepconnection-class)  
   
-**References:** [ConnectionDirection](#connectiondirection-enum), [BaseConnection](#baseconnection-class)  
+**References:** [ConnectionDirection](#connectiondirection-enum)  
   
 Represents a line that has an arrow indicating its [BaseConnection.Direction](#baseconnection-class#direction).  
   
@@ -4684,7 +4685,7 @@ protected override ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### InterpolateLine(Point, Point, Point, Point, Double)  
   
@@ -4706,7 +4707,7 @@ protected static ValueTuple<ValueTuple<Point, Point>, Point> InterpolateLine(Poi
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, Point>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, Point>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### InterpolateLine(Point, Point, Point, Double)  
   
@@ -4726,7 +4727,7 @@ protected static ValueTuple<ValueTuple<Point, Point>, Point> InterpolateLine(Poi
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, Point>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, Point>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### InterpolateLineSegment(Point, Point, Double)  
   
@@ -4780,7 +4781,7 @@ Any = 0;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl) → [Minimap](#minimap-class)  
   
-**References:** [ZoomEventHandler](#zoomeventhandler-delegate), [MinimapItem](#minimapitem-class), [NodifyEditor](#nodifyeditor-class), [ZoomEventArgs](#zoomeventargs-class)  
+**References:** [MinimapItem](#minimapitem-class), [NodifyEditor](#nodifyeditor-class), [ZoomEventArgs](#zoomeventargs-class), [ZoomEventHandler](#zoomeventhandler-delegate)  
   
 A minimap control that can position the viewport, and zoom in and out.  
   
@@ -5414,7 +5415,7 @@ public override void OnApplyTemplate();
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [Connector](#connector-class) → [NodeInput](#nodeinput-class)  
   
-**References:** [Node](#node-class), [Connector](#connector-class)  
+**References:** [Node](#node-class)  
   
 Represents the default control for the [Node.InputConnectorTemplate](#node-class#inputconnectortemplate).  
   
@@ -5486,7 +5487,7 @@ public Orientation Orientation { get; set; }
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [Connector](#connector-class) → [NodeOutput](#nodeoutput-class)  
   
-**References:** [Node](#node-class), [Connector](#connector-class)  
+**References:** [Node](#node-class)  
   
 Represents the default control for the [Node.OutputConnectorTemplate](#node-class#outputconnectortemplate).  
   
@@ -5628,7 +5629,7 @@ protected override Size MeasureOverride(Size constraint);
   
 **Implements:** [IScrollInfo](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.IScrollInfo)  
   
-**References:** [ContainerState](#containerstate-class), [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorPushingItemsState](#editorpushingitemsstate-class), [EditorSelectingState](#editorselectingstate-class), [EditorState](#editorstate-class), [SelectionHelper](#selectionhelper-class), [ItemContainer](#itemcontainer-class), [PendingConnection](#pendingconnection-class), [GroupingNode](#groupingnode-class), [Connector](#connector-class), [CuttingLine](#cuttingline-class), [DecoratorContainer](#decoratorcontainer-class), [EditorCommands](#editorcommands-class), [EditorGestures](#editorgestures-class), [Minimap](#minimap-class), [Connection](#connection-class), [BaseConnection](#baseconnection-class)  
+**References:** [BaseConnection](#baseconnection-class), [Connection](#connection-class), [Connector](#connector-class), [ContainerState](#containerstate-class), [CuttingLine](#cuttingline-class), [DecoratorContainer](#decoratorcontainer-class), [EditorCommands](#editorcommands-class), [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorGestures](#editorgestures-class), [EditorPanningState](#editorpanningstate-class), [EditorPushingItemsState](#editorpushingitemsstate-class), [EditorSelectingState](#editorselectingstate-class), [EditorState](#editorstate-class), [GroupingNode](#groupingnode-class), [ItemContainer](#itemcontainer-class), [Minimap](#minimap-class), [PendingConnection](#pendingconnection-class), [SelectionHelper](#selectionhelper-class)  
   
 Groups [ItemContainer](#itemcontainer-class)s and [Connection](#connection-class)s in an area that you can drag, zoom and select.  
   
@@ -7020,7 +7021,7 @@ public event RoutedEventHandler ViewportUpdated;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [NodifyEditorGestures](#nodifyeditorgestures-class)  
   
-**References:** [EditorGestures](#editorgestures-class), [SelectionGestures](#selectiongestures-class), [InputGestureRef](#inputgestureref-class)  
+**References:** [EditorGestures](#editorgestures-class), [InputGestureRef](#inputgestureref-class), [SelectionGestures](#selectiongestures-class)  
   
 ```csharp  
 public class NodifyEditorGestures  
@@ -7156,7 +7157,7 @@ public void Apply(NodifyEditorGestures gestures);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [ContentControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ContentControl) → [PendingConnection](#pendingconnection-class)  
   
-**References:** [PendingConnectionEventArgs](#pendingconnectioneventargs-class), [ConnectionDirection](#connectiondirection-enum), [NodifyEditor](#nodifyeditor-class), [Connector](#connector-class), [ItemContainer](#itemcontainer-class), [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate), [StateNode](#statenode-class)  
+**References:** [ConnectionDirection](#connectiondirection-enum), [Connector](#connector-class), [ItemContainer](#itemcontainer-class), [NodifyEditor](#nodifyeditor-class), [PendingConnectionEventArgs](#pendingconnectioneventargs-class), [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate), [StateNode](#statenode-class)  
   
 Represents a pending connection usually started by a [Connector](#connector-class) which invokes the [PendingConnection.CompletedCommand](#pendingconnection-class#completedcommand) when completed.  
   
@@ -7449,7 +7450,7 @@ public static void SetIsOverElement(UIElement elem, bool value);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.EventArgs) → [RoutedEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.RoutedEventArgs) → [PendingConnectionEventArgs](#pendingconnectioneventargs-class)  
   
-**References:** [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate), [PendingConnection](#pendingconnection-class), [Connector](#connector-class)  
+**References:** [Connector](#connector-class), [PendingConnection](#pendingconnection-class), [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate)  
   
 Provides data for [PendingConnection](#pendingconnection-class) related routed events.  
   
@@ -7567,7 +7568,7 @@ protected override void InvokeEventHandler(Delegate genericHandler, object gener
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [Delegate](https://docs.microsoft.com/en-us/dotnet/api/System.Delegate) → [MulticastDelegate](https://docs.microsoft.com/en-us/dotnet/api/System.MulticastDelegate) → [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate)  
   
-**References:** [PendingConnectionEventArgs](#pendingconnectioneventargs-class), [Connector](#connector-class), [PendingConnection](#pendingconnection-class)  
+**References:** [Connector](#connector-class), [PendingConnection](#pendingconnection-class), [PendingConnectionEventArgs](#pendingconnectioneventargs-class)  
   
 Represents the method that will handle [PendingConnection](#pendingconnection-class) related routed events.  
   
@@ -7681,7 +7682,7 @@ protected override void InvokeEventHandler(Delegate genericHandler, object gener
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [Delegate](https://docs.microsoft.com/en-us/dotnet/api/System.Delegate) → [MulticastDelegate](https://docs.microsoft.com/en-us/dotnet/api/System.MulticastDelegate) → [ResizeEventHandler](#resizeeventhandler-delegate)  
   
-**References:** [ResizeEventArgs](#resizeeventargs-class), [GroupingNode](#groupingnode-class)  
+**References:** [GroupingNode](#groupingnode-class), [ResizeEventArgs](#resizeeventargs-class)  
   
 Represents the method that will handle resize related routed events.  
   
@@ -7703,7 +7704,7 @@ public delegate void ResizeEventHandler(object sender, ResizeEventArgs e);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [SelectionGestures](#selectiongestures-class)  
   
-**References:** [InputGestureRef](#inputgestureref-class), [ItemContainerGestures](#itemcontainergestures-class), [NodifyEditorGestures](#nodifyeditorgestures-class), [ConnectionGestures](#connectiongestures-class)  
+**References:** [ConnectionGestures](#connectiongestures-class), [InputGestureRef](#inputgestureref-class), [ItemContainerGestures](#itemcontainergestures-class), [NodifyEditorGestures](#nodifyeditorgestures-class)  
   
 ```csharp  
 public class SelectionGestures  
@@ -7821,7 +7822,7 @@ public void Apply(SelectionGestures gestures);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [SelectionHelper](#selectionhelper-class)  
   
-**References:** [EditorSelectingState](#editorselectingstate-class), [NodifyEditor](#nodifyeditor-class), [SelectionType](#selectiontype-enum), [ItemContainer](#itemcontainer-class)  
+**References:** [EditorSelectingState](#editorselectingstate-class), [ItemContainer](#itemcontainer-class), [NodifyEditor](#nodifyeditor-class), [SelectionType](#selectiontype-enum)  
   
 Helps with selecting [ItemContainer](#itemcontainer-class)s and updating the [NodifyEditor.SelectedArea](#nodifyeditor-class#selectedarea) and [NodifyEditor.IsSelecting](#nodifyeditor-class#isselecting) properties.  
   
@@ -7933,7 +7934,7 @@ Replace = 0;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [Connector](#connector-class) → [StateNode](#statenode-class)  
   
-**References:** [Connector](#connector-class), [PendingConnection](#pendingconnection-class)  
+**References:** [PendingConnection](#pendingconnection-class)  
   
 Represents a control that acts as a [Connector](#connector-class).  
   
@@ -8131,7 +8132,7 @@ protected override ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### GetTextPosition(FormattedText, Point, Point)  
   
@@ -8159,7 +8160,7 @@ protected override Point GetTextPosition(FormattedText text, Point source, Point
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.EventArgs) → [RoutedEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.RoutedEventArgs) → [ZoomEventArgs](#zoomeventargs-class)  
   
-**References:** [ZoomEventHandler](#zoomeventhandler-delegate), [Minimap](#minimap-class)  
+**References:** [Minimap](#minimap-class), [ZoomEventHandler](#zoomeventhandler-delegate)  
   
 Provides data for [Minimap.Zoom](#minimap-class#zoom) routed event.  
   
@@ -8231,7 +8232,7 @@ protected override void InvokeEventHandler(Delegate genericHandler, object gener
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [Delegate](https://docs.microsoft.com/en-us/dotnet/api/System.Delegate) → [MulticastDelegate](https://docs.microsoft.com/en-us/dotnet/api/System.MulticastDelegate) → [ZoomEventHandler](#zoomeventhandler-delegate)  
   
-**References:** [ZoomEventArgs](#zoomeventargs-class), [Minimap](#minimap-class)  
+**References:** [Minimap](#minimap-class), [ZoomEventArgs](#zoomeventargs-class)  
   
 Represents the method that will handle [Minimap.Zoom](#minimap-class#zoom) routed event.  
   

--- a/docs/Editor-Overview.md
+++ b/docs/Editor-Overview.md
@@ -6,6 +6,7 @@
 - [Selecting items](#selecting)
   - [Selection API](#selection-api)
 - [Snapping to grid](#snapping)
+- [Pushing items](#pushing-items)
 - [Commands](#commands)
 - [Editor API](#editor-api)
 
@@ -90,9 +91,13 @@ Default values:
 
 The following methods can be called on a NodifyEditor instance.
 
+- SelectAll
+- UnselectAll
 - SelectArea
 - InvertSelection
 - UnselectArea
+- SelectAllConnections
+- UnselectAllConnections
 
 ## Snapping
 
@@ -105,6 +110,16 @@ Default values:
 
 - `GridCellSize`: 1
 - `EnableSnappingCorrection`: true
+
+## Pushing Items
+
+The Pushing Items feature allows users to interactively move items within the editor by performing a drag gesture.
+
+To initiate the push operation, hold `CTRL+SHIFT` and click with the **Left Mouse Button**. During the push items operation, the `IsPushingItems` dependency property is set to `true`, the `PushOrientation` dependency property is initialized with the direction the user is dragging, and the `PushedArea` dependency property updates in real time to reflect the interaction state.
+
+To cancel the push operation, press the `Escape` key or release `CTRL+SHIFT` and click the **Right Mouse Button**. You can configure the default keybindings by modifying the `EditorGestures.Editor.PushItems` gesture. To prevent cancellation, set `NodifyEditor.AllowPushItemsCancellation` to `false`.
+
+The visual appearance of the push area can be customized by setting the `PushedAreaStyle` property.
 
 ## Commands
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -20,6 +20,7 @@
 - [Zooming](Editor-Overview#zooming)
 - [Scrolling](Editor-Overview#scrolling)
 - [Selecting items](Editor-Overview#selecting)
+- [Pushing items](Editor-Overview#pushing-items)
 - [Snapping to grid](Editor-Overview#snapping)
 - [Commands](Editor-Overview#commands)
 

--- a/docs/localization/zh-CN/API-Reference.md
+++ b/docs/localization/zh-CN/API-Reference.md
@@ -27,6 +27,7 @@
 - [EditorDefaultState Class](#editordefaultstate-class)  
 - [EditorGestures Class](#editorgestures-class)  
 - [EditorPanningState Class](#editorpanningstate-class)  
+- [EditorPushingItemsState Class](#editorpushingitemsstate-class)  
 - [EditorSelectingState Class](#editorselectingstate-class)  
 - [EditorState Class](#editorstate-class)  
 - [GeneratedInternalTypeHelper Class](#generatedinternaltypehelper-class)  
@@ -3069,6 +3070,92 @@ public override void HandleMouseUp(MouseButtonEventArgs e);
   
 `e` [MouseButtonEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.MouseButtonEventArgs)  
   
+## EditorPushingItemsState Class  
+  
+**Namespace:** Nodify  
+  
+**Assembly:** Nodify  
+  
+**Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class) → [EditorPushingItemsState](#editorpushingitemsstate-class)  
+  
+**References:** [NodifyEditor](#nodifyeditor-class), [EditorState](#editorstate-class)  
+  
+```csharp  
+public class EditorPushingItemsState : EditorState  
+```  
+  
+### Constructors  
+  
+#### EditorPushingItemsState(NodifyEditor)  
+  
+```csharp  
+public EditorPushingItemsState(NodifyEditor editor);  
+```  
+  
+**Parameters**  
+  
+`editor` [NodifyEditor](#nodifyeditor-class)  
+  
+### Properties  
+  
+#### Canceled  
+  
+```csharp  
+public bool Canceled { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean)  
+  
+### Methods  
+  
+#### Enter(EditorState)  
+  
+```csharp  
+public override void Enter(EditorState from);  
+```  
+  
+**Parameters**  
+  
+`from` [EditorState](#editorstate-class)  
+  
+#### Exit()  
+  
+```csharp  
+public override void Exit();  
+```  
+  
+#### HandleKeyUp(KeyEventArgs)  
+  
+```csharp  
+public override void HandleKeyUp(KeyEventArgs e);  
+```  
+  
+**Parameters**  
+  
+`e` [KeyEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.KeyEventArgs)  
+  
+#### HandleMouseMove(MouseEventArgs)  
+  
+```csharp  
+public override void HandleMouseMove(MouseEventArgs e);  
+```  
+  
+**Parameters**  
+  
+`e` [MouseEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.MouseEventArgs)  
+  
+#### HandleMouseUp(MouseButtonEventArgs)  
+  
+```csharp  
+public override void HandleMouseUp(MouseButtonEventArgs e);  
+```  
+  
+**Parameters**  
+  
+`e` [MouseButtonEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.MouseButtonEventArgs)  
+  
 ## EditorSelectingState Class  
   
 **Namespace:** Nodify  
@@ -3191,9 +3278,9 @@ public override void HandleMouseUp(MouseButtonEventArgs e);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class)  
   
-**Derived:** [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorSelectingState](#editorselectingstate-class)  
+**Derived:** [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorPushingItemsState](#editorpushingitemsstate-class), [EditorSelectingState](#editorselectingstate-class)  
   
-**References:** [EditorCuttingState](#editorcuttingstate-class), [EditorPanningState](#editorpanningstate-class), [EditorSelectingState](#editorselectingstate-class), [NodifyEditor](#nodifyeditor-class)  
+**References:** [EditorCuttingState](#editorcuttingstate-class), [EditorPanningState](#editorpanningstate-class), [EditorPushingItemsState](#editorpushingitemsstate-class), [EditorSelectingState](#editorselectingstate-class), [NodifyEditor](#nodifyeditor-class)  
   
 The base class for editor states.  
   
@@ -4515,7 +4602,39 @@ public class LineConnection : BaseConnection
 public LineConnection();  
 ```  
   
+### Properties  
+  
+#### CornerRadius  
+  
+The radius of the corners between the line segments.  
+  
+```csharp  
+public double CornerRadius { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double)  
+  
 ### Methods  
+  
+#### AddSmoothCorner(StreamGeometryContext, Point, Point, Point, Double)  
+  
+```csharp  
+protected static void AddSmoothCorner(StreamGeometryContext context, Point start, Point corner, Point end, double radius);  
+```  
+  
+**Parameters**  
+  
+`context` [StreamGeometryContext](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.StreamGeometryContext)  
+  
+`start` [Point](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Point)  
+  
+`corner` [Point](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Point)  
+  
+`end` [Point](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Point)  
+  
+`radius` [Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double)  
   
 #### DrawDefaultArrowhead(StreamGeometryContext, Point, Point, ConnectionDirection, Orientation)  
   
@@ -5059,6 +5178,28 @@ public class Node : HeaderedContentControl
 public Node();  
 ```  
   
+### Fields  
+  
+#### ElementInputItemsControl  
+  
+```csharp  
+protected const string ElementInputItemsControl = "PART_Input";  
+```  
+  
+**Field Value**  
+  
+[String](https://docs.microsoft.com/en-us/dotnet/api/System.String)  
+  
+#### ElementOutputItemsControl  
+  
+```csharp  
+protected const string ElementOutputItemsControl = "PART_Output";  
+```  
+  
+**Field Value**  
+  
+[String](https://docs.microsoft.com/en-us/dotnet/api/System.String)  
+  
 ### Properties  
   
 #### ContentBrush  
@@ -5193,6 +5334,26 @@ public DataTemplate InputConnectorTemplate { get; set; }
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
   
+#### InputGroupStyle  
+  
+```csharp  
+public ObservableCollection<GroupStyle> InputGroupStyle { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ObservableCollection<GroupStyle>](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.ObjectModel.ObservableCollection)  
+  
+#### InputItemsControl  
+  
+```csharp  
+protected ItemsControl InputItemsControl { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl)  
+  
 #### Output  
   
 Gets or sets the data for the output [Connector](#connector-class)s of this control.  
@@ -5216,6 +5377,34 @@ public DataTemplate OutputConnectorTemplate { get; set; }
 **Property Value**  
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
+  
+#### OutputGroupStyle  
+  
+```csharp  
+public ObservableCollection<GroupStyle> OutputGroupStyle { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ObservableCollection<GroupStyle>](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.ObjectModel.ObservableCollection)  
+  
+#### OutputItemsControl  
+  
+```csharp  
+protected ItemsControl OutputItemsControl { get; set; }  
+```  
+  
+**Property Value**  
+  
+[ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl)  
+  
+### Methods  
+  
+#### OnApplyTemplate()  
+  
+```csharp  
+public override void OnApplyTemplate();  
+```  
   
 ## NodeInput Class  
   
@@ -5437,12 +5626,14 @@ protected override Size MeasureOverride(Size constraint);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl) → [Selector](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.Selector) → [MultiSelector](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.MultiSelector) → [NodifyEditor](#nodifyeditor-class)  
   
-**References:** [ContainerState](#containerstate-class), [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorSelectingState](#editorselectingstate-class), [EditorState](#editorstate-class), [SelectionHelper](#selectionhelper-class), [ItemContainer](#itemcontainer-class), [PendingConnection](#pendingconnection-class), [GroupingNode](#groupingnode-class), [Connector](#connector-class), [CuttingLine](#cuttingline-class), [DecoratorContainer](#decoratorcontainer-class), [EditorCommands](#editorcommands-class), [EditorGestures](#editorgestures-class), [Minimap](#minimap-class), [Connection](#connection-class), [BaseConnection](#baseconnection-class)  
+**Implements:** [IScrollInfo](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.IScrollInfo)  
+  
+**References:** [ContainerState](#containerstate-class), [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorPushingItemsState](#editorpushingitemsstate-class), [EditorSelectingState](#editorselectingstate-class), [EditorState](#editorstate-class), [SelectionHelper](#selectionhelper-class), [ItemContainer](#itemcontainer-class), [PendingConnection](#pendingconnection-class), [GroupingNode](#groupingnode-class), [Connector](#connector-class), [CuttingLine](#cuttingline-class), [DecoratorContainer](#decoratorcontainer-class), [EditorCommands](#editorcommands-class), [EditorGestures](#editorgestures-class), [Minimap](#minimap-class), [Connection](#connection-class), [BaseConnection](#baseconnection-class)  
   
 Groups [ItemContainer](#itemcontainer-class)s and [Connection](#connection-class)s in an area that you can drag, zoom and select.  
   
 ```csharp  
-public class NodifyEditor : MultiSelector  
+public class NodifyEditor : MultiSelector, IScrollInfo  
 ```  
   
 ### Constructors  
@@ -5458,6 +5649,8 @@ public NodifyEditor();
 ### Fields  
   
 #### CuttingConnectionTypes  
+  
+The list of supported connection types for cutting. Type must be derived from [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement).  
   
 ```csharp  
 public static HashSet<Type> CuttingConnectionTypes;  
@@ -5527,6 +5720,16 @@ public static DependencyPropertyKey IsPanningPropertyKey;
   
 [DependencyPropertyKey](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyPropertyKey)  
   
+#### IsPushingItemsPropertyKey  
+  
+```csharp  
+protected static DependencyPropertyKey IsPushingItemsPropertyKey;  
+```  
+  
+**Field Value**  
+  
+[DependencyPropertyKey](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyPropertyKey)  
+  
 #### IsSelectingPropertyKey  
   
 ```csharp  
@@ -5541,6 +5744,26 @@ protected static DependencyPropertyKey IsSelectingPropertyKey;
   
 ```csharp  
 protected static DependencyPropertyKey MouseLocationPropertyKey;  
+```  
+  
+**Field Value**  
+  
+[DependencyPropertyKey](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyPropertyKey)  
+  
+#### PushedAreaOrientationPropertyKey  
+  
+```csharp  
+protected static DependencyPropertyKey PushedAreaOrientationPropertyKey;  
+```  
+  
+**Field Value**  
+  
+[DependencyPropertyKey](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyPropertyKey)  
+  
+#### PushedAreaPropertyKey  
+  
+```csharp  
+protected static DependencyPropertyKey PushedAreaPropertyKey;  
 ```  
   
 **Field Value**  
@@ -5582,6 +5805,18 @@ protected readonly TranslateTransform TranslateTransform;
 [TranslateTransform](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.TranslateTransform)  
   
 ### Properties  
+  
+#### AllowPushItemsCancellation  
+  
+Gets or sets whether push items cancellation is allowed.  
+  
+```csharp  
+public static bool AllowPushItemsCancellation { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean)  
   
 #### AutoPanEdgeDistance  
   
@@ -6023,6 +6258,18 @@ public bool IsPanning { get; set; }
   
 [Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean)  
   
+#### IsPushingItems  
+  
+Gets a value that indicates whether a pushing operation is in progress.  
+  
+```csharp  
+public bool IsPushingItems { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean)  
+  
 #### IsSelecting  
   
 Gets a value that indicates whether a selection operation is in progress.  
@@ -6180,6 +6427,42 @@ public DataTemplate PendingConnectionTemplate { get; set; }
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
   
+#### PushedArea  
+  
+Gets the currently pushed area while [NodifyEditor.IsPushingItems](#nodifyeditor-class#ispushingitems) is true.  
+  
+```csharp  
+public Rect PushedArea { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Rect](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Rect)  
+  
+#### PushedAreaOrientation  
+  
+Gets the orientation of the [NodifyEditor.PushedArea](#nodifyeditor-class#pushedarea).  
+  
+```csharp  
+public Orientation PushedAreaOrientation { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Orientation](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Orientation)  
+  
+#### PushedAreaStyle  
+  
+Gets or sets the style to use for the pushed area.  
+  
+```csharp  
+public Style PushedAreaStyle { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Style](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Style)  
+  
 #### RemoveConnectionCommand  
   
 Invoked when the [BaseConnection.Disconnect](#baseconnection-class#disconnect) event is raised. 
@@ -6193,6 +6476,18 @@ public ICommand RemoveConnectionCommand { get; set; }
 **Property Value**  
   
 [ICommand](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.ICommand)  
+  
+#### ScrollIncrement  
+  
+The number of units the mouse wheel is rotated to scroll one line.  
+  
+```csharp  
+public static double ScrollIncrement { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double)  
   
 #### SelectedArea  
   
@@ -6635,6 +6930,22 @@ public void SelectArea(Rect area, bool append = false, bool fit = false);
   
 `fit` [Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean): True to check if the area contains the [ItemContainer](#itemcontainer-class). False to check if area intersects the [ItemContainer](#itemcontainer-class).  
   
+#### SnapToGrid(Double)  
+  
+Snaps the given value down to the nearest multiple of the grid cell size.  
+  
+```csharp  
+public double SnapToGrid(double value);  
+```  
+  
+**Parameters**  
+  
+`value` [Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double): The value to be snapped to the grid.  
+  
+**Returns**  
+  
+[Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double): The largest multiple of the grid cell size less than or equal to the value.  
+  
 #### UnselectAllConnection()  
   
 Unselect all [NodifyEditor.Connections](#nodifyeditor-class#connections).  
@@ -6759,6 +7070,16 @@ public InputGestureRef FitToScreen { get; set; }
   
 ```csharp  
 public InputGestureRef Pan { get; set; }  
+```  
+  
+**Property Value**  
+  
+[InputGestureRef](#inputgestureref-class)  
+  
+#### PushItems  
+  
+```csharp  
+public InputGestureRef PushItems { get; set; }  
 ```  
   
 **Property Value**  

--- a/docs/localization/zh-CN/API-Reference.md
+++ b/docs/localization/zh-CN/API-Reference.md
@@ -65,6 +65,7 @@
 - [ZoomEventArgs Class](#zoomeventargs-class)  
 - [ZoomEventHandler Delegate](#zoomeventhandler-delegate)  
   
+  
 ## Alignment Enum  
   
 **Namespace:** Nodify  
@@ -259,7 +260,7 @@ Rectangle = 2;
   
 **Derived:** [LineConnection](#lineconnection-class), [Connection](#connection-class)  
   
-**References:** [ConnectionEventHandler](#connectioneventhandler-delegate), [ConnectionDirection](#connectiondirection-enum), [ArrowHeadShape](#arrowheadshape-enum), [ConnectionOffsetMode](#connectionoffsetmode-enum), [ArrowHeadEnds](#arrowheadends-enum), [CuttingLine](#cuttingline-class), [LineConnection](#lineconnection-class), [ConnectionEventArgs](#connectioneventargs-class), [NodifyEditor](#nodifyeditor-class)  
+**References:** [ArrowHeadEnds](#arrowheadends-enum), [ArrowHeadShape](#arrowheadshape-enum), [ConnectionDirection](#connectiondirection-enum), [ConnectionEventArgs](#connectioneventargs-class), [ConnectionEventHandler](#connectioneventhandler-delegate), [ConnectionOffsetMode](#connectionoffsetmode-enum), [CuttingLine](#cuttingline-class), [NodifyEditor](#nodifyeditor-class)  
   
 Represents the base class for shapes that are drawn from a [BaseConnection.Source](#baseconnection-class#source) point to a [BaseConnection.Target](#baseconnection-class#target) point.  
   
@@ -1206,7 +1207,7 @@ protected override ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### GetTextPosition(FormattedText, Point, Point)  
   
@@ -1282,7 +1283,7 @@ protected override ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### GetTextPosition(FormattedText, Point, Point)  
   
@@ -1364,7 +1365,7 @@ Forward = 0;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.EventArgs) → [RoutedEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.RoutedEventArgs) → [ConnectionEventArgs](#connectioneventargs-class)  
   
-**References:** [ConnectionEventHandler](#connectioneventhandler-delegate), [BaseConnection](#baseconnection-class)  
+**References:** [BaseConnection](#baseconnection-class), [ConnectionEventHandler](#connectioneventhandler-delegate)  
   
 Provides data for [BaseConnection](#baseconnection-class) related routed events.  
   
@@ -1434,7 +1435,7 @@ protected override void InvokeEventHandler(Delegate genericHandler, object gener
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [Delegate](https://docs.microsoft.com/en-us/dotnet/api/System.Delegate) → [MulticastDelegate](https://docs.microsoft.com/en-us/dotnet/api/System.MulticastDelegate) → [ConnectionEventHandler](#connectioneventhandler-delegate)  
   
-**References:** [ConnectionEventArgs](#connectioneventargs-class), [BaseConnection](#baseconnection-class)  
+**References:** [BaseConnection](#baseconnection-class), [ConnectionEventArgs](#connectioneventargs-class)  
   
 Represents the method that will handle [BaseConnection](#baseconnection-class) related routed events.  
   
@@ -1580,7 +1581,7 @@ Static = 4;
   
 **Derived:** [NodeInput](#nodeinput-class), [NodeOutput](#nodeoutput-class), [StateNode](#statenode-class)  
   
-**References:** [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate), [ConnectorEventHandler](#connectoreventhandler-delegate), [ItemContainer](#itemcontainer-class), [PendingConnection](#pendingconnection-class), [Connection](#connection-class), [NodifyEditor](#nodifyeditor-class), [ConnectorEventArgs](#connectoreventargs-class), [PendingConnectionEventArgs](#pendingconnectioneventargs-class), [KnotNode](#knotnode-class), [Node](#node-class), [NodeInput](#nodeinput-class), [NodeOutput](#nodeoutput-class), [StateNode](#statenode-class)  
+**References:** [Connection](#connection-class), [ConnectorEventArgs](#connectoreventargs-class), [ConnectorEventHandler](#connectoreventhandler-delegate), [ItemContainer](#itemcontainer-class), [KnotNode](#knotnode-class), [Node](#node-class), [NodifyEditor](#nodifyeditor-class), [PendingConnection](#pendingconnection-class), [PendingConnectionEventArgs](#pendingconnectioneventargs-class), [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate)  
   
 Represents a connector control that can start and complete a [PendingConnection](#pendingconnection-class).
             Has a [Connector.ElementConnector](#connector-class#elementconnector) that the [Connector.Anchor](#connector-class#anchor) is calculated from for the [PendingConnection](#pendingconnection-class). Center of this control is used if missing.  
@@ -1935,7 +1936,7 @@ public event PendingConnectionEventHandler PendingConnectionStarted;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.EventArgs) → [RoutedEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.RoutedEventArgs) → [ConnectorEventArgs](#connectoreventargs-class)  
   
-**References:** [ConnectorEventHandler](#connectoreventhandler-delegate), [Connector](#connector-class)  
+**References:** [Connector](#connector-class), [ConnectorEventHandler](#connectoreventhandler-delegate)  
   
 Provides data for [Connector](#connector-class) related routed events.  
   
@@ -2005,7 +2006,7 @@ protected override void InvokeEventHandler(Delegate genericHandler, object gener
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [Delegate](https://docs.microsoft.com/en-us/dotnet/api/System.Delegate) → [MulticastDelegate](https://docs.microsoft.com/en-us/dotnet/api/System.MulticastDelegate) → [ConnectorEventHandler](#connectoreventhandler-delegate)  
   
-**References:** [ConnectorEventArgs](#connectoreventargs-class), [Connector](#connector-class)  
+**References:** [Connector](#connector-class), [ConnectorEventArgs](#connectoreventargs-class)  
   
 Represents the method that will handle [Connector](#connector-class) related routed events.  
   
@@ -2131,7 +2132,7 @@ Top = 0;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [ContainerState](#containerstate-class) → [ContainerDefaultState](#containerdefaultstate-class)  
   
-**References:** [ItemContainer](#itemcontainer-class), [ContainerState](#containerstate-class)  
+**References:** [ItemContainer](#itemcontainer-class)  
   
 The default state of the [ItemContainer](#itemcontainer-class).  
   
@@ -2203,7 +2204,7 @@ public override void ReEnter(ContainerState from);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [ContainerState](#containerstate-class) → [ContainerDraggingState](#containerdraggingstate-class)  
   
-**References:** [ItemContainer](#itemcontainer-class), [ContainerState](#containerstate-class)  
+**References:** [ItemContainer](#itemcontainer-class)  
   
 Dragging state of the container.  
   
@@ -2659,7 +2660,7 @@ public event RoutedEventHandler LocationChanged;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorCommands](#editorcommands-class)  
   
-**References:** [ItemContainer](#itemcontainer-class), [NodifyEditor](#nodifyeditor-class), [InputGestureRef](#inputgestureref-class)  
+**References:** [InputGestureRef](#inputgestureref-class), [ItemContainer](#itemcontainer-class), [NodifyEditor](#nodifyeditor-class)  
   
 ```csharp  
 public static class EditorCommands  
@@ -2749,7 +2750,7 @@ public static RoutedUICommand ZoomOut { get; set; }
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class) → [EditorCuttingState](#editorcuttingstate-class)  
   
-**References:** [NodifyEditor](#nodifyeditor-class), [EditorState](#editorstate-class)  
+**References:** [NodifyEditor](#nodifyeditor-class)  
   
 ```csharp  
 public class EditorCuttingState : EditorState  
@@ -2886,7 +2887,7 @@ public override void HandleMouseDown(MouseButtonEventArgs e);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorGestures](#editorgestures-class)  
   
-**References:** [NodifyEditorGestures](#nodifyeditorgestures-class), [ItemContainerGestures](#itemcontainergestures-class), [ConnectorGestures](#connectorgestures-class), [ConnectionGestures](#connectiongestures-class), [GroupingNodeGestures](#groupingnodegestures-class), [MinimapGestures](#minimapgestures-class), [NodifyEditor](#nodifyeditor-class)  
+**References:** [ConnectionGestures](#connectiongestures-class), [ConnectorGestures](#connectorgestures-class), [GroupingNodeGestures](#groupingnodegestures-class), [ItemContainerGestures](#itemcontainergestures-class), [MinimapGestures](#minimapgestures-class), [NodifyEditor](#nodifyeditor-class), [NodifyEditorGestures](#nodifyeditorgestures-class)  
   
 Gestures used by built-in controls inside the [NodifyEditor](#nodifyeditor-class).  
   
@@ -3010,7 +3011,7 @@ public void Apply(EditorGestures gestures);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class) → [EditorPanningState](#editorpanningstate-class)  
   
-**References:** [NodifyEditor](#nodifyeditor-class), [EditorState](#editorstate-class)  
+**References:** [NodifyEditor](#nodifyeditor-class)  
   
 The panning state of the editor.  
   
@@ -3078,7 +3079,7 @@ public override void HandleMouseUp(MouseButtonEventArgs e);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class) → [EditorPushingItemsState](#editorpushingitemsstate-class)  
   
-**References:** [NodifyEditor](#nodifyeditor-class), [EditorState](#editorstate-class)  
+**References:** [NodifyEditor](#nodifyeditor-class)  
   
 ```csharp  
 public class EditorPushingItemsState : EditorState  
@@ -3164,7 +3165,7 @@ public override void HandleMouseUp(MouseButtonEventArgs e);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EditorState](#editorstate-class) → [EditorSelectingState](#editorselectingstate-class)  
   
-**References:** [NodifyEditor](#nodifyeditor-class), [SelectionType](#selectiontype-enum), [SelectionHelper](#selectionhelper-class), [EditorState](#editorstate-class)  
+**References:** [NodifyEditor](#nodifyeditor-class), [SelectionHelper](#selectionhelper-class), [SelectionType](#selectiontype-enum)  
   
 The selecting state of the editor.  
   
@@ -3598,7 +3599,7 @@ Self = 1;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [ContentControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ContentControl) → [HeaderedContentControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.HeaderedContentControl) → [GroupingNode](#groupingnode-class)  
   
-**References:** [ResizeEventHandler](#resizeeventhandler-delegate), [GroupingMovementMode](#groupingmovementmode-enum), [NodifyEditor](#nodifyeditor-class), [ItemContainer](#itemcontainer-class)  
+**References:** [GroupingMovementMode](#groupingmovementmode-enum), [ItemContainer](#itemcontainer-class), [NodifyEditor](#nodifyeditor-class), [ResizeEventHandler](#resizeeventhandler-delegate)  
   
 Defines a panel with a header that groups [ItemContainer](#itemcontainer-class)s inside it and can be resized.  
   
@@ -3938,7 +3939,7 @@ public virtual void Arrange(Rect rect);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [InputGesture](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Input.InputGesture) → [InputGestureRef](#inputgestureref-class)  
   
-**References:** [SelectionGestures](#selectiongestures-class), [ItemContainerGestures](#itemcontainergestures-class), [NodifyEditorGestures](#nodifyeditorgestures-class), [ConnectorGestures](#connectorgestures-class), [ConnectionGestures](#connectiongestures-class), [MinimapGestures](#minimapgestures-class), [EditorCommands](#editorcommands-class)  
+**References:** [ConnectionGestures](#connectiongestures-class), [ConnectorGestures](#connectorgestures-class), [EditorCommands](#editorcommands-class), [ItemContainerGestures](#itemcontainergestures-class), [MinimapGestures](#minimapgestures-class), [NodifyEditorGestures](#nodifyeditorgestures-class), [SelectionGestures](#selectiongestures-class)  
   
 An input gesture that allows changing its logic at runtime without changing its reference.
             Useful for classes that capture the object reference without the posibility of updating it. (e.g. [EditorCommands](#editorcommands-class))  
@@ -3989,7 +3990,7 @@ public override bool Matches(object targetElement, InputEventArgs inputEventArgs
   
 **Implements:** [INodifyCanvasItem](#inodifycanvasitem-interface)  
   
-**References:** [Connector](#connector-class), [ContainerDefaultState](#containerdefaultstate-class), [ContainerDraggingState](#containerdraggingstate-class), [ContainerState](#containerstate-class), [NodifyEditor](#nodifyeditor-class), [PreviewLocationChanged](#previewlocationchanged-delegate), [GroupingNode](#groupingnode-class), [PendingConnection](#pendingconnection-class), [EditorCommands](#editorcommands-class), [SelectionHelper](#selectionhelper-class)  
+**References:** [Connector](#connector-class), [ContainerDefaultState](#containerdefaultstate-class), [ContainerDraggingState](#containerdraggingstate-class), [ContainerState](#containerstate-class), [EditorCommands](#editorcommands-class), [GroupingNode](#groupingnode-class), [NodifyEditor](#nodifyeditor-class), [PendingConnection](#pendingconnection-class), [PreviewLocationChanged](#previewlocationchanged-delegate), [SelectionHelper](#selectionhelper-class)  
   
 The container for all the items generated by the [ItemsControl.ItemsSource](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl.itemssource) of the [NodifyEditor](#nodifyeditor-class).  
   
@@ -4494,7 +4495,7 @@ public event RoutedEventHandler Unselected;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [ItemContainerGestures](#itemcontainergestures-class)  
   
-**References:** [EditorGestures](#editorgestures-class), [SelectionGestures](#selectiongestures-class), [InputGestureRef](#inputgestureref-class)  
+**References:** [EditorGestures](#editorgestures-class), [InputGestureRef](#inputgestureref-class), [SelectionGestures](#selectiongestures-class)  
   
 ```csharp  
 public class ItemContainerGestures  
@@ -4586,7 +4587,7 @@ public KnotNode();
   
 **Derived:** [CircuitConnection](#circuitconnection-class), [StepConnection](#stepconnection-class)  
   
-**References:** [ConnectionDirection](#connectiondirection-enum), [BaseConnection](#baseconnection-class)  
+**References:** [ConnectionDirection](#connectiondirection-enum)  
   
 Represents a line that has an arrow indicating its [BaseConnection.Direction](#baseconnection-class#direction).  
   
@@ -4684,7 +4685,7 @@ protected override ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### InterpolateLine(Point, Point, Point, Point, Double)  
   
@@ -4706,7 +4707,7 @@ protected static ValueTuple<ValueTuple<Point, Point>, Point> InterpolateLine(Poi
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, Point>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, Point>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### InterpolateLine(Point, Point, Point, Double)  
   
@@ -4726,7 +4727,7 @@ protected static ValueTuple<ValueTuple<Point, Point>, Point> InterpolateLine(Poi
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, Point>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, Point>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### InterpolateLineSegment(Point, Point, Double)  
   
@@ -4780,7 +4781,7 @@ Any = 0;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [ItemsControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ItemsControl) → [Minimap](#minimap-class)  
   
-**References:** [ZoomEventHandler](#zoomeventhandler-delegate), [MinimapItem](#minimapitem-class), [NodifyEditor](#nodifyeditor-class), [ZoomEventArgs](#zoomeventargs-class)  
+**References:** [MinimapItem](#minimapitem-class), [NodifyEditor](#nodifyeditor-class), [ZoomEventArgs](#zoomeventargs-class), [ZoomEventHandler](#zoomeventhandler-delegate)  
   
 A minimap control that can position the viewport, and zoom in and out.  
   
@@ -5414,7 +5415,7 @@ public override void OnApplyTemplate();
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [Connector](#connector-class) → [NodeInput](#nodeinput-class)  
   
-**References:** [Node](#node-class), [Connector](#connector-class)  
+**References:** [Node](#node-class)  
   
 Represents the default control for the [Node.InputConnectorTemplate](#node-class#inputconnectortemplate).  
   
@@ -5486,7 +5487,7 @@ public Orientation Orientation { get; set; }
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [Connector](#connector-class) → [NodeOutput](#nodeoutput-class)  
   
-**References:** [Node](#node-class), [Connector](#connector-class)  
+**References:** [Node](#node-class)  
   
 Represents the default control for the [Node.OutputConnectorTemplate](#node-class#outputconnectortemplate).  
   
@@ -5628,7 +5629,7 @@ protected override Size MeasureOverride(Size constraint);
   
 **Implements:** [IScrollInfo](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Primitives.IScrollInfo)  
   
-**References:** [ContainerState](#containerstate-class), [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorPanningState](#editorpanningstate-class), [EditorPushingItemsState](#editorpushingitemsstate-class), [EditorSelectingState](#editorselectingstate-class), [EditorState](#editorstate-class), [SelectionHelper](#selectionhelper-class), [ItemContainer](#itemcontainer-class), [PendingConnection](#pendingconnection-class), [GroupingNode](#groupingnode-class), [Connector](#connector-class), [CuttingLine](#cuttingline-class), [DecoratorContainer](#decoratorcontainer-class), [EditorCommands](#editorcommands-class), [EditorGestures](#editorgestures-class), [Minimap](#minimap-class), [Connection](#connection-class), [BaseConnection](#baseconnection-class)  
+**References:** [BaseConnection](#baseconnection-class), [Connection](#connection-class), [Connector](#connector-class), [ContainerState](#containerstate-class), [CuttingLine](#cuttingline-class), [DecoratorContainer](#decoratorcontainer-class), [EditorCommands](#editorcommands-class), [EditorCuttingState](#editorcuttingstate-class), [EditorDefaultState](#editordefaultstate-class), [EditorGestures](#editorgestures-class), [EditorPanningState](#editorpanningstate-class), [EditorPushingItemsState](#editorpushingitemsstate-class), [EditorSelectingState](#editorselectingstate-class), [EditorState](#editorstate-class), [GroupingNode](#groupingnode-class), [ItemContainer](#itemcontainer-class), [Minimap](#minimap-class), [PendingConnection](#pendingconnection-class), [SelectionHelper](#selectionhelper-class)  
   
 Groups [ItemContainer](#itemcontainer-class)s and [Connection](#connection-class)s in an area that you can drag, zoom and select.  
   
@@ -7020,7 +7021,7 @@ public event RoutedEventHandler ViewportUpdated;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [NodifyEditorGestures](#nodifyeditorgestures-class)  
   
-**References:** [EditorGestures](#editorgestures-class), [SelectionGestures](#selectiongestures-class), [InputGestureRef](#inputgestureref-class)  
+**References:** [EditorGestures](#editorgestures-class), [InputGestureRef](#inputgestureref-class), [SelectionGestures](#selectiongestures-class)  
   
 ```csharp  
 public class NodifyEditorGestures  
@@ -7156,7 +7157,7 @@ public void Apply(NodifyEditorGestures gestures);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [ContentControl](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.ContentControl) → [PendingConnection](#pendingconnection-class)  
   
-**References:** [PendingConnectionEventArgs](#pendingconnectioneventargs-class), [ConnectionDirection](#connectiondirection-enum), [NodifyEditor](#nodifyeditor-class), [Connector](#connector-class), [ItemContainer](#itemcontainer-class), [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate), [StateNode](#statenode-class)  
+**References:** [ConnectionDirection](#connectiondirection-enum), [Connector](#connector-class), [ItemContainer](#itemcontainer-class), [NodifyEditor](#nodifyeditor-class), [PendingConnectionEventArgs](#pendingconnectioneventargs-class), [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate), [StateNode](#statenode-class)  
   
 Represents a pending connection usually started by a [Connector](#connector-class) which invokes the [PendingConnection.CompletedCommand](#pendingconnection-class#completedcommand) when completed.  
   
@@ -7449,7 +7450,7 @@ public static void SetIsOverElement(UIElement elem, bool value);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.EventArgs) → [RoutedEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.RoutedEventArgs) → [PendingConnectionEventArgs](#pendingconnectioneventargs-class)  
   
-**References:** [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate), [PendingConnection](#pendingconnection-class), [Connector](#connector-class)  
+**References:** [Connector](#connector-class), [PendingConnection](#pendingconnection-class), [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate)  
   
 Provides data for [PendingConnection](#pendingconnection-class) related routed events.  
   
@@ -7567,7 +7568,7 @@ protected override void InvokeEventHandler(Delegate genericHandler, object gener
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [Delegate](https://docs.microsoft.com/en-us/dotnet/api/System.Delegate) → [MulticastDelegate](https://docs.microsoft.com/en-us/dotnet/api/System.MulticastDelegate) → [PendingConnectionEventHandler](#pendingconnectioneventhandler-delegate)  
   
-**References:** [PendingConnectionEventArgs](#pendingconnectioneventargs-class), [Connector](#connector-class), [PendingConnection](#pendingconnection-class)  
+**References:** [Connector](#connector-class), [PendingConnection](#pendingconnection-class), [PendingConnectionEventArgs](#pendingconnectioneventargs-class)  
   
 Represents the method that will handle [PendingConnection](#pendingconnection-class) related routed events.  
   
@@ -7681,7 +7682,7 @@ protected override void InvokeEventHandler(Delegate genericHandler, object gener
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [Delegate](https://docs.microsoft.com/en-us/dotnet/api/System.Delegate) → [MulticastDelegate](https://docs.microsoft.com/en-us/dotnet/api/System.MulticastDelegate) → [ResizeEventHandler](#resizeeventhandler-delegate)  
   
-**References:** [ResizeEventArgs](#resizeeventargs-class), [GroupingNode](#groupingnode-class)  
+**References:** [GroupingNode](#groupingnode-class), [ResizeEventArgs](#resizeeventargs-class)  
   
 Represents the method that will handle resize related routed events.  
   
@@ -7703,7 +7704,7 @@ public delegate void ResizeEventHandler(object sender, ResizeEventArgs e);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [SelectionGestures](#selectiongestures-class)  
   
-**References:** [InputGestureRef](#inputgestureref-class), [ItemContainerGestures](#itemcontainergestures-class), [NodifyEditorGestures](#nodifyeditorgestures-class), [ConnectionGestures](#connectiongestures-class)  
+**References:** [ConnectionGestures](#connectiongestures-class), [InputGestureRef](#inputgestureref-class), [ItemContainerGestures](#itemcontainergestures-class), [NodifyEditorGestures](#nodifyeditorgestures-class)  
   
 ```csharp  
 public class SelectionGestures  
@@ -7821,7 +7822,7 @@ public void Apply(SelectionGestures gestures);
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [SelectionHelper](#selectionhelper-class)  
   
-**References:** [EditorSelectingState](#editorselectingstate-class), [NodifyEditor](#nodifyeditor-class), [SelectionType](#selectiontype-enum), [ItemContainer](#itemcontainer-class)  
+**References:** [EditorSelectingState](#editorselectingstate-class), [ItemContainer](#itemcontainer-class), [NodifyEditor](#nodifyeditor-class), [SelectionType](#selectiontype-enum)  
   
 Helps with selecting [ItemContainer](#itemcontainer-class)s and updating the [NodifyEditor.SelectedArea](#nodifyeditor-class#selectedarea) and [NodifyEditor.IsSelecting](#nodifyeditor-class#isselecting) properties.  
   
@@ -7933,7 +7934,7 @@ Replace = 0;
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [DispatcherObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Threading.DispatcherObject) → [DependencyObject](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DependencyObject) → [Visual](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Visual) → [UIElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.UIElement) → [FrameworkElement](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.FrameworkElement) → [Control](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Control) → [Connector](#connector-class) → [StateNode](#statenode-class)  
   
-**References:** [Connector](#connector-class), [PendingConnection](#pendingconnection-class)  
+**References:** [PendingConnection](#pendingconnection-class)  
   
 Represents a control that acts as a [Connector](#connector-class).  
   
@@ -8131,7 +8132,7 @@ protected override ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>
   
 **Returns**  
   
-[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)
+[ValueTuple<ValueTuple<Point, Point>, ValueTuple<Point, Point>>](https://docs.microsoft.com/en-us/dotnet/api/System.ValueTuple)  
   
 #### GetTextPosition(FormattedText, Point, Point)  
   
@@ -8159,7 +8160,7 @@ protected override Point GetTextPosition(FormattedText text, Point source, Point
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [EventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.EventArgs) → [RoutedEventArgs](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.RoutedEventArgs) → [ZoomEventArgs](#zoomeventargs-class)  
   
-**References:** [ZoomEventHandler](#zoomeventhandler-delegate), [Minimap](#minimap-class)  
+**References:** [Minimap](#minimap-class), [ZoomEventHandler](#zoomeventhandler-delegate)  
   
 Provides data for [Minimap.Zoom](#minimap-class#zoom) routed event.  
   
@@ -8231,7 +8232,7 @@ protected override void InvokeEventHandler(Delegate genericHandler, object gener
   
 **Inheritance:** [Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object) → [Delegate](https://docs.microsoft.com/en-us/dotnet/api/System.Delegate) → [MulticastDelegate](https://docs.microsoft.com/en-us/dotnet/api/System.MulticastDelegate) → [ZoomEventHandler](#zoomeventhandler-delegate)  
   
-**References:** [ZoomEventArgs](#zoomeventargs-class), [Minimap](#minimap-class)  
+**References:** [Minimap](#minimap-class), [ZoomEventArgs](#zoomeventargs-class)  
   
 Represents the method that will handle [Minimap.Zoom](#minimap-class#zoom) routed event.  
   


### PR DESCRIPTION
### 📝 Description of the Change

Interactively move all items relative to the cursor within the editor by performing a drag gesture.

New editor dependency properties:
- PushedAreaOrientation
- IsPushingItems
- PushedAreaStyle

New gestures:
- EditorGestures.Editor.PushItems - `CTRL+SHIFT+LeftClick`

New utility functions:
- NodifyEditor.SnapToGrid

![push-items](https://github.com/user-attachments/assets/21b64b46-3312-421b-9356-bef4a2baef92)

### 🐛 Possible Drawbacks

None that I can think of.
