### PR TITLE
Add dragging methods to NodifyEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor
 >	- Added UpdateCuttingLine to NodifyEditor
 >	- Added BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
+>	- Added IsDragging, BeginDragging, UpdateDragging, EndDragging and CancelDragging to NodifyEditor
 > - Bugfixes:
 	
 #### **Version 6.6.0**

--- a/Nodify/ItemContainer.cs
+++ b/Nodify/ItemContainer.cs
@@ -25,12 +25,12 @@ namespace Nodify
         public static readonly DependencyProperty SelectedBorderThicknessProperty = DependencyProperty.Register(nameof(SelectedBorderThickness), typeof(Thickness), typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.Thickness2));
         public static readonly DependencyProperty IsSelectableProperty = DependencyProperty.Register(nameof(IsSelectable), typeof(bool), typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.True));
         public static readonly DependencyProperty IsSelectedProperty = Selector.IsSelectedProperty.AddOwner(typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.False, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnIsSelectedChanged));
-        public static readonly DependencyPropertyKey IsPreviewingSelectionPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsPreviewingSelection), typeof(bool?), typeof(ItemContainer), new FrameworkPropertyMetadata(null));
+        protected static readonly DependencyPropertyKey IsPreviewingSelectionPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsPreviewingSelection), typeof(bool?), typeof(ItemContainer), new FrameworkPropertyMetadata(null));
         public static readonly DependencyProperty IsPreviewingSelectionProperty = IsPreviewingSelectionPropertyKey.DependencyProperty;
         public static readonly DependencyProperty LocationProperty = DependencyProperty.Register(nameof(Location), typeof(Point), typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.Point, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnLocationChanged));
         public static readonly DependencyProperty ActualSizeProperty = DependencyProperty.Register(nameof(ActualSize), typeof(Size), typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.Size));
         public static readonly DependencyProperty DesiredSizeForSelectionProperty = DependencyProperty.Register(nameof(DesiredSizeForSelection), typeof(Size?), typeof(ItemContainer), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.NotDataBindable));
-        public static readonly DependencyPropertyKey IsPreviewingLocationPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsPreviewingLocation), typeof(bool), typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.False));
+        private static readonly DependencyPropertyKey IsPreviewingLocationPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsPreviewingLocation), typeof(bool), typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.False));
         public static readonly DependencyProperty IsPreviewingLocationProperty = IsPreviewingLocationPropertyKey.DependencyProperty;
         public static readonly DependencyProperty IsDraggableProperty = DependencyProperty.Register(nameof(IsDraggable), typeof(bool), typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.True));
 

--- a/Nodify/Nodes/Node.cs
+++ b/Nodify/Nodes/Node.cs
@@ -25,7 +25,7 @@ namespace Nodify
         public static readonly DependencyProperty FooterProperty = DependencyProperty.Register(nameof(Footer), typeof(object), typeof(Node), new FrameworkPropertyMetadata(OnFooterChanged));
         public static readonly DependencyProperty FooterTemplateProperty = DependencyProperty.Register(nameof(FooterTemplate), typeof(DataTemplate), typeof(Node));
         public static readonly DependencyProperty InputConnectorTemplateProperty = DependencyProperty.Register(nameof(InputConnectorTemplate), typeof(DataTemplate), typeof(Node));
-        protected internal static readonly DependencyPropertyKey HasFooterPropertyKey = DependencyProperty.RegisterReadOnly(nameof(HasFooter), typeof(bool), typeof(Node), new FrameworkPropertyMetadata(BoxValue.False));
+        protected static readonly DependencyPropertyKey HasFooterPropertyKey = DependencyProperty.RegisterReadOnly(nameof(HasFooter), typeof(bool), typeof(Node), new FrameworkPropertyMetadata(BoxValue.False));
         public static readonly DependencyProperty HasFooterProperty = HasFooterPropertyKey.DependencyProperty;
         public static readonly DependencyProperty OutputConnectorTemplateProperty = DependencyProperty.Register(nameof(OutputConnectorTemplate), typeof(DataTemplate), typeof(Node));
         public static readonly DependencyProperty InputProperty = DependencyProperty.Register(nameof(Input), typeof(IEnumerable), typeof(Node));

--- a/Nodify/NodifyEditor.Dragging.cs
+++ b/Nodify/NodifyEditor.Dragging.cs
@@ -1,0 +1,189 @@
+﻿using System.Windows.Input;
+using System.Windows;
+using System.Collections.Generic;
+using System.Windows.Controls.Primitives;
+using System.Diagnostics;
+
+namespace Nodify
+{
+    public partial class NodifyEditor
+    {
+        public static readonly DependencyProperty ItemsDragStartedCommandProperty = DependencyProperty.Register(nameof(ItemsDragStartedCommand), typeof(ICommand), typeof(NodifyEditor));
+        public static readonly DependencyProperty ItemsDragCompletedCommandProperty = DependencyProperty.Register(nameof(ItemsDragCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
+
+        protected static readonly DependencyPropertyKey IsDraggingPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsDragging), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False, OnIsDraggingChanged));
+        public static readonly DependencyProperty IsDraggingProperty = IsDraggingPropertyKey.DependencyProperty;
+
+        private static void OnIsDraggingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var editor = (NodifyEditor)d;
+
+            if ((bool)e.NewValue == true)
+            {
+                editor.OnItemsDragStarted();
+            }
+            else
+            {
+                editor.OnItemsDragCompleted();
+            }
+        }
+
+        private void OnItemsDragCompleted()
+        {
+            if (ItemsDragCompletedCommand?.CanExecute(DataContext) ?? false)
+                ItemsDragCompletedCommand.Execute(DataContext);
+        }
+
+        private void OnItemsDragStarted()
+        {
+            if (ItemsDragStartedCommand?.CanExecute(DataContext) ?? false)
+                ItemsDragStartedCommand.Execute(DataContext);
+        }
+
+        /// <summary>
+        /// Invoked when a drag operation starts for the <see cref="SelectedItems"/>, or when <see cref="IsPushingItems"/> is set to true.
+        /// </summary>
+        public ICommand? ItemsDragStartedCommand
+        {
+            get => (ICommand?)GetValue(ItemsDragStartedCommandProperty);
+            set => SetValue(ItemsDragStartedCommandProperty, value);
+        }
+
+        /// <summary>
+        /// Invoked when a drag operation is completed for the <see cref="SelectedItems"/>, or when <see cref="IsPushingItems"/> is set to false.
+        /// </summary>
+        public ICommand? ItemsDragCompletedCommand
+        {
+            get => (ICommand?)GetValue(ItemsDragCompletedCommandProperty);
+            set => SetValue(ItemsDragCompletedCommandProperty, value);
+        }
+
+        /// <summary>
+        /// Gets a value that indicates whether a dragging operation is in progress.
+        /// </summary>
+        public bool IsDragging
+        {
+            get => (bool)GetValue(IsDraggingProperty);
+            private set => SetValue(IsDraggingPropertyKey, value);
+        }
+
+        /// <summary>
+        /// Gets or sets if the current position of containers that are being dragged should not be committed until the end of the dragging operation.
+        /// </summary>
+        public static bool EnableDraggingContainersOptimizations { get; set; } = true;
+
+        private IDraggingStrategy? _draggingStrategy;
+
+        private void RegisterDragEvents()
+        {
+            AddHandler(ItemContainer.DragStartedEvent, new DragStartedEventHandler(OnItemsDragStarted));
+            AddHandler(ItemContainer.DragCompletedEvent, new DragCompletedEventHandler(OnItemsDragCompleted));
+            AddHandler(ItemContainer.DragDeltaEvent, new DragDeltaEventHandler(OnItemsDragDelta));
+        }
+
+        /// <summary>
+        /// Initiates the dragging operation using the currently selected <see cref="ItemContainer" />s.
+        /// </summary>
+        /// <remarks>This method has no effect if a dragging operation is already in progress.</remarks>
+        public void BeginDragging() 
+            => BeginDragging(SelectedContainers);
+
+        /// <summary>
+        /// Initiates the dragging operation for the specified <see cref="ItemContainer" />s.
+        /// </summary>
+        /// <param name="containers">The collection of item containers to be dragged.</param>
+        /// <remarks>This method has no effect if a dragging operation is already in progress.</remarks>
+        public void BeginDragging(IEnumerable<ItemContainer> containers)
+        {
+            if(IsDragging)
+            {
+                return;
+            }
+
+            IsDragging = true;
+            _draggingStrategy = CreateDraggingStrategy(containers);
+        }
+
+        /// <summary>
+        /// Updates the position of the items being dragged by a specified offset.
+        /// </summary>
+        /// <param name="amount">The vector by which to adjust the position of the dragged items.</param>
+        /// This method adjusts the items positions incrementally. It should only be called while a dragging operation is in progress (see <see cref="BeginDragging"/>).
+        /// </remarks>
+        public void UpdateDragging(Vector amount)
+        {
+            Debug.Assert(IsDragging);
+            _draggingStrategy!.Update(amount);
+        }
+
+        /// <summary>
+        /// Completes the dragging operation, finalizing the position of the dragged items.
+        /// </summary>
+        /// <remarks>This method has no effect if there's no dragging operation in progress.</remarks>
+        public void EndDragging()
+        {
+            if (!IsDragging)
+            {
+                return;
+            }
+
+            IsBulkUpdatingItems = true;
+            _draggingStrategy!.End();
+            IsBulkUpdatingItems = false;
+
+            // Draw the containers at the new position.
+            ItemsHost.InvalidateArrange();
+
+            _draggingStrategy = null;
+            IsDragging = false;
+        }
+
+        /// <summary>
+        /// Cancels the ongoing dragging operation, reverting any changes made to the positions of the dragged items.
+        /// </summary>
+        /// <remarks>This method has no effect if there's no dragging operation in progress.</remarks>
+        public void CancelDragging()
+        {
+            if (!ItemContainer.AllowDraggingCancellation || !IsDragging)
+            {
+                return;
+            }
+
+            _draggingStrategy!.Abort();
+            IsDragging = false;
+        }
+
+        private IDraggingStrategy CreateDraggingStrategy(IEnumerable<ItemContainer> containers)
+        {
+            if (EnableDraggingContainersOptimizations)
+            {
+                return new DraggingOptimized(containers, GridCellSize);
+            }
+
+            return new DraggingSimple(containers, GridCellSize);
+        }
+
+        private void OnItemsDragStarted(object sender, DragStartedEventArgs e)
+        {
+            BeginDragging();
+            e.Handled = true;
+        }
+
+        private void OnItemsDragDelta(object sender, DragDeltaEventArgs e)
+        {
+            UpdateDragging(new Vector(e.HorizontalChange, e.VerticalChange));
+        }
+
+        private void OnItemsDragCompleted(object sender, DragCompletedEventArgs e)
+        {
+            if (e.Canceled)
+            {
+                CancelDragging();
+            }
+            else
+            {
+                EndDragging();
+            }
+        }
+    }
+}

--- a/Nodify/NodifyEditor.Dragging.cs
+++ b/Nodify/NodifyEditor.Dragging.cs
@@ -108,7 +108,8 @@ namespace Nodify
         /// Updates the position of the items being dragged by a specified offset.
         /// </summary>
         /// <param name="amount">The vector by which to adjust the position of the dragged items.</param>
-        /// This method adjusts the items positions incrementally. It should only be called while a dragging operation is in progress (see <see cref="BeginDragging"/>).
+        /// <remarks>
+        /// This method adjusts the items positions incrementally. It should only be called while a dragging operation is in progress (see <see cref="BeginDragging" />).
         /// </remarks>
         public void UpdateDragging(Vector amount)
         {


### PR DESCRIPTION
### 📝 Description of the Change

Move logic from editor states into the editor itself to better support different input sources.

New NodifyEditor methods:
- `BeginDragging`
- `UpdateDragging`
- `EndDragging`
- `CancelDragging` 

New NodifyEditor properties:
- `IsDragging`

Related: #146

### 🐛 Possible Drawbacks

None.
