### PR TITLE
Improve cutting methods in NodifyEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 > - Breaking Changes:
 >	- Made the setter of NodifyEditor.IsPanning private
+>	- Renamed StartCutting to BeginCutting in NodifyEditor
 > - Features:
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor
+>	- Added UpdateCutting to NodifyEditor
 > - Bugfixes:
 	
 #### **Version 6.6.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 >	- Renamed StartCutting to BeginCutting in NodifyEditor
 > - Features:
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor
->	- Added UpdateCutting to NodifyEditor
+>	- Added UpdateCuttingLine to NodifyEditor
 > - Bugfixes:
 	
 #### **Version 6.6.0**

--- a/Nodify/Connections/CuttingLine.cs
+++ b/Nodify/Connections/CuttingLine.cs
@@ -21,7 +21,7 @@ namespace Nodify
             => elem.SetValue(IsOverElementProperty, value);
 
         /// <summary>
-        /// Gets or sets whether cancelling a cutting operation is allowed.
+        /// Gets or sets whether cancelling a cutting operation is allowed (see <see cref="EditorGestures.NodifyEditorGestures.CancelAction"/>).
         /// </summary>
         public static bool AllowCuttingCancellation { get; set; } = true;
 

--- a/Nodify/EditorStates/EditorCuttingState.cs
+++ b/Nodify/EditorStates/EditorCuttingState.cs
@@ -1,15 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Windows;
-using System.Windows.Input;
-using System.Windows.Media;
+﻿using System.Windows.Input;
 
 namespace Nodify
 {
     public class EditorCuttingState : EditorState
     {
-        private readonly LineGeometry _lineGeometry = new LineGeometry();
-        private List<FrameworkElement>? _previousConnections;
-
         public bool Canceled { get; set; } = CuttingLine.AllowCuttingCancellation;
 
         public EditorCuttingState(NodifyEditor editor) : base(editor)
@@ -20,17 +14,11 @@ namespace Nodify
         {
             Canceled = false;
 
-            var startLocation = Editor.MouseLocation;
-            Editor.StartCutting(startLocation);
-
-            _lineGeometry.StartPoint = startLocation;
-            _lineGeometry.EndPoint = startLocation;
+            Editor.BeginCutting(Editor.MouseLocation);
         }
 
         public override void Exit()
         {
-            ResetConnectionStyle();
-
             // TODO: This is not canceled on LostMouseCapture (add OnLostMouseCapture/OnCancel callback?)
             if (Canceled)
             {
@@ -38,7 +26,7 @@ namespace Nodify
             }
             else
             {
-                Editor.EndCutting(Editor.MouseLocation);
+                Editor.EndCutting();
             }
         }
 
@@ -60,32 +48,7 @@ namespace Nodify
 
         public override void HandleMouseMove(MouseEventArgs e)
         {
-            Editor.CuttingLineEnd = Editor.MouseLocation;
-
-            if (NodifyEditor.EnableCuttingLinePreview)
-            {
-                ResetConnectionStyle();
-
-                _lineGeometry.EndPoint = Editor.MouseLocation;
-                var connections = Editor.ConnectionsHost.GetIntersectingElements(_lineGeometry, NodifyEditor.CuttingConnectionTypes);
-                foreach (var connection in connections)
-                {
-                    CuttingLine.SetIsOverElement(connection, true);
-                }
-
-                _previousConnections = connections;
-            }
-        }
-
-        private void ResetConnectionStyle()
-        {
-            if (_previousConnections != null)
-            {
-                foreach (var connection in _previousConnections)
-                {
-                    CuttingLine.SetIsOverElement(connection, false);
-                }
-            }
+            Editor.UpdateCuttingLine(Editor.MouseLocation);
         }
 
         public override void HandleKeyUp(KeyEventArgs e)

--- a/Nodify/EditorStates/EditorPanningState.cs
+++ b/Nodify/EditorStates/EditorPanningState.cs
@@ -21,6 +21,7 @@ namespace Nodify
         /// <inheritdoc />
         public override void Exit()
         {
+            // TODO: This is not canceled on LostMouseCapture (add OnLostMouseCapture/OnCancel callback?)
             if (Canceled)
             {
                 Editor.CancelPanning();

--- a/Nodify/NodifyEditor.Cutting.cs
+++ b/Nodify/NodifyEditor.Cutting.cs
@@ -1,0 +1,244 @@
+﻿using System.Collections.Generic;
+using System;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Diagnostics;
+
+namespace Nodify
+{
+    [StyleTypedProperty(Property = nameof(CuttingLineStyle), StyleTargetType = typeof(CuttingLine))]
+    public partial class NodifyEditor
+    {
+        protected static readonly DependencyPropertyKey CuttingLineStartPropertyKey = DependencyProperty.RegisterReadOnly(nameof(CuttingLineStart), typeof(Point), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Point));
+        public static readonly DependencyProperty CuttingLineStartProperty = CuttingLineStartPropertyKey.DependencyProperty;
+
+        protected static readonly DependencyPropertyKey CuttingLineEndPropertyKey = DependencyProperty.RegisterReadOnly(nameof(CuttingLineEnd), typeof(Point), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Point));
+        public static readonly DependencyProperty CuttingLineEndProperty = CuttingLineEndPropertyKey.DependencyProperty;
+
+        protected static readonly DependencyPropertyKey IsCuttingPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsCutting), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False, OnIsCuttingChanged));
+        public static readonly DependencyProperty IsCuttingProperty = IsCuttingPropertyKey.DependencyProperty;
+
+        public static readonly DependencyProperty CuttingLineStyleProperty = DependencyProperty.Register(nameof(CuttingLineStyle), typeof(Style), typeof(NodifyEditor));
+
+        public static readonly DependencyProperty CuttingStartedCommandProperty = DependencyProperty.Register(nameof(CuttingStartedCommand), typeof(ICommand), typeof(NodifyEditor));
+        public static readonly DependencyProperty CuttingCompletedCommandProperty = DependencyProperty.Register(nameof(CuttingCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
+
+        private static void OnIsCuttingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var editor = (NodifyEditor)d;
+            if ((bool)e.NewValue == true)
+                editor.OnCuttingStarted();
+            else
+                editor.OnCuttingCompleted();
+        }
+
+        private void OnCuttingCompleted()
+        {
+            if (CuttingCompletedCommand?.CanExecute(DataContext) ?? false)
+                CuttingCompletedCommand.Execute(DataContext);
+        }
+
+        private void OnCuttingStarted()
+        {
+            if (CuttingStartedCommand?.CanExecute(DataContext) ?? false)
+                CuttingStartedCommand.Execute(DataContext);
+        }
+
+        /// <summary>
+        /// Gets or sets the style to use for the cutting line.
+        /// </summary>
+        public Style CuttingLineStyle
+        {
+            get => (Style)GetValue(CuttingLineStyleProperty);
+            set => SetValue(CuttingLineStyleProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the start point of the <see cref="CuttingLine"/> while <see cref="IsCutting"/> is true.
+        /// </summary>
+        public Point CuttingLineStart
+        {
+            get => (Point)GetValue(CuttingLineStartProperty);
+            private set => SetValue(CuttingLineStartPropertyKey, value);
+        }
+
+        /// <summary>
+        /// Gets the end point of the <see cref="CuttingLine"/> while <see cref="IsCutting"/> is true.
+        /// </summary>
+        public Point CuttingLineEnd
+        {
+            get => (Point)GetValue(CuttingLineEndProperty);
+            private set => SetValue(CuttingLineEndPropertyKey, value);
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether a cutting operation is in progress.
+        /// </summary>
+        public bool IsCutting
+        {
+            get => (bool)GetValue(IsCuttingProperty);
+            private set => SetValue(IsCuttingPropertyKey, value);
+        }
+
+        /// <summary>Invoked when a cutting operation is started.</summary>
+        public ICommand? CuttingStartedCommand
+        {
+            get => (ICommand?)GetValue(CuttingStartedCommandProperty);
+            set => SetValue(CuttingStartedCommandProperty, value);
+        }
+
+        /// <summary>Invoked when a cutting operation is completed.</summary>
+        public ICommand? CuttingCompletedCommand
+        {
+            get => (ICommand?)GetValue(CuttingCompletedCommandProperty);
+            set => SetValue(CuttingCompletedCommandProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether the cutting line should apply the preview style to the interesected elements.
+        /// </summary>
+        /// <remarks>
+        /// This may hurt performance because intersection must be calculated on mouse move.
+        /// </remarks>
+        public static bool EnableCuttingLinePreview { get; set; } = false;
+
+        /// <summary>
+        /// The list of supported connection types for cutting. Type must be derived from <see cref="FrameworkElement" />.
+        /// </summary>
+        public static readonly HashSet<Type> CuttingConnectionTypes = new HashSet<Type>();
+
+        private List<FrameworkElement>? _cuttingLinePreviousConnections;
+        private readonly LineGeometry _cuttingLineGeometry = new LineGeometry();
+
+        /// <summary>
+        /// Starts the cutting operation at the specified location. Call <see cref="EndCutting"/> to complete the operation or <see cref="CancelCutting"/> to abort it.
+        /// </summary>
+        /// <remarks>This method has no effect if a cutting operation is already in progress.</remarks>
+        /// <param name="location">The starting location for cutting items, in graph space coordinates.</param>
+        public void BeginCutting(Point location)
+        {
+            if (IsCutting)
+            {
+                return;
+            }
+
+            CuttingLineStart = location;
+            CuttingLineEnd = location;
+            IsCutting = true;
+
+            _cuttingLineGeometry.StartPoint = location;
+            _cuttingLineGeometry.EndPoint = location;
+        }
+
+        /// <summary>
+        /// Updates the current cutting line position and the style for the intersecting elements if <see cref="EnableCuttingLinePreview"/> is true.
+        /// </summary>
+        /// <param name="amount">The amount to adjust the cutting line's endpoint.</param>
+        public void UpdateCuttingLine(Vector amount)
+        {
+            CuttingLineEnd += amount;
+
+            UpdateCuttingLine(CuttingLineEnd);
+        }
+
+        /// <summary>
+        /// Updates the current cutting line position and the style for the intersecting elements if <see cref="EnableCuttingLinePreview"/> is true.
+        /// </summary>
+        /// <param name="location">The location of the cutting line's endpoint.</param>
+        public void UpdateCuttingLine(Point location)
+        {
+            Debug.Assert(IsCutting);
+            CuttingLineEnd = location;
+
+            if (EnableCuttingLinePreview)
+            {
+                _cuttingLineGeometry.EndPoint = CuttingLineEnd;
+
+                ResetConnectionStyle();
+                ApplyConnectionStyle();
+            }
+        }
+
+        /// <summary>
+        /// Cancels the current cutting operation without applying any changes.
+        /// </summary>
+        /// <remarks>This method has no effect if there's no cutting operation in progress.</remarks>
+        public void CancelCutting()
+        {
+            if (!CuttingLine.AllowCuttingCancellation || !IsCutting)
+            {
+                return;
+            }
+
+            ResetConnectionStyle();
+            IsCutting = false;
+        }
+
+        /// <summary>
+        /// Completes the cutting operation and applies the changes.
+        /// </summary>
+        /// <remarks>This method has no effect if there's no cutting operation in progress.</remarks>
+        public void EndCutting()
+        {
+            if (!IsCutting)
+            {
+                return;
+            }
+
+            ResetConnectionStyle();
+
+            var lineGeometry = new LineGeometry(CuttingLineStart, CuttingLineEnd);
+            var connections = ConnectionsHost.GetIntersectingElements(lineGeometry, CuttingConnectionTypes);
+
+            if (RemoveConnectionCommand != null)
+            {
+                foreach (var connection in connections)
+                {
+                    OnRemoveConnection(connection.DataContext);
+                }
+            }
+            else
+            {
+                RemoveSupportedConnections(connections);
+            }
+
+            IsCutting = false;
+        }
+
+        private static void RemoveSupportedConnections(List<FrameworkElement> connections)
+        {
+            foreach (var connection in connections)
+            {
+                if (connection is BaseConnection bc)
+                {
+                    bc.OnDisconnect();
+                }
+            }
+        }
+
+        private void ApplyConnectionStyle()
+        {
+            var connections = ConnectionsHost.GetIntersectingElements(_cuttingLineGeometry, CuttingConnectionTypes);
+            foreach (var connection in connections)
+            {
+                CuttingLine.SetIsOverElement(connection, true);
+            }
+
+            _cuttingLinePreviousConnections = connections;
+        }
+
+        private void ResetConnectionStyle()
+        {
+            if (_cuttingLinePreviousConnections != null)
+            {
+                foreach (var connection in _cuttingLinePreviousConnections)
+                {
+                    CuttingLine.SetIsOverElement(connection, false);
+                }
+
+                _cuttingLinePreviousConnections = null;
+            }
+        }
+    }
+}

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -21,7 +21,6 @@ namespace Nodify
     [StyleTypedProperty(Property = nameof(ItemContainerStyle), StyleTargetType = typeof(ItemContainer))]
     [StyleTypedProperty(Property = nameof(DecoratorContainerStyle), StyleTargetType = typeof(DecoratorContainer))]
     [StyleTypedProperty(Property = nameof(SelectionRectangleStyle), StyleTargetType = typeof(Rectangle))]
-    [StyleTypedProperty(Property = nameof(CuttingLineStyle), StyleTargetType = typeof(CuttingLine))]
     [ContentProperty(nameof(Decorators))]
     [DefaultProperty(nameof(Decorators))]
     public partial class NodifyEditor : MultiSelector
@@ -252,7 +251,6 @@ namespace Nodify
         public static readonly DependencyProperty DecoratorTemplateProperty = DependencyProperty.Register(nameof(DecoratorTemplate), typeof(DataTemplate), typeof(NodifyEditor));
         public static readonly DependencyProperty PendingConnectionTemplateProperty = DependencyProperty.Register(nameof(PendingConnectionTemplate), typeof(DataTemplate), typeof(NodifyEditor));
         public static readonly DependencyProperty SelectionRectangleStyleProperty = DependencyProperty.Register(nameof(SelectionRectangleStyle), typeof(Style), typeof(NodifyEditor));
-        public static readonly DependencyProperty CuttingLineStyleProperty = DependencyProperty.Register(nameof(CuttingLineStyle), typeof(Style), typeof(NodifyEditor));
         public static readonly DependencyProperty DecoratorContainerStyleProperty = DependencyProperty.Register(nameof(DecoratorContainerStyle), typeof(Style), typeof(NodifyEditor));
 
         /// <summary>
@@ -320,15 +318,6 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Gets or sets the style to use for the cutting line.
-        /// </summary>
-        public Style CuttingLineStyle
-        {
-            get => (Style)GetValue(CuttingLineStyleProperty);
-            set => SetValue(CuttingLineStyleProperty, value);
-        }
-
-        /// <summary>
         /// Gets or sets the style to use for the <see cref="DecoratorContainer"/>.
         /// </summary>
         public Style DecoratorContainerStyle
@@ -346,15 +335,6 @@ namespace Nodify
 
         protected static readonly DependencyPropertyKey IsSelectingPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsSelecting), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False, OnIsSelectingChanged));
         public static readonly DependencyProperty IsSelectingProperty = IsSelectingPropertyKey.DependencyProperty;
-
-        protected static readonly DependencyPropertyKey CuttingLineStartPropertyKey = DependencyProperty.RegisterReadOnly(nameof(CuttingLineStart), typeof(Point), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Point));
-        public static readonly DependencyProperty CuttingLineStartProperty = CuttingLineStartPropertyKey.DependencyProperty;
-
-        protected static readonly DependencyPropertyKey CuttingLineEndPropertyKey = DependencyProperty.RegisterReadOnly(nameof(CuttingLineEnd), typeof(Point), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Point));
-        public static readonly DependencyProperty CuttingLineEndProperty = CuttingLineEndPropertyKey.DependencyProperty;
-
-        protected static readonly DependencyPropertyKey IsCuttingPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsCutting), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False, OnIsCuttingChanged));
-        public static readonly DependencyProperty IsCuttingProperty = IsCuttingPropertyKey.DependencyProperty;
 
         protected static readonly DependencyPropertyKey MouseLocationPropertyKey = DependencyProperty.RegisterReadOnly(nameof(MouseLocation), typeof(Point), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Point));
         public static readonly DependencyProperty MouseLocationProperty = MouseLocationPropertyKey.DependencyProperty;
@@ -380,27 +360,6 @@ namespace Nodify
                 ItemsSelectStartedCommand.Execute(DataContext);
         }
 
-        private static void OnIsCuttingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var editor = (NodifyEditor)d;
-            if ((bool)e.NewValue == true)
-                editor.OnCuttingStarted();
-            else
-                editor.OnCuttingCompleted();
-        }
-
-        private void OnCuttingCompleted()
-        {
-            if (CuttingCompletedCommand?.CanExecute(DataContext) ?? false)
-                CuttingCompletedCommand.Execute(DataContext);
-        }
-
-        private void OnCuttingStarted()
-        {
-            if (CuttingStartedCommand?.CanExecute(DataContext) ?? false)
-                CuttingStartedCommand.Execute(DataContext);
-        }
-
         /// <summary>
         /// Gets the currently selected area while <see cref="IsSelecting"/> is true.
         /// </summary>
@@ -417,33 +376,6 @@ namespace Nodify
         {
             get => (bool)GetValue(IsSelectingProperty);
             internal set => SetValue(IsSelectingPropertyKey, value);
-        }
-
-        /// <summary>
-        /// Gets the start point of the <see cref="CuttingLine"/> while <see cref="IsCutting"/> is true.
-        /// </summary>
-        public Point CuttingLineStart
-        {
-            get => (Point)GetValue(CuttingLineStartProperty);
-            private set => SetValue(CuttingLineStartPropertyKey, value);
-        }
-
-        /// <summary>
-        /// Gets the end point of the <see cref="CuttingLine"/> while <see cref="IsCutting"/> is true.
-        /// </summary>
-        public Point CuttingLineEnd
-        {
-            get => (Point)GetValue(CuttingLineEndProperty);
-            protected internal set => SetValue(CuttingLineEndPropertyKey, value);
-        }
-
-        /// <summary>
-        /// Gets a value that indicates whether a cutting operation is in progress.
-        /// </summary>
-        public bool IsCutting
-        {
-            get => (bool)GetValue(IsCuttingProperty);
-            private set => SetValue(IsCuttingPropertyKey, value);
         }
 
         /// <summary>
@@ -603,8 +535,6 @@ namespace Nodify
         public static readonly DependencyProperty ItemsDragCompletedCommandProperty = DependencyProperty.Register(nameof(ItemsDragCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
         public static readonly DependencyProperty ItemsSelectStartedCommandProperty = DependencyProperty.Register(nameof(ItemsSelectStartedCommand), typeof(ICommand), typeof(NodifyEditor));
         public static readonly DependencyProperty ItemsSelectCompletedCommandProperty = DependencyProperty.Register(nameof(ItemsSelectCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
-        public static readonly DependencyProperty CuttingStartedCommandProperty = DependencyProperty.Register(nameof(CuttingStartedCommand), typeof(ICommand), typeof(NodifyEditor));
-        public static readonly DependencyProperty CuttingCompletedCommandProperty = DependencyProperty.Register(nameof(CuttingCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
 
         /// <summary>
         /// Invoked when the <see cref="Nodify.PendingConnection"/> is completed. <br />
@@ -682,20 +612,6 @@ namespace Nodify
             set => SetValue(ItemsSelectCompletedCommandProperty, value);
         }
 
-        /// <summary>Invoked when a cutting operation is started.</summary>
-        public ICommand? CuttingStartedCommand
-        {
-            get => (ICommand?)GetValue(CuttingStartedCommandProperty);
-            set => SetValue(CuttingStartedCommandProperty, value);
-        }
-
-        /// <summary>Invoked when a cutting operation is completed.</summary>
-        public ICommand? CuttingCompletedCommand
-        {
-            get => (ICommand?)GetValue(CuttingCompletedCommandProperty);
-            set => SetValue(CuttingCompletedCommandProperty, value);
-        }
-
         #endregion
 
         #region Fields
@@ -730,19 +646,6 @@ namespace Nodify
         /// Gets or sets if the current position of containers that are being dragged should not be committed until the end of the dragging operation.
         /// </summary>
         public static bool EnableDraggingContainersOptimizations { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets whether the cutting line should apply the preview style to the interesected elements.
-        /// </summary>
-        /// <remarks>
-        /// This may hurt performance because intersection must be calculated on mouse move.
-        /// </remarks>
-        public static bool EnableCuttingLinePreview { get; set; } = false;
-
-        /// <summary>
-        /// The list of supported connection types for cutting. Type must be derived from <see cref="FrameworkElement" />.
-        /// </summary>
-        public static readonly HashSet<Type> CuttingConnectionTypes = new HashSet<Type>();
 
         /// <summary>
         /// Tells if the <see cref="NodifyEditor"/> is doing operations on multiple items at once.
@@ -1433,62 +1336,6 @@ namespace Nodify
             }
 
             return new DraggingSimple(containers, GridCellSize);
-        }
-
-        #endregion
-
-        #region Cutting
-
-        /// <summary>
-        /// Starts the cutting operation at the specified location. Call <see cref="EndCutting"/> to finish cutting.
-        /// </summary>
-        protected internal void StartCutting(Point location)
-        {
-            CuttingLineStart = location;
-            CuttingLineEnd = location;
-            IsCutting = true;
-        }
-
-        /// <summary>
-        /// Cancels the cutting operation.
-        /// </summary>
-        protected internal void CancelCutting()
-        {
-            if (IsCutting)
-            {
-                IsCutting = false;
-            }
-        }
-
-        /// <summary>
-        /// Ends the cutting operation at the specified location.
-        /// </summary>
-        protected internal void EndCutting(Point location)
-        {
-            CuttingLineEnd = location;
-
-            var lineGeometry = new LineGeometry(CuttingLineStart, CuttingLineEnd);
-            var connections = ConnectionsHost.GetIntersectingElements(lineGeometry, CuttingConnectionTypes);
-
-            if (RemoveConnectionCommand != null)
-            {
-                foreach (var connection in connections)
-                {
-                    OnRemoveConnection(connection.DataContext);
-                }
-            }
-            else
-            {
-                foreach (var connection in connections)
-                {
-                    if (connection is BaseConnection bc)
-                    {
-                        bc.OnDisconnect();
-                    }
-                }
-            }
-
-            IsCutting = false;
         }
 
         #endregion


### PR DESCRIPTION
### 📝 Description of the Change

Move logic from editor states into the editor itself to better support different input sources.

New NodifyEditor methods:
- BeginCutting (former StartCutting)
- UpdateCuttingLine

Related #146

### 🐛 Possible Drawbacks

None.
