### PR TITLE
Add dragging methods to ItemContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 > - Breaking Changes:
 >	- Made the setter of NodifyEditor.IsPanning private
+>	- Made SelectionHelper internal
 >	- Renamed StartCutting to BeginCutting in NodifyEditor
 >	- Renamed PushItems to UpdatePushedArea and StartPushingItems to BeginPushingItems in NodifyEditor
 >	- Renamed UnselectAllConnection to UnselectAllConnections in NodifyEditor
@@ -12,7 +13,9 @@
 >	- Added UpdateCuttingLine to NodifyEditor
 >	- Added BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
 >	- Added IsDragging, BeginDragging, UpdateDragging, EndDragging and CancelDragging to NodifyEditor
+>	- Added Select, BeginDragging, UpdateDragging, EndDragging and CancelDragging to ItemContainer
 > - Bugfixes:
+>	- Fixed ItemContainer being selected by releasing the mouse button on it without having the mouse captured
 	
 #### **Version 6.6.0**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 >	- Renamed StartCutting to BeginCutting in NodifyEditor
 >	- Renamed PushItems to UpdatePushedArea and StartPushingItems to BeginPushingItems in NodifyEditor
 >	- Renamed UnselectAllConnection to UnselectAllConnections in NodifyEditor
+>	- Removed DragStarted, DragDelta and DragCompleted routed events from ItemContainer
 > - Features:
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor
 >	- Added UpdateCuttingLine to NodifyEditor

--- a/Examples/Nodify.Calculator/EditorView.xaml.cs
+++ b/Examples/Nodify.Calculator/EditorView.xaml.cs
@@ -11,7 +11,6 @@ namespace Nodify.Calculator
             InitializeComponent();
 
             EventManager.RegisterClassHandler(typeof(NodifyEditor), MouseLeftButtonDownEvent, new MouseButtonEventHandler(CloseOperationsMenu));
-            EventManager.RegisterClassHandler(typeof(ItemContainer), ItemContainer.DragStartedEvent, new RoutedEventHandler(CloseOperationsMenu));
             EventManager.RegisterClassHandler(typeof(NodifyEditor), MouseRightButtonUpEvent, new MouseButtonEventHandler(OpenOperationsMenu));
         }
 

--- a/Nodify/Connections/ConnectionContainer.cs
+++ b/Nodify/Connections/ConnectionContainer.cs
@@ -102,28 +102,36 @@ namespace Nodify
             EditorGestures.ConnectionGestures gestures = EditorGestures.Mappings.Connection;
             if (gestures.Selection.Select.Matches(e.Source, e))
             {
-                if (gestures.Selection.Append.Matches(e.Source, e))
+                var selectionType = gestures.Selection.GetSelectionType(e);
+                bool allowContextMenu = e.ChangedButton == MouseButton.Right && IsSelected;
+                if (!(selectionType == SelectionType.Replace && allowContextMenu))
                 {
-                    IsSelected = true;
+                    Select(selectionType);
                 }
-                else if (gestures.Selection.Invert.Matches(e.Source, e))
-                {
-                    IsSelected = !IsSelected;
-                }
-                else if (gestures.Selection.Remove.Matches(e.Source, e))
-                {
-                    IsSelected = false;
-                }
-                else
-                {
-                    // Allow context menu on selection
-                    if (!(e.ChangedButton == MouseButton.Right && e.RightButton == MouseButtonState.Released) || !IsSelected)
-                    {
-                        Selector.UnselectAll();
-                    }
+            }
+        }
 
+        /// <summary>
+        /// Modifies the selection state of the current item based on the specified selection type.
+        /// </summary>
+        /// <param name="type">The type of selection to perform.</param>
+        private void Select(SelectionType type)
+        {
+            switch (type)
+            {
+                case SelectionType.Append:
                     IsSelected = true;
-                }
+                    break;
+                case SelectionType.Remove:
+                    IsSelected = false;
+                    break;
+                case SelectionType.Invert:
+                    IsSelected = !IsSelected;
+                    break;
+                case SelectionType.Replace:
+                    Selector.UnselectAll();
+                    IsSelected = true;
+                    break;
             }
         }
     }

--- a/Nodify/EditorStates/ContainerDefaultState.cs
+++ b/Nodify/EditorStates/ContainerDefaultState.cs
@@ -54,14 +54,12 @@ namespace Nodify
         /// <inheritdoc />
         public override void HandleMouseUp(MouseButtonEventArgs e)
         {
-            EditorGestures.ItemContainerGestures gestures = EditorGestures.Mappings.ItemContainer;
-            if (gestures.Selection.Select.Matches(e.Source, e))
+            if (_selectionType.HasValue)
             {
-                var selectionType = gestures.Selection.GetSelectionType(e);
                 bool allowContextMenu = e.ChangedButton == MouseButton.Right && Container.IsSelected;
-                if (!(selectionType == SelectionType.Replace && allowContextMenu))
+                if (!(_selectionType == SelectionType.Replace && allowContextMenu))
                 {
-                    Container.Select(selectionType);
+                    Container.Select(_selectionType.Value);
                 }
             }
 

--- a/Nodify/EditorStates/ContainerDefaultState.cs
+++ b/Nodify/EditorStates/ContainerDefaultState.cs
@@ -50,33 +50,17 @@ namespace Nodify
             EditorGestures.ItemContainerGestures gestures = EditorGestures.Mappings.ItemContainer;
             if (!_canceled && gestures.Selection.Select.Matches(e.Source, e))
             {
-                if (gestures.Selection.Append.Matches(e.Source, e))
+                var selectionType = gestures.Selection.GetSelectionType(e);
+                bool allowContextMenu = e.ChangedButton == MouseButton.Right && Container.IsSelected;
+                if (!(selectionType == SelectionType.Replace && allowContextMenu))
                 {
-                    Container.IsSelected = true;
-                }
-                else if (gestures.Selection.Invert.Matches(e.Source, e))
-                {
-                    Container.IsSelected = !Container.IsSelected;
-                }
-                else if (gestures.Selection.Remove.Matches(e.Source, e))
-                {
-                    Container.IsSelected = false;
-                }
-                else
-                {
-                    // Allow context menu on selection
-                    if (!(e.ChangedButton == MouseButton.Right && e.RightButton == MouseButtonState.Released) || !Container.IsSelected)
-                    {
-                        Editor.UnselectAll();
-                    }
-
-                    Container.IsSelected = true;
+                    Container.Select(selectionType);
                 }
 
                 _canBeDragging = false;
             }
 
-            if(!_canceled && gestures.Drag.Matches(e.Source, e))
+            if (!_canceled && gestures.Drag.Matches(e.Source, e))
             {
                 _canBeDragging = false;
             }

--- a/Nodify/EditorStates/ContainerDefaultState.cs
+++ b/Nodify/EditorStates/ContainerDefaultState.cs
@@ -1,10 +1,12 @@
-﻿using System.Windows.Input;
+﻿using System.Windows;
+using System.Windows.Input;
 
 namespace Nodify
 {
     /// <summary>The default state of the <see cref="ItemContainer"/>.</summary>
     public class ContainerDefaultState : ContainerState
     {
+        private Point _initialPosition;
         private SelectionType? _selectionType;
         private bool _isDragging;
 
@@ -19,6 +21,7 @@ namespace Nodify
         {
             _isDragging = false;
             _selectionType = null;
+            _initialPosition = Editor.MouseLocation;
         }
 
         /// <inheritdoc />
@@ -34,12 +37,17 @@ namespace Nodify
             {
                 _selectionType = gestures.Selection.GetSelectionType(e);
             }
+
+            _initialPosition = Editor.MouseLocation;
         }
 
         /// <inheritdoc />
         public override void HandleMouseMove(MouseEventArgs e)
         {
-            if (_isDragging)
+            double dragThreshold = NodifyEditor.HandleRightClickAfterPanningThreshold * NodifyEditor.HandleRightClickAfterPanningThreshold;
+            double dragDistance = (Editor.MouseLocation - _initialPosition).LengthSquared;
+
+            if (_isDragging && (dragDistance > dragThreshold))
             {
                 if (!Container.IsSelected)
                 {
@@ -69,7 +77,7 @@ namespace Nodify
 
         private static SelectionType GetSelectionTypeForDragging(SelectionType? selectionType)
         {
-            // we should always select the container when dragging
+            // Always select the container when dragging
             return selectionType == SelectionType.Remove
                 ? SelectionType.Replace
                 : selectionType.GetValueOrDefault(SelectionType.Replace);

--- a/Nodify/EditorStates/ContainerDraggingState.cs
+++ b/Nodify/EditorStates/ContainerDraggingState.cs
@@ -55,11 +55,13 @@ namespace Nodify
             EditorGestures.ItemContainerGestures gestures = EditorGestures.Mappings.ItemContainer;
             if (gestures.Drag.Matches(e.Source, e))
             {
-                // Handle right click if dragging or canceled and moved the mouse more than threshold so context menus don't open
+                // Suppress the context menu if the mouse moved beyond the defined drag threshold
                 if (e.ChangedButton == MouseButton.Right)
                 {
-                    double contextMenuTreshold = NodifyEditor.HandleRightClickAfterPanningThreshold * NodifyEditor.HandleRightClickAfterPanningThreshold;
-                    if ((Editor.MouseLocation - _initialMousePosition).LengthSquared > contextMenuTreshold)
+                    double dragThreshold = NodifyEditor.HandleRightClickAfterPanningThreshold * NodifyEditor.HandleRightClickAfterPanningThreshold;
+                    double dragDistance = (Editor.MouseLocation - _initialMousePosition).LengthSquared;
+
+                    if (dragDistance > dragThreshold)
                     {
                         e.Handled = true;
                     }

--- a/Nodify/EditorStates/ContainerDraggingState.cs
+++ b/Nodify/EditorStates/ContainerDraggingState.cs
@@ -25,7 +25,6 @@ namespace Nodify
             _initialMousePosition = Editor.MouseLocation;
             _previousMousePosition = _initialMousePosition;
 
-            Container.Select(SelectionType.Append);
             Container.BeginDragging();
         }
 

--- a/Nodify/EditorStates/ContainerDraggingState.cs
+++ b/Nodify/EditorStates/ContainerDraggingState.cs
@@ -9,7 +9,7 @@ namespace Nodify
         private Point _initialMousePosition;
         private Point _previousMousePosition;
         
-        public bool Canceled { get; set; } = ItemContainer.AllowDraggingCancellation;
+        private bool Canceled { get; set; } = ItemContainer.AllowDraggingCancellation;
 
         /// <summary>Constructs an instance of the <see cref="ContainerDraggingState"/> state.</summary>
         /// <param name="container">The owner of the state.</param>
@@ -23,8 +23,10 @@ namespace Nodify
             Canceled = false;
 
             _initialMousePosition = Editor.MouseLocation;
-            Container.BeginDragging();
             _previousMousePosition = _initialMousePosition;
+
+            Container.Select(SelectionType.Append);
+            Container.BeginDragging();
         }
 
         /// <inheritdoc />

--- a/Nodify/EditorStates/EditorDefaultState.cs
+++ b/Nodify/EditorStates/EditorDefaultState.cs
@@ -33,7 +33,7 @@ namespace Nodify
             EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
             if (Editor.CanSelectMultipleItems && gestures.Selection.Select.Matches(e.Source, e))
             {
-                SelectionType selectionType = SelectionHelper.GetSelectionType(e);
+                SelectionType selectionType = gestures.Selection.GetSelectionType(e);
                 PushState(new EditorSelectingState(Editor, selectionType));
             }
             else if (!Editor.DisablePanning && gestures.Pan.Matches(e.Source, e))

--- a/Nodify/Helpers/SelectionHelper.cs
+++ b/Nodify/Helpers/SelectionHelper.cs
@@ -167,10 +167,12 @@ namespace Nodify
                 }
             }
         }
+    }
 
-        internal static SelectionType GetSelectionType(MouseButtonEventArgs e)
+    internal static class SelectionGesturesExtensions
+    {
+        public static SelectionType GetSelectionType(this EditorGestures.SelectionGestures gestures, MouseButtonEventArgs e)
         {
-            EditorGestures.SelectionGestures gestures = EditorGestures.Mappings.Editor.Selection;
             if (gestures.Append.Matches(e.Source, e))
             {
                 return SelectionType.Append;

--- a/Nodify/ItemContainer.cs
+++ b/Nodify/ItemContainer.cs
@@ -150,9 +150,6 @@ namespace Nodify
 
         #region Routed Events
 
-        public static readonly RoutedEvent DragStartedEvent = EventManager.RegisterRoutedEvent(nameof(DragStarted), RoutingStrategy.Bubble, typeof(DragStartedEventHandler), typeof(ItemContainer));
-        public static readonly RoutedEvent DragCompletedEvent = EventManager.RegisterRoutedEvent(nameof(DragCompleted), RoutingStrategy.Bubble, typeof(DragCompletedEventHandler), typeof(ItemContainer));
-        public static readonly RoutedEvent DragDeltaEvent = EventManager.RegisterRoutedEvent(nameof(DragDelta), RoutingStrategy.Bubble, typeof(DragDeltaEventHandler), typeof(ItemContainer));
         public static readonly RoutedEvent SelectedEvent = Selector.SelectedEvent.AddOwner(typeof(ItemContainer));
         public static readonly RoutedEvent UnselectedEvent = Selector.UnselectedEvent.AddOwner(typeof(ItemContainer));
         public static readonly RoutedEvent LocationChangedEvent = EventManager.RegisterRoutedEvent(nameof(LocationChanged), RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(ItemContainer));
@@ -164,33 +161,6 @@ namespace Nodify
         {
             add => AddHandler(LocationChangedEvent, value);
             remove => RemoveHandler(LocationChangedEvent, value);
-        }
-
-        /// <summary>
-        /// Occurs when this <see cref="ItemContainer"/> is the instigator of a drag operation.
-        /// </summary>
-        public event DragStartedEventHandler DragStarted
-        {
-            add => AddHandler(DragStartedEvent, value);
-            remove => RemoveHandler(DragStartedEvent, value);
-        }
-
-        /// <summary>
-        /// Occurs when this <see cref="ItemContainer"/> is being dragged.
-        /// </summary>
-        public event DragDeltaEventHandler DragDelta
-        {
-            add => AddHandler(DragDeltaEvent, value);
-            remove => RemoveHandler(DragDeltaEvent, value);
-        }
-
-        /// <summary>
-        /// Occurs when this <see cref="ItemContainer"/> completed the drag operation.
-        /// </summary>
-        public event DragCompletedEventHandler DragCompleted
-        {
-            add => AddHandler(DragCompletedEvent, value);
-            remove => RemoveHandler(DragCompletedEvent, value);
         }
 
         /// <summary>
@@ -336,10 +306,14 @@ namespace Nodify
         }
 
         /// <inheritdoc cref="NodifyEditor.BeginDragging()" />
-        /// <remarks>Appends the container to the selection.</remarks>
+        /// <remarks>Replaces the selection if the container is not selected.</remarks>
         public void BeginDragging()
         {
-            Select(SelectionType.Append);
+            if (!IsSelected)
+            {
+                Select(SelectionType.Replace);
+            }
+
             Editor.BeginDragging();
         }
 
@@ -443,7 +417,7 @@ namespace Nodify
         /// <inheritdoc />
         protected override void OnMouseUp(MouseButtonEventArgs e)
         {
-            if (IsSelectableLocation(e.GetPosition(this)) && IsMouseCaptured)
+            if (IsMouseCaptured)
             {
                 State.HandleMouseUp(e);
             }
@@ -456,16 +430,12 @@ namespace Nodify
         }
 
         /// <inheritdoc />
-        protected override void OnMouseMove(MouseEventArgs e)
-        {
-            State.HandleMouseMove(e);
-        }
+        protected override void OnMouseMove(MouseEventArgs e) 
+            => State.HandleMouseMove(e);
 
         /// <inheritdoc />
-        protected override void OnMouseWheel(MouseWheelEventArgs e)
-        {
-            State.HandleMouseWheel(e);
-        }
+        protected override void OnMouseWheel(MouseWheelEventArgs e) 
+            => State.HandleMouseWheel(e);
 
         /// <inheritdoc />
         protected override void OnLostMouseCapture(MouseEventArgs e)

--- a/Nodify/ItemContainer.cs
+++ b/Nodify/ItemContainer.cs
@@ -335,6 +335,50 @@ namespace Nodify
             return isContained ? area.Contains(bounds) : area.IntersectsWith(bounds);
         }
 
+        /// <inheritdoc cref="NodifyEditor.BeginDragging()" />
+        /// <remarks>Appends the container to the selection.</remarks>
+        public void BeginDragging()
+        {
+            Select(SelectionType.Append);
+            Editor.BeginDragging();
+        }
+
+        /// <inheritdoc cref="NodifyEditor.UpdateDragging(Vector)" />
+        public void UpdateDragging(Vector amount)
+            => Editor.UpdateDragging(amount);
+
+        /// <inheritdoc cref="NodifyEditor.CancelDragging" />
+        public void CancelDragging()
+            => Editor.CancelDragging();
+
+        /// <inheritdoc cref="NodifyEditor.EndDragging" />
+        public void EndDragging()
+            => Editor.EndDragging();
+
+        /// <summary>
+        /// Modifies the selection state of the current item based on the specified selection type.
+        /// </summary>
+        /// <param name="type">The type of selection to perform.</param>
+        public void Select(SelectionType type)
+        {
+            switch (type)
+            {
+                case SelectionType.Append:
+                    IsSelected = true;
+                    break;
+                case SelectionType.Remove:
+                    IsSelected = false;
+                    break;
+                case SelectionType.Invert:
+                    IsSelected = !IsSelected;
+                    break;
+                case SelectionType.Replace:
+                    Editor.UnselectAll();
+                    IsSelected = true;
+                break;
+            }
+        }
+
         #region State Handling
 
         private readonly Stack<ContainerState> _states = new Stack<ContainerState>();
@@ -399,7 +443,7 @@ namespace Nodify
         /// <inheritdoc />
         protected override void OnMouseUp(MouseButtonEventArgs e)
         {
-            if (IsSelectableLocation(e.GetPosition(this)) || IsMouseCaptured)
+            if (IsSelectableLocation(e.GetPosition(this)) && IsMouseCaptured)
             {
                 State.HandleMouseUp(e);
             }

--- a/Nodify/NodifyEditor.Dragging.cs
+++ b/Nodify/NodifyEditor.Dragging.cs
@@ -1,7 +1,6 @@
 ﻿using System.Windows.Input;
 using System.Windows;
 using System.Collections.Generic;
-using System.Windows.Controls.Primitives;
 using System.Diagnostics;
 
 namespace Nodify
@@ -73,13 +72,6 @@ namespace Nodify
         public static bool EnableDraggingContainersOptimizations { get; set; } = true;
 
         private IDraggingStrategy? _draggingStrategy;
-
-        private void RegisterDragEvents()
-        {
-            AddHandler(ItemContainer.DragStartedEvent, new DragStartedEventHandler(OnItemsDragStarted));
-            AddHandler(ItemContainer.DragCompletedEvent, new DragCompletedEventHandler(OnItemsDragCompleted));
-            AddHandler(ItemContainer.DragDeltaEvent, new DragDeltaEventHandler(OnItemsDragDelta));
-        }
 
         /// <summary>
         /// Initiates the dragging operation using the currently selected <see cref="ItemContainer" />s.
@@ -162,29 +154,6 @@ namespace Nodify
             }
 
             return new DraggingSimple(containers, GridCellSize);
-        }
-
-        private void OnItemsDragStarted(object sender, DragStartedEventArgs e)
-        {
-            BeginDragging();
-            e.Handled = true;
-        }
-
-        private void OnItemsDragDelta(object sender, DragDeltaEventArgs e)
-        {
-            UpdateDragging(new Vector(e.HorizontalChange, e.VerticalChange));
-        }
-
-        private void OnItemsDragCompleted(object sender, DragCompletedEventArgs e)
-        {
-            if (e.Canceled)
-            {
-                CancelDragging();
-            }
-            else
-            {
-                EndDragging();
-            }
         }
     }
 }

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -529,8 +529,6 @@ namespace Nodify
 
             AddHandler(BaseConnection.DisconnectEvent, new ConnectionEventHandler(OnRemoveConnection));
 
-            RegisterDragEvents();
-
             var transform = new TransformGroup();
             transform.Children.Add(ScaleTransform);
             transform.Children.Add(TranslateTransform);


### PR DESCRIPTION
### 📝 Description of the Change

Move logic from container states into the container itself to better support different input sources.

New ItemContainer methods:
- `BeginDragging`
- `UpdateDragging`
- `EndDragging`
- `CancelDragging` 
- `Select`

Removed ItemContainer routed events:
- `DragStarted`
- `DragDelta`
- `DragCompleted`

Related: #146

### 🐛 Possible Drawbacks

None.
