### PR TITLE
Fix ItemContainer borders not reacting to theme changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 >	- Added PushedAreaStyle, PushedAreaOrientation and IsPushingItems dependency properties to NodifyEditor
 >	- Added NodifyEditor.SnapToGrid utility function
 > - Bugfixes:
+>	- Fixed ItemContainer.BorderBrush and ItemContainer.SelectedBrush not reacting to theme changes
 
 #### **Version 6.5.0**
 

--- a/Nodify/Themes/Brushes.xaml
+++ b/Nodify/Themes/Brushes.xaml
@@ -51,7 +51,7 @@
                   TileMode="Tile">
         <DrawingBrush.Drawing>
             <DrawingGroup>
-                <GeometryDrawing Brush="{DynamicResource ItemContainer.BorderBrush}">
+                <GeometryDrawing Brush="{StaticResource ItemContainer.BorderBrush}">
                     <GeometryDrawing.Geometry>
                         <GeometryGroup>
                             <RectangleGeometry Rect="0 0 50 50" />

--- a/Nodify/Themes/Controls.xaml
+++ b/Nodify/Themes/Controls.xaml
@@ -47,9 +47,9 @@
         <Setter Property="HighlightBrush"
                 Value="{StaticResource ItemContainer.HighlightBrush}" />
         <Setter Property="BorderBrush"
-                Value="{StaticResource ItemContainer.BorderBrush}" />
+                Value="{DynamicResource ItemContainer.BorderBrush}" />
         <Setter Property="SelectedBrush"
-                Value="{StaticResource ItemContainer.SelectedBrush}" />
+                Value="{DynamicResource ItemContainer.SelectedBrush}" />
     </Style>
 
     <!--DECORATOR CONTAINER-->


### PR DESCRIPTION
### 📝 Description of the Change

Fixes `ItemContainer.BorderBrush` and `ItemContainer.SelectedBrush` not reacting to theme changes.

![borders](https://github.com/user-attachments/assets/da7a28a8-ed46-4c4b-96c8-fc406bb917ab)

Fixes #111

### 🐛 Possible Drawbacks

None.
