### PR TITLE
Add selecting methods to NodifyEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 > - Features:
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor
 >	- Added UpdateCuttingLine to NodifyEditor
+>	- Added BeginSelection, UpdateSelection, EndSelection, CancelSelection and AllowSelectionCancellation to NodifyEditor
 > - Bugfixes:
 	
 #### **Version 6.6.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 >	- Made the setter of NodifyEditor.IsPanning private
 >	- Renamed StartCutting to BeginCutting in NodifyEditor
 >	- Renamed PushItems to UpdatePushedArea and StartPushingItems to BeginPushingItems in NodifyEditor
+>	- Renamed UnselectAllConnection to UnselectAllConnections in NodifyEditor
 > - Features:
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor
 >	- Added UpdateCuttingLine to NodifyEditor
->	- Added BeginSelection, UpdateSelection, EndSelection, CancelSelection and AllowSelectionCancellation to NodifyEditor
+>	- Added BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
 > - Bugfixes:
 	
 #### **Version 6.6.0**

--- a/Nodify/EditorStates/EditorCuttingState.cs
+++ b/Nodify/EditorStates/EditorCuttingState.cs
@@ -4,7 +4,7 @@ namespace Nodify
 {
     public class EditorCuttingState : EditorState
     {
-        public bool Canceled { get; set; } = CuttingLine.AllowCuttingCancellation;
+        private bool Canceled { get; set; } = CuttingLine.AllowCuttingCancellation;
 
         public EditorCuttingState(NodifyEditor editor) : base(editor)
         {

--- a/Nodify/EditorStates/EditorDefaultState.cs
+++ b/Nodify/EditorStates/EditorDefaultState.cs
@@ -1,6 +1,5 @@
 ﻿using System.Windows;
 using System.Windows.Input;
-using static Nodify.SelectionHelper;
 
 namespace Nodify
 {
@@ -32,23 +31,22 @@ namespace Nodify
         public override void HandleMouseDown(MouseButtonEventArgs e)
         {
             EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
-            if (gestures.Cutting.Matches(e.Source, e))
+            if (Editor.CanSelectMultipleItems && gestures.Selection.Select.Matches(e.Source, e))
+            {
+                SelectionType selectionType = SelectionHelper.GetSelectionType(e);
+                PushState(new EditorSelectingState(Editor, selectionType));
+            }
+            else if (!Editor.DisablePanning && gestures.Pan.Matches(e.Source, e))
+            {
+                PushState(new EditorPanningState(Editor));
+            }
+            else if (gestures.Cutting.Matches(e.Source, e))
             {
                 PushState(new EditorCuttingState(Editor));
             }
             else if (gestures.PushItems.Matches(e.Source, e))
             {
                 PushState(new EditorPushingItemsState(Editor));
-            }
-            else if (gestures.Selection.Select.Matches(e.Source, e))
-            {
-                SelectionType selectionType = GetSelectionType(e);
-                var selecting = new EditorSelectingState(Editor, selectionType);
-                PushState(selecting);
-            }
-            else if (!Editor.DisablePanning && gestures.Pan.Matches(e.Source, e))
-            {
-                PushState(new EditorPanningState(Editor));
             }
         }
 

--- a/Nodify/EditorStates/EditorPushingItemsState.cs
+++ b/Nodify/EditorStates/EditorPushingItemsState.cs
@@ -10,7 +10,7 @@ namespace Nodify
         private Point _prevPosition;
         private const int _minDragDistance = 10;
 
-        public bool Canceled { get; set; } = NodifyEditor.AllowPushItemsCancellation;
+        private bool Canceled { get; set; } = NodifyEditor.AllowPushItemsCancellation;
 
         public EditorPushingItemsState(NodifyEditor editor) : base(editor)
         {

--- a/Nodify/EditorStates/EditorSelectingState.cs
+++ b/Nodify/EditorStates/EditorSelectingState.cs
@@ -21,7 +21,7 @@ namespace Nodify
         {
             Canceled = false;
 
-            Editor.BeginSelection(Editor.MouseLocation, _type);
+            Editor.BeginSelecting(Editor.MouseLocation, _type);
         }
 
         /// <inheritdoc />
@@ -30,11 +30,11 @@ namespace Nodify
             // TODO: This is not canceled on LostMouseCapture (add OnLostMouseCapture/OnCancel callback?)
             if (Canceled)
             {
-                Editor.CancelSelection();
+                Editor.CancelSelecting();
             }
             else
             {
-                Editor.EndSelection();
+                Editor.EndSelecting();
             }
         }
 

--- a/Nodify/NodifyEditor.Selecting.cs
+++ b/Nodify/NodifyEditor.Selecting.cs
@@ -332,7 +332,7 @@ namespace Nodify
         /// <summary>
         /// Unselect all <see cref="Connections"/>.
         /// </summary>
-        public void UnselectAllConnection()
+        public void UnselectAllConnections()
         {
             if (ConnectionsHost is MultiSelector selector)
             {
@@ -356,14 +356,14 @@ namespace Nodify
         /// <remarks>This method has no effect if a selection operation is already in progress.</remarks>
         /// <param name="location">The starting point for the selection, in graph space coordinates.</param>
         /// <param name="type">The type of selection to perform. Defaults to <see cref="SelectionType.Replace"/>.</param>
-        public void BeginSelection(Point location, SelectionType type = SelectionType.Replace)
+        public void BeginSelecting(Point location, SelectionType type = SelectionType.Replace)
         {
             if (IsSelecting)
             {
                 return;
             }
 
-            UnselectAllConnection();
+            UnselectAllConnections();
             SelectedArea = _selection.Start(ItemContainers, location, type, EnableRealtimeSelection);
             IsSelecting = true;
         }
@@ -392,7 +392,7 @@ namespace Nodify
         /// Completes the selection operation and applies any pending changes.
         /// </summary>
         /// <remarks>This method has no effect if there's no selection operation in progress.</remarks>
-        public void EndSelection()
+        public void EndSelecting()
         {
             if (!IsSelecting)
             {
@@ -408,7 +408,7 @@ namespace Nodify
         /// Cancels the current selection operation and reverts any changes made during the selection process. 
         /// </summary>
         /// <remarks>This method has no effect if there's no selection operation in progress.</remarks>
-        public void CancelSelection()
+        public void CancelSelecting()
         {
             if (!IsSelecting)
             {

--- a/Nodify/NodifyEditor.Selecting.cs
+++ b/Nodify/NodifyEditor.Selecting.cs
@@ -1,0 +1,517 @@
+﻿using System.Diagnostics;
+using System.Windows.Controls.Primitives;
+using System.Windows.Controls;
+using System.Windows;
+using System.Collections;
+using System.Collections.Specialized;
+using System.Collections.Generic;
+using System.Windows.Input;
+using System.Windows.Shapes;
+
+namespace Nodify
+{
+    /// <summary>Available selection logic.</summary>
+    public enum SelectionType
+    {
+        /// <summary>Replaces the old selection.</summary>
+        Replace,
+        /// <summary>Removes items from existing selection.</summary>
+        Remove,
+        /// <summary>Adds items to the current selection.</summary>
+        Append,
+        /// <summary>Inverts the selection.</summary>
+        Invert
+    }
+
+    [StyleTypedProperty(Property = nameof(SelectionRectangleStyle), StyleTargetType = typeof(Rectangle))]
+    public partial class NodifyEditor : MultiSelector
+    {
+        public static readonly DependencyProperty ItemsSelectStartedCommandProperty = DependencyProperty.Register(nameof(ItemsSelectStartedCommand), typeof(ICommand), typeof(NodifyEditor));
+        public static readonly DependencyProperty ItemsSelectCompletedCommandProperty = DependencyProperty.Register(nameof(ItemsSelectCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
+
+        public static readonly DependencyProperty SelectionRectangleStyleProperty = DependencyProperty.Register(nameof(SelectionRectangleStyle), typeof(Style), typeof(NodifyEditor));
+
+        protected static readonly DependencyPropertyKey SelectedAreaPropertyKey = DependencyProperty.RegisterReadOnly(nameof(SelectedArea), typeof(Rect), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Rect));
+        public static readonly DependencyProperty SelectedAreaProperty = SelectedAreaPropertyKey.DependencyProperty;
+
+        protected static readonly DependencyPropertyKey IsSelectingPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsSelecting), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False, OnIsSelectingChanged));
+        public static readonly DependencyProperty IsSelectingProperty = IsSelectingPropertyKey.DependencyProperty;
+
+        public static readonly DependencyProperty EnableRealtimeSelectionProperty = DependencyProperty.Register(nameof(EnableRealtimeSelection), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False));
+        public static readonly DependencyProperty CanSelectMultipleConnectionsProperty = DependencyProperty.Register(nameof(CanSelectMultipleConnections), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.True));
+        public static readonly DependencyProperty CanSelectMultipleItemsProperty = DependencyProperty.Register(nameof(CanSelectMultipleItems), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.True, OnCanSelectMultipleItemsChanged, CoerceCanSelectMultipleItems));
+        public static readonly DependencyProperty SelectedItemsProperty = DependencyProperty.Register(nameof(SelectedItems), typeof(IList), typeof(NodifyEditor), new FrameworkPropertyMetadata(default(IList), OnSelectedItemsSourceChanged));
+        public static readonly DependencyProperty SelectedConnectionsProperty = DependencyProperty.Register(nameof(SelectedConnections), typeof(IList), typeof(NodifyEditor), new FrameworkPropertyMetadata(default(IList)));
+        public static readonly DependencyProperty SelectedConnectionProperty = DependencyProperty.Register(nameof(SelectedConnection), typeof(object), typeof(NodifyEditor), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+        private static void OnCanSelectMultipleItemsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+            => ((NodifyEditor)d).CanSelectMultipleItemsBase = (bool)e.NewValue;
+
+        private static object CoerceCanSelectMultipleItems(DependencyObject d, object baseValue)
+            => ((NodifyEditor)d).CanSelectMultipleItemsBase = (bool)baseValue;
+
+        private static void OnSelectedItemsSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+            => ((NodifyEditor)d).OnSelectedItemsSourceChanged((IList)e.OldValue, (IList)e.NewValue);
+
+        private static void OnIsSelectingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var editor = (NodifyEditor)d;
+            if ((bool)e.NewValue == true)
+                editor.OnItemsSelectStarted();
+            else
+                editor.OnItemsSelectCompleted();
+        }
+
+        private void OnItemsSelectCompleted()
+        {
+            if (ItemsSelectCompletedCommand?.CanExecute(DataContext) ?? false)
+                ItemsSelectCompletedCommand.Execute(DataContext);
+        }
+
+        private void OnItemsSelectStarted()
+        {
+            if (ItemsSelectStartedCommand?.CanExecute(DataContext) ?? false)
+                ItemsSelectStartedCommand.Execute(DataContext);
+        }
+
+        /// <summary>Invoked when a selection operation is started.</summary>
+        public ICommand? ItemsSelectStartedCommand
+        {
+            get => (ICommand?)GetValue(ItemsSelectStartedCommandProperty);
+            set => SetValue(ItemsSelectStartedCommandProperty, value);
+        }
+
+        /// <summary>Invoked when a selection operation is completed.</summary>
+        public ICommand? ItemsSelectCompletedCommand
+        {
+            get => (ICommand?)GetValue(ItemsSelectCompletedCommandProperty);
+            set => SetValue(ItemsSelectCompletedCommandProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether multiple connections can be selected.
+        /// </summary>
+        public bool CanSelectMultipleConnections
+        {
+            get => (bool)GetValue(CanSelectMultipleConnectionsProperty);
+            set => SetValue(CanSelectMultipleConnectionsProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether multiple <see cref="ItemContainer" />s can be selected.
+        /// </summary>
+        public new bool CanSelectMultipleItems
+        {
+            get => (bool)GetValue(CanSelectMultipleItemsProperty);
+            set => SetValue(CanSelectMultipleItemsProperty, value);
+        }
+
+        private bool CanSelectMultipleItemsBase
+        {
+            get => base.CanSelectMultipleItems;
+            set => base.CanSelectMultipleItems = value;
+        }
+
+        /// <summary>
+        /// Enables selecting and deselecting items while the <see cref="SelectedArea"/> changes.
+        /// Disable for maximum performance when hundreds of items are generated.
+        /// </summary>
+        public bool EnableRealtimeSelection
+        {
+            get => (bool)GetValue(EnableRealtimeSelectionProperty);
+            set => SetValue(EnableRealtimeSelectionProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the selected connection.
+        /// </summary>
+        public object? SelectedConnection
+        {
+            get => GetValue(SelectedConnectionProperty);
+            set => SetValue(SelectedConnectionProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the selected connections in the <see cref="NodifyEditor"/>.
+        /// </summary>
+        public IList? SelectedConnections
+        {
+            get => (IList?)GetValue(SelectedConnectionsProperty);
+            set => SetValue(SelectedConnectionsProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the selected items in the <see cref="NodifyEditor"/>.
+        /// </summary>
+        public new IList? SelectedItems
+        {
+            get => (IList?)GetValue(SelectedItemsProperty);
+            set => SetValue(SelectedItemsProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the currently selected area while <see cref="IsSelecting"/> is true.
+        /// </summary>
+        public Rect SelectedArea
+        {
+            get => (Rect)GetValue(SelectedAreaProperty);
+            private set => SetValue(SelectedAreaPropertyKey, value);
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether a selection operation is in progress.
+        /// </summary>
+        public bool IsSelecting
+        {
+            get => (bool)GetValue(IsSelectingProperty);
+            private set => SetValue(IsSelectingPropertyKey, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the style to use for the selection rectangle.
+        /// </summary>
+        public Style SelectionRectangleStyle
+        {
+            get => (Style)GetValue(SelectionRectangleStyleProperty);
+            set => SetValue(SelectionRectangleStyleProperty, value);
+        }
+
+        /// <summary>
+        /// Gets a list of <see cref="ItemContainer"/>s that are selected.
+        /// </summary>
+        /// <remarks>Cache the result before using it to avoid extra allocations.</remarks>
+        protected internal IReadOnlyList<ItemContainer> SelectedContainers
+        {
+            get
+            {
+                IList selectedItems = base.SelectedItems;
+                var selectedContainers = new List<ItemContainer>(selectedItems.Count);
+
+                for (var i = 0; i < selectedItems.Count; i++)
+                {
+                    var container = (ItemContainer)ItemContainerGenerator.ContainerFromItem(selectedItems[i]);
+                    selectedContainers.Add(container);
+                }
+
+                return selectedContainers;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether cancelling a selection operation is allowed (see <see cref="EditorGestures.SelectionGestures.Cancel"/>).
+        /// </summary>
+        public static bool AllowSelectionCancellation { get; set; } = true;
+
+        /// <summary>The selection helper.</summary>
+        private readonly SelectionHelper _selection = new SelectionHelper();
+
+        #region Selection
+
+        internal void ApplyPreviewingSelection()
+        {
+            Debug.Assert(IsSelecting);
+
+            ItemCollection items = Items;
+            IList selected = base.SelectedItems;
+
+            BeginUpdateSelectedItems();
+            for (var i = 0; i < items.Count; i++)
+            {
+                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                if (container.IsPreviewingSelection == true && container.IsSelectable)
+                {
+                    selected.Add(items[i]);
+                }
+                else if (container.IsPreviewingSelection == false)
+                {
+                    selected.Remove(items[i]);
+                }
+                container.IsPreviewingSelection = null;
+            }
+            EndUpdateSelectedItems();
+        }
+
+        internal void ClearPreviewingSelection()
+        {
+            Debug.Assert(IsSelecting);
+
+            ItemCollection items = Items;
+            for (var i = 0; i < items.Count; i++)
+            {
+                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                container.IsPreviewingSelection = null;
+            }
+        }
+
+        /// <summary>
+        /// Inverts the <see cref="ItemContainer"/>s selection in the specified <paramref name="area"/>.
+        /// </summary>
+        /// <param name="area">The area to look for <see cref="ItemContainer"/>s.</param>
+        /// <param name="fit">True to check if the <paramref name="area"/> contains the <see cref="ItemContainer"/>. <br />False to check if <paramref name="area"/> intersects the <see cref="ItemContainer"/>.</param>
+        public void InvertSelection(Rect area, bool fit = false)
+        {
+            ItemCollection items = Items;
+            IList selected = base.SelectedItems;
+
+            IsSelecting = true;
+            BeginUpdateSelectedItems();
+            for (var i = 0; i < items.Count; i++)
+            {
+                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+
+                if (container.IsSelectableInArea(area, fit))
+                {
+                    object? item = items[i];
+                    if (container.IsSelected)
+                    {
+                        selected.Remove(item);
+                    }
+                    else
+                    {
+                        selected.Add(item);
+                    }
+                }
+            }
+            EndUpdateSelectedItems();
+            IsSelecting = false;
+        }
+
+        /// <summary>
+        /// Selects the <see cref="ItemContainer"/>s in the specified <paramref name="area"/>.
+        /// </summary>
+        /// <param name="area">The area to look for <see cref="ItemContainer"/>s.</param>
+        /// <param name="append">If true, it will add to the existing selection.</param>
+        /// <param name="fit">True to check if the <paramref name="area"/> contains the <see cref="ItemContainer"/>. <br />False to check if <paramref name="area"/> intersects the <see cref="ItemContainer"/>.</param>
+        public void SelectArea(Rect area, bool append = false, bool fit = false)
+        {
+            if (!append)
+            {
+                UnselectAll();
+            }
+
+            ItemCollection items = Items;
+            IList selected = base.SelectedItems;
+
+            IsSelecting = true;
+            BeginUpdateSelectedItems();
+            for (var i = 0; i < items.Count; i++)
+            {
+                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                if (container.IsSelectableInArea(area, fit))
+                {
+                    selected.Add(items[i]);
+                }
+            }
+            EndUpdateSelectedItems();
+            IsSelecting = false;
+        }
+
+        /// <summary>
+        /// Unselect the <see cref="ItemContainer"/>s in the specified <paramref name="area"/>.
+        /// </summary>
+        /// <param name="area">The area to look for <see cref="ItemContainer"/>s.</param>
+        /// <param name="fit">True to check if the <paramref name="area"/> contains the <see cref="ItemContainer"/>. <br />False to check if <paramref name="area"/> intersects the <see cref="ItemContainer"/>.</param>
+        public void UnselectArea(Rect area, bool fit = false)
+        {
+            IList items = base.SelectedItems;
+
+            IsSelecting = true;
+            BeginUpdateSelectedItems();
+            for (var i = 0; i < items.Count; i++)
+            {
+                var container = (ItemContainer)ItemContainerGenerator.ContainerFromItem(items[i]);
+                if (container.IsSelectableInArea(area, fit))
+                {
+                    items.Remove(items[i]);
+                }
+            }
+            EndUpdateSelectedItems();
+            IsSelecting = false;
+        }
+
+        /// <summary>
+        /// Unselect all <see cref="Connections"/>.
+        /// </summary>
+        public void UnselectAllConnection()
+        {
+            if (ConnectionsHost is MultiSelector selector)
+            {
+                selector.UnselectAll();
+            }
+        }
+
+        /// <summary>
+        /// Select all <see cref="Connections"/>.
+        /// </summary>
+        public void SelectAllConnections()
+        {
+            if (ConnectionsHost is MultiSelector selector)
+            {
+                selector.SelectAll();
+            }
+        }
+        /// <summary>
+        /// Initiates a selection operation from the specified location.
+        /// </summary>
+        /// <remarks>This method has no effect if a selection operation is already in progress.</remarks>
+        /// <param name="location">The starting point for the selection, in graph space coordinates.</param>
+        /// <param name="type">The type of selection to perform. Defaults to <see cref="SelectionType.Replace"/>.</param>
+        public void BeginSelection(Point location, SelectionType type = SelectionType.Replace)
+        {
+            if (IsSelecting)
+            {
+                return;
+            }
+
+            UnselectAllConnection();
+            SelectedArea = _selection.Start(ItemContainers, location, type, EnableRealtimeSelection);
+            IsSelecting = true;
+        }
+
+        /// <summary>
+        /// Expands or modifies the selection area by the specified amount.
+        /// </summary>
+        /// <param name="amount">Rrepresents the change to apply to the selection area.</param>
+        public void UpdateSelection(Vector amount)
+        {
+            Debug.Assert(IsSelecting);
+            SelectedArea = _selection.Update(amount);
+        }
+
+        /// <summary>
+        /// Expands or modifies the selection area to the specified location.
+        /// </summary>
+        /// <param name="location">The point, in graph space coordinates, to extend or adjust the selection area to.</param>
+        public void UpdateSelection(Point location)
+        {
+            Debug.Assert(IsSelecting);
+            SelectedArea = _selection.Update(location);
+        }
+
+        /// <summary>
+        /// Completes the selection operation and applies any pending changes.
+        /// </summary>
+        /// <remarks>This method has no effect if there's no selection operation in progress.</remarks>
+        public void EndSelection()
+        {
+            if (!IsSelecting)
+            {
+                return;
+            }
+
+            SelectedArea = _selection.End();
+            ApplyPreviewingSelection();
+            IsSelecting = false;
+        }
+
+        /// <summary>
+        /// Cancels the current selection operation and reverts any changes made during the selection process. 
+        /// </summary>
+        /// <remarks>This method has no effect if there's no selection operation in progress.</remarks>
+        public void CancelSelection()
+        {
+            if (!IsSelecting)
+            {
+                return;
+            }
+
+            ClearPreviewingSelection();
+            IsSelecting = false;
+        }
+
+        #endregion
+
+        #region Selection Handlers
+
+        private void OnSelectedItemsSourceChanged(IList oldValue, IList newValue)
+        {
+            if (oldValue is INotifyCollectionChanged oc)
+            {
+                oc.CollectionChanged -= OnSelectedItemsChanged;
+            }
+
+            if (newValue is INotifyCollectionChanged nc)
+            {
+                nc.CollectionChanged += OnSelectedItemsChanged;
+            }
+
+            IList selectedItems = base.SelectedItems;
+
+            BeginUpdateSelectedItems();
+            selectedItems.Clear();
+            if (newValue != null)
+            {
+                for (var i = 0; i < newValue.Count; i++)
+                {
+                    selectedItems.Add(newValue[i]);
+                }
+            }
+            EndUpdateSelectedItems();
+        }
+
+        private void OnSelectedItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (!CanSelectMultipleItems)
+                return;
+
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Reset:
+                    base.SelectedItems.Clear();
+                    break;
+
+                case NotifyCollectionChangedAction.Add:
+                    IList? newItems = e.NewItems;
+                    if (newItems != null)
+                    {
+                        IList selectedItems = base.SelectedItems;
+                        for (var i = 0; i < newItems.Count; i++)
+                        {
+                            selectedItems.Add(newItems[i]);
+                        }
+                    }
+                    break;
+
+                case NotifyCollectionChangedAction.Remove:
+                    IList? oldItems = e.OldItems;
+                    if (oldItems != null)
+                    {
+                        IList selectedItems = base.SelectedItems;
+                        for (var i = 0; i < oldItems.Count; i++)
+                        {
+                            selectedItems.Remove(oldItems[i]);
+                        }
+                    }
+                    break;
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnSelectionChanged(SelectionChangedEventArgs e)
+        {
+            base.OnSelectionChanged(e);
+
+            IList? selected = SelectedItems;
+            if (selected != null)
+            {
+                IList added = e.AddedItems;
+                for (var i = 0; i < added.Count; i++)
+                {
+                    // Ensure no duplicates are added
+                    if (!selected.Contains(added[i]))
+                    {
+                        selected.Add(added[i]);
+                    }
+                }
+
+                IList removed = e.RemovedItems;
+                for (var i = 0; i < removed.Count; i++)
+                {
+                    selected.Remove(removed[i]);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
@@ -9,7 +8,6 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Markup;
 using System.Windows.Media;
-using System.Windows.Shapes;
 
 namespace Nodify
 {
@@ -20,10 +18,9 @@ namespace Nodify
     [TemplatePart(Name = ElementConnectionsHost, Type = typeof(FrameworkElement))]
     [StyleTypedProperty(Property = nameof(ItemContainerStyle), StyleTargetType = typeof(ItemContainer))]
     [StyleTypedProperty(Property = nameof(DecoratorContainerStyle), StyleTargetType = typeof(DecoratorContainer))]
-    [StyleTypedProperty(Property = nameof(SelectionRectangleStyle), StyleTargetType = typeof(Rectangle))]
     [ContentProperty(nameof(Decorators))]
     [DefaultProperty(nameof(Decorators))]
-    public partial class NodifyEditor : MultiSelector
+    public partial class NodifyEditor
     {
         protected const string ElementItemsHost = "PART_ItemsHost";
         protected const string ElementConnectionsHost = "PART_ConnectionsHost";
@@ -250,7 +247,6 @@ namespace Nodify
         public static readonly DependencyProperty ConnectionTemplateProperty = DependencyProperty.Register(nameof(ConnectionTemplate), typeof(DataTemplate), typeof(NodifyEditor));
         public static readonly DependencyProperty DecoratorTemplateProperty = DependencyProperty.Register(nameof(DecoratorTemplate), typeof(DataTemplate), typeof(NodifyEditor));
         public static readonly DependencyProperty PendingConnectionTemplateProperty = DependencyProperty.Register(nameof(PendingConnectionTemplate), typeof(DataTemplate), typeof(NodifyEditor));
-        public static readonly DependencyProperty SelectionRectangleStyleProperty = DependencyProperty.Register(nameof(SelectionRectangleStyle), typeof(Style), typeof(NodifyEditor));
         public static readonly DependencyProperty DecoratorContainerStyleProperty = DependencyProperty.Register(nameof(DecoratorContainerStyle), typeof(Style), typeof(NodifyEditor));
 
         /// <summary>
@@ -309,15 +305,6 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Gets or sets the style to use for the selection rectangle.
-        /// </summary>
-        public Style SelectionRectangleStyle
-        {
-            get => (Style)GetValue(SelectionRectangleStyleProperty);
-            set => SetValue(SelectionRectangleStyleProperty, value);
-        }
-
-        /// <summary>
         /// Gets or sets the style to use for the <see cref="DecoratorContainer"/>.
         /// </summary>
         public Style DecoratorContainerStyle
@@ -330,53 +317,8 @@ namespace Nodify
 
         #region Readonly Dependency Properties
 
-        protected static readonly DependencyPropertyKey SelectedAreaPropertyKey = DependencyProperty.RegisterReadOnly(nameof(SelectedArea), typeof(Rect), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Rect));
-        public static readonly DependencyProperty SelectedAreaProperty = SelectedAreaPropertyKey.DependencyProperty;
-
-        protected static readonly DependencyPropertyKey IsSelectingPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsSelecting), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False, OnIsSelectingChanged));
-        public static readonly DependencyProperty IsSelectingProperty = IsSelectingPropertyKey.DependencyProperty;
-
         protected static readonly DependencyPropertyKey MouseLocationPropertyKey = DependencyProperty.RegisterReadOnly(nameof(MouseLocation), typeof(Point), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Point));
         public static readonly DependencyProperty MouseLocationProperty = MouseLocationPropertyKey.DependencyProperty;
-
-        private static void OnIsSelectingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var editor = (NodifyEditor)d;
-            if ((bool)e.NewValue == true)
-                editor.OnItemsSelectStarted();
-            else
-                editor.OnItemsSelectCompleted();
-        }
-
-        private void OnItemsSelectCompleted()
-        {
-            if (ItemsSelectCompletedCommand?.CanExecute(DataContext) ?? false)
-                ItemsSelectCompletedCommand.Execute(DataContext);
-        }
-
-        private void OnItemsSelectStarted()
-        {
-            if (ItemsSelectStartedCommand?.CanExecute(DataContext) ?? false)
-                ItemsSelectStartedCommand.Execute(DataContext);
-        }
-
-        /// <summary>
-        /// Gets the currently selected area while <see cref="IsSelecting"/> is true.
-        /// </summary>
-        public Rect SelectedArea
-        {
-            get => (Rect)GetValue(SelectedAreaProperty);
-            internal set => SetValue(SelectedAreaPropertyKey, value);
-        }
-
-        /// <summary>
-        /// Gets a value that indicates whether a selection operation is in progress.
-        /// </summary>
-        public bool IsSelecting
-        {
-            get => (bool)GetValue(IsSelectingProperty);
-            internal set => SetValue(IsSelectingPropertyKey, value);
-        }
 
         /// <summary>
         /// Gets the current mouse location in graph space coordinates (relative to the <see cref="ItemsHost" />).
@@ -392,25 +334,10 @@ namespace Nodify
         #region Dependency Properties
 
         public static readonly DependencyProperty ConnectionsProperty = DependencyProperty.Register(nameof(Connections), typeof(IEnumerable), typeof(NodifyEditor));
-        public static readonly DependencyProperty SelectedItemsProperty = DependencyProperty.Register(nameof(SelectedItems), typeof(IList), typeof(NodifyEditor), new FrameworkPropertyMetadata(default(IList), OnSelectedItemsSourceChanged));
-        public static readonly DependencyProperty SelectedConnectionsProperty = DependencyProperty.Register(nameof(SelectedConnections), typeof(IList), typeof(NodifyEditor), new FrameworkPropertyMetadata(default(IList)));
-        public static readonly DependencyProperty SelectedConnectionProperty = DependencyProperty.Register(nameof(SelectedConnection), typeof(object), typeof(NodifyEditor), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
         public static readonly DependencyProperty PendingConnectionProperty = DependencyProperty.Register(nameof(PendingConnection), typeof(object), typeof(NodifyEditor));
         public static readonly DependencyProperty GridCellSizeProperty = DependencyProperty.Register(nameof(GridCellSize), typeof(uint), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.UInt1, OnGridCellSizeChanged, OnCoerceGridCellSize));
         public static readonly DependencyProperty DisableZoomingProperty = DependencyProperty.Register(nameof(DisableZooming), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False));
-        public static readonly DependencyProperty EnableRealtimeSelectionProperty = DependencyProperty.Register(nameof(EnableRealtimeSelection), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False));
         public static readonly DependencyProperty DecoratorsProperty = DependencyProperty.Register(nameof(Decorators), typeof(IEnumerable), typeof(NodifyEditor));
-        public static readonly DependencyProperty CanSelectMultipleConnectionsProperty = DependencyProperty.Register(nameof(CanSelectMultipleConnections), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.True));
-        public static readonly DependencyProperty CanSelectMultipleItemsProperty = DependencyProperty.Register(nameof(CanSelectMultipleItems), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.True, OnCanSelectMultipleItemsChanged, CoerceCanSelectMultipleItems));
-
-        private static void OnCanSelectMultipleItemsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-            => ((NodifyEditor)d).CanSelectMultipleItemsBase = (bool)e.NewValue;
-
-        private static object CoerceCanSelectMultipleItems(DependencyObject d, object baseValue)
-            => ((NodifyEditor)d).CanSelectMultipleItemsBase = (bool)baseValue;
-
-        private static void OnSelectedItemsSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-            => ((NodifyEditor)d).OnSelectedItemsSourceChanged((IList)e.OldValue, (IList)e.NewValue);
 
         private static object OnCoerceGridCellSize(DependencyObject d, object value)
             => (uint)value > 0u ? value : BoxValue.UInt1;
@@ -454,73 +381,12 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Gets or sets the selected connection.
-        /// </summary>
-        public object? SelectedConnection
-        {
-            get => GetValue(SelectedConnectionProperty);
-            set => SetValue(SelectedConnectionProperty, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the selected connections in the <see cref="NodifyEditor"/>.
-        /// </summary>
-        public IList? SelectedConnections
-        {
-            get => (IList?)GetValue(SelectedConnectionsProperty);
-            set => SetValue(SelectedConnectionsProperty, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the selected items in the <see cref="NodifyEditor"/>.
-        /// </summary>
-        public new IList? SelectedItems
-        {
-            get => (IList?)GetValue(SelectedItemsProperty);
-            set => SetValue(SelectedItemsProperty, value);
-        }
-
-        /// <summary>
         /// Gets or sets whether zooming should be disabled.
         /// </summary>
         public bool DisableZooming
         {
             get => (bool)GetValue(DisableZoomingProperty);
             set => SetValue(DisableZoomingProperty, value);
-        }
-
-        /// <summary>
-        /// Enables selecting and deselecting items while the <see cref="SelectedArea"/> changes.
-        /// Disable for maximum performance when hundreds of items are generated.
-        /// </summary>
-        public bool EnableRealtimeSelection
-        {
-            get => (bool)GetValue(EnableRealtimeSelectionProperty);
-            set => SetValue(EnableRealtimeSelectionProperty, value);
-        }
-
-        /// <summary>
-        /// Gets or sets whether multiple connections can be selected.
-        /// </summary>
-        public bool CanSelectMultipleConnections
-        {
-            get => (bool)GetValue(CanSelectMultipleConnectionsProperty);
-            set => SetValue(CanSelectMultipleConnectionsProperty, value);
-        }
-
-        /// <summary>
-        /// Gets or sets whether multiple <see cref="ItemContainer" />s can be selected.
-        /// </summary>
-        public new bool CanSelectMultipleItems
-        {
-            get => (bool)GetValue(CanSelectMultipleItemsProperty);
-            set => SetValue(CanSelectMultipleItemsProperty, value);
-        }
-
-        private bool CanSelectMultipleItemsBase
-        {
-            get => base.CanSelectMultipleItems;
-            set => base.CanSelectMultipleItems = value;
         }
 
         #endregion
@@ -533,8 +399,6 @@ namespace Nodify
         public static readonly DependencyProperty RemoveConnectionCommandProperty = DependencyProperty.Register(nameof(RemoveConnectionCommand), typeof(ICommand), typeof(NodifyEditor));
         public static readonly DependencyProperty ItemsDragStartedCommandProperty = DependencyProperty.Register(nameof(ItemsDragStartedCommand), typeof(ICommand), typeof(NodifyEditor));
         public static readonly DependencyProperty ItemsDragCompletedCommandProperty = DependencyProperty.Register(nameof(ItemsDragCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
-        public static readonly DependencyProperty ItemsSelectStartedCommandProperty = DependencyProperty.Register(nameof(ItemsSelectStartedCommand), typeof(ICommand), typeof(NodifyEditor));
-        public static readonly DependencyProperty ItemsSelectCompletedCommandProperty = DependencyProperty.Register(nameof(ItemsSelectCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
 
         /// <summary>
         /// Invoked when the <see cref="Nodify.PendingConnection"/> is completed. <br />
@@ -581,7 +445,7 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Invoked when a drag operation starts for the <see cref="SelectedItems"/>.
+        /// Invoked when a drag operation starts for the <see cref="SelectedItems"/>, or when <see cref="IsPushingItems"/> is set to true.
         /// </summary>
         public ICommand? ItemsDragStartedCommand
         {
@@ -590,26 +454,12 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Invoked when a drag operation is completed for the <see cref="SelectedItems"/>.
+        /// Invoked when a drag operation is completed for the <see cref="SelectedItems"/>, or when <see cref="IsPushingItems"/> is set to false.
         /// </summary>
         public ICommand? ItemsDragCompletedCommand
         {
             get => (ICommand?)GetValue(ItemsDragCompletedCommandProperty);
             set => SetValue(ItemsDragCompletedCommandProperty, value);
-        }
-
-        /// <summary>Invoked when a selection operation is started.</summary>
-        public ICommand? ItemsSelectStartedCommand
-        {
-            get => (ICommand?)GetValue(ItemsSelectStartedCommandProperty);
-            set => SetValue(ItemsSelectStartedCommandProperty, value);
-        }
-
-        /// <summary>Invoked when a selection operation is completed.</summary>
-        public ICommand? ItemsSelectCompletedCommand
-        {
-            get => (ICommand?)GetValue(ItemsSelectCompletedCommandProperty);
-            set => SetValue(ItemsSelectCompletedCommandProperty, value);
         }
 
         #endregion
@@ -663,27 +513,6 @@ namespace Nodify
         protected internal UIElement ConnectionsHost { get; private set; } = default!;
 
         private IDraggingStrategy? _draggingStrategy;
-
-        /// <summary>
-        /// Gets a list of <see cref="ItemContainer"/>s that are selected.
-        /// </summary>
-        /// <remarks>Cache the result before using it to avoid extra allocations.</remarks>
-        protected internal IReadOnlyList<ItemContainer> SelectedContainers
-        {
-            get
-            {
-                IList selectedItems = base.SelectedItems;
-                var selectedContainers = new List<ItemContainer>(selectedItems.Count);
-
-                for (var i = 0; i < selectedItems.Count; i++)
-                {
-                    var container = (ItemContainer)ItemContainerGenerator.ContainerFromItem(selectedItems[i]);
-                    selectedContainers.Add(container);
-                }
-
-                return selectedContainers;
-            }
-        }
 
         /// <summary>
         /// Gets a list of all <see cref="ItemContainer"/>s.
@@ -1038,245 +867,6 @@ namespace Nodify
 
         protected override void OnKeyDown(KeyEventArgs e)
             => State.HandleKeyDown(e);
-
-        #endregion
-
-        #region Selection Handlers
-
-        private void OnSelectedItemsSourceChanged(IList oldValue, IList newValue)
-        {
-            if (oldValue is INotifyCollectionChanged oc)
-            {
-                oc.CollectionChanged -= OnSelectedItemsChanged;
-            }
-
-            if (newValue is INotifyCollectionChanged nc)
-            {
-                nc.CollectionChanged += OnSelectedItemsChanged;
-            }
-
-            IList selectedItems = base.SelectedItems;
-
-            BeginUpdateSelectedItems();
-            selectedItems.Clear();
-            if (newValue != null)
-            {
-                for (var i = 0; i < newValue.Count; i++)
-                {
-                    selectedItems.Add(newValue[i]);
-                }
-            }
-            EndUpdateSelectedItems();
-        }
-
-        private void OnSelectedItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
-        {
-            if (!CanSelectMultipleItems)
-                return;
-
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Reset:
-                    base.SelectedItems.Clear();
-                    break;
-
-                case NotifyCollectionChangedAction.Add:
-                    IList? newItems = e.NewItems;
-                    if (newItems != null)
-                    {
-                        IList selectedItems = base.SelectedItems;
-                        for (var i = 0; i < newItems.Count; i++)
-                        {
-                            selectedItems.Add(newItems[i]);
-                        }
-                    }
-                    break;
-
-                case NotifyCollectionChangedAction.Remove:
-                    IList? oldItems = e.OldItems;
-                    if (oldItems != null)
-                    {
-                        IList selectedItems = base.SelectedItems;
-                        for (var i = 0; i < oldItems.Count; i++)
-                        {
-                            selectedItems.Remove(oldItems[i]);
-                        }
-                    }
-                    break;
-            }
-        }
-
-        /// <inheritdoc />
-        protected override void OnSelectionChanged(SelectionChangedEventArgs e)
-        {
-            base.OnSelectionChanged(e);
-
-            IList? selected = SelectedItems;
-            if (selected != null)
-            {
-                IList added = e.AddedItems;
-                for (var i = 0; i < added.Count; i++)
-                {
-                    // Ensure no duplicates are added
-                    if (!selected.Contains(added[i]))
-                    {
-                        selected.Add(added[i]);
-                    }
-                }
-
-                IList removed = e.RemovedItems;
-                for (var i = 0; i < removed.Count; i++)
-                {
-                    selected.Remove(removed[i]);
-                }
-            }
-        }
-
-        #endregion
-
-        #region Selection
-
-        internal void ApplyPreviewingSelection()
-        {
-            ItemCollection items = Items;
-            IList selected = base.SelectedItems;
-
-            IsSelecting = true;
-            BeginUpdateSelectedItems();
-            for (var i = 0; i < items.Count; i++)
-            {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
-                if (container.IsPreviewingSelection == true && container.IsSelectable)
-                {
-                    selected.Add(items[i]);
-                }
-                else if (container.IsPreviewingSelection == false)
-                {
-                    selected.Remove(items[i]);
-                }
-                container.IsPreviewingSelection = null;
-            }
-            EndUpdateSelectedItems();
-            IsSelecting = false;
-        }
-
-        internal void ClearPreviewingSelection()
-        {
-            ItemCollection items = Items;
-            for (var i = 0; i < items.Count; i++)
-            {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
-                container.IsPreviewingSelection = null;
-            }
-        }
-
-        /// <summary>
-        /// Inverts the <see cref="ItemContainer"/>s selection in the specified <paramref name="area"/>.
-        /// </summary>
-        /// <param name="area">The area to look for <see cref="ItemContainer"/>s.</param>
-        /// <param name="fit">True to check if the <paramref name="area"/> contains the <see cref="ItemContainer"/>. <br />False to check if <paramref name="area"/> intersects the <see cref="ItemContainer"/>.</param>
-        public void InvertSelection(Rect area, bool fit = false)
-        {
-            ItemCollection items = Items;
-            IList selected = base.SelectedItems;
-
-            IsSelecting = true;
-            BeginUpdateSelectedItems();
-            for (var i = 0; i < items.Count; i++)
-            {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
-
-                if (container.IsSelectableInArea(area, fit))
-                {
-                    object? item = items[i];
-                    if (container.IsSelected)
-                    {
-                        selected.Remove(item);
-                    }
-                    else
-                    {
-                        selected.Add(item);
-                    }
-                }
-            }
-            EndUpdateSelectedItems();
-            IsSelecting = false;
-        }
-
-        /// <summary>
-        /// Selects the <see cref="ItemContainer"/>s in the specified <paramref name="area"/>.
-        /// </summary>
-        /// <param name="area">The area to look for <see cref="ItemContainer"/>s.</param>
-        /// <param name="append">If true, it will add to the existing selection.</param>
-        /// <param name="fit">True to check if the <paramref name="area"/> contains the <see cref="ItemContainer"/>. <br />False to check if <paramref name="area"/> intersects the <see cref="ItemContainer"/>.</param>
-        public void SelectArea(Rect area, bool append = false, bool fit = false)
-        {
-            if (!append)
-            {
-                UnselectAll();
-            }
-
-            ItemCollection items = Items;
-            IList selected = base.SelectedItems;
-
-            IsSelecting = true;
-            BeginUpdateSelectedItems();
-            for (var i = 0; i < items.Count; i++)
-            {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
-                if (container.IsSelectableInArea(area, fit))
-                {
-                    selected.Add(items[i]);
-                }
-            }
-            EndUpdateSelectedItems();
-            IsSelecting = false;
-        }
-
-        /// <summary>
-        /// Unselect the <see cref="ItemContainer"/>s in the specified <paramref name="area"/>.
-        /// </summary>
-        /// <param name="area">The area to look for <see cref="ItemContainer"/>s.</param>
-        /// <param name="fit">True to check if the <paramref name="area"/> contains the <see cref="ItemContainer"/>. <br />False to check if <paramref name="area"/> intersects the <see cref="ItemContainer"/>.</param>
-        public void UnselectArea(Rect area, bool fit = false)
-        {
-            IList items = base.SelectedItems;
-
-            IsSelecting = true;
-            BeginUpdateSelectedItems();
-            for (var i = 0; i < items.Count; i++)
-            {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromItem(items[i]);
-                if (container.IsSelectableInArea(area, fit))
-                {
-                    items.Remove(items[i]);
-                }
-            }
-            EndUpdateSelectedItems();
-            IsSelecting = false;
-        }
-
-        /// <summary>
-        /// Unselect all <see cref="Connections"/>.
-        /// </summary>
-        public void UnselectAllConnection()
-        {
-            if (ConnectionsHost is MultiSelector selector)
-            {
-                selector.UnselectAll();
-            }
-        }
-
-        /// <summary>
-        /// Select all <see cref="Connections"/>.
-        /// </summary>
-        public void SelectAllConnections()
-        {
-            if (ConnectionsHost is MultiSelector selector)
-            {
-                selector.SelectAll();
-            }
-        }
 
         #endregion
 


### PR DESCRIPTION
### 📝 Description of the Change

Move logic from editor states into the editor itself to better support different input sources.

New NodifyEditor methods:
- `BeginSelecting`
- `UpdateSelection`
- `EndSelecting`
- `CancelSelecting` 

New NodifyEditor configuration:
- `AllowSelectionCancellation` - selecting can be cancelled by pressing `Escape` or `RightClick` by default if this field is set to `true`

Related: #146

### 🐛 Possible Drawbacks

None.
