### PR TITLE
Suppress context menu for common actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > - Breaking Changes:
 >	- Made the setter of NodifyEditor.IsPanning private
 >	- Made SelectionHelper internal
+>	- Renamed HandleRightClickAfterPanningThreshold to MouseActionSuppressionThreshold in NodifyEditor
 >	- Renamed StartCutting to BeginCutting in NodifyEditor
 >	- Renamed PushItems to UpdatePushedArea and StartPushingItems to BeginPushingItems in NodifyEditor
 >	- Renamed UnselectAllConnection to UnselectAllConnections in NodifyEditor
@@ -15,8 +16,10 @@
 >	- Added BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
 >	- Added IsDragging, BeginDragging, UpdateDragging, EndDragging and CancelDragging to NodifyEditor
 >	- Added Select, BeginDragging, UpdateDragging, EndDragging and CancelDragging to ItemContainer
+>	- Added PreserveSelectionOnRightClick configuration field to ItemContainer
 > - Bugfixes:
->	- Fixed ItemContainer being selected by releasing the mouse button on it without having the mouse captured
+>	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured
+>	- Fixed an issue where the Home button caused the editor to fail to display items when contained within a ScrollViewer
 	
 #### **Version 6.6.0**
 

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -211,10 +211,10 @@ namespace Nodify.Playground
             _advancedSettings = new List<ISettingViewModel>()
             {
                 new ProxySettingViewModel<double>(
-                    () => Instance.HandleRightClickAfterPanningThreshold,
-                    val => Instance.HandleRightClickAfterPanningThreshold = val,
-                    "Disable context menu after panning: ",
-                    "Disable after mouse moved this far"),
+                    () => Instance.MouseActionSuppressionThreshold,
+                    val => Instance.MouseActionSuppressionThreshold = val,
+                    "Context menu suppression threshold: ",
+                    "Disable context menu after mouse moved this far"),
                 new ProxySettingViewModel<double>(
                     () => Instance.AutoPanningTickRate,
                     val => Instance.AutoPanningTickRate = val,
@@ -585,10 +585,10 @@ namespace Nodify.Playground
 
         #region Advanced settings
 
-        public double HandleRightClickAfterPanningThreshold
+        public double MouseActionSuppressionThreshold
         {
-            get => NodifyEditor.HandleRightClickAfterPanningThreshold;
-            set => NodifyEditor.HandleRightClickAfterPanningThreshold = value;
+            get => NodifyEditor.MouseActionSuppressionThreshold;
+            set => NodifyEditor.MouseActionSuppressionThreshold = value;
         }
 
         public double AutoPanningTickRate

--- a/Examples/Nodify.StateMachine/Helpers/BlackboardDescriptor.cs
+++ b/Examples/Nodify.StateMachine/Helpers/BlackboardDescriptor.cs
@@ -128,7 +128,7 @@ namespace Nodify.StateMachine
             for (int i = 0; i < types.Length; i++)
             {
                 var type = types[i];
-                if (type.IsClass && !type.IsAbstract && ourType.IsAssignableFrom(type))
+                if (type.IsClass && !type.IsAbstract && ourType.IsAssignableFrom(type) && type.GetCustomAttribute<BlackboardItemAttribute>() != null)
                 {
                     result.Add(GetReference(type));
                 }

--- a/Examples/Nodify.StateMachine/MainWindow.xaml
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml
@@ -32,7 +32,6 @@
         </Grid.ColumnDefinitions>
 
         <ScrollViewer CanContentScroll="True"
-                      PreviewMouseWheel="ScrollViewer_MouseWheel"
                       PreviewKeyDown="ScrollViewer_PreviewKeyDown"
                       Grid.Column="1">
             <nodify:NodifyEditor x:Name="Editor"

--- a/Examples/Nodify.StateMachine/MainWindow.xaml.cs
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml.cs
@@ -15,25 +15,7 @@ namespace Nodify.StateMachine
 
             EditorGestures.Mappings.Connection.Disconnect.Value = MultiGesture.None;
             EditorGestures.Mappings.Editor.ZoomModifierKey = ModifierKeys.Control;
-        }
-
-        private void ScrollViewer_MouseWheel(object sender, MouseWheelEventArgs e)
-        {
-            if (Keyboard.Modifiers != ModifierKeys.Shift)
-                return;
-
-            var scrollViewer = (ScrollViewer)sender;
-
-            if (e.Delta < 0)
-            {
-                scrollViewer.LineRight();
-            }
-            else
-            {
-                scrollViewer.LineLeft();
-            }
-
-            e.Handled = true;
+            EditorGestures.Mappings.Editor.PanWithMouseWheel = true;
         }
 
         private void ScrollViewer_PreviewKeyDown(object sender, KeyEventArgs e)

--- a/Nodify/EditorStates/ContainerDefaultState.cs
+++ b/Nodify/EditorStates/ContainerDefaultState.cs
@@ -44,7 +44,7 @@ namespace Nodify
         /// <inheritdoc />
         public override void HandleMouseMove(MouseEventArgs e)
         {
-            double dragThreshold = NodifyEditor.HandleRightClickAfterPanningThreshold * NodifyEditor.HandleRightClickAfterPanningThreshold;
+            double dragThreshold = NodifyEditor.MouseActionSuppressionThreshold * NodifyEditor.MouseActionSuppressionThreshold;
             double dragDistance = (Editor.MouseLocation - _initialPosition).LengthSquared;
 
             if (_isDragging && (dragDistance > dragThreshold))
@@ -64,7 +64,13 @@ namespace Nodify
         {
             if (_selectionType.HasValue)
             {
-                bool allowContextMenu = e.ChangedButton == MouseButton.Right && Container.IsSelected;
+                // Determine whether the current selection should remain intact or be replaced by the clicked item. 
+                // If the right mouse button is pressed on an already selected item, and the item either has an 
+                // explicit context menu or is configured to preserve the selection on right-click, the selection 
+                // remains unchanged. This ensures that the context menu applies to the entire selection rather 
+                // than only the clicked item.
+                bool hasContextMenu = Container.ContextMenu != null || ItemContainer.PreserveSelectionOnRightClick;
+                bool allowContextMenu = e.ChangedButton == MouseButton.Right && Container.IsSelected && hasContextMenu;
                 if (!(_selectionType == SelectionType.Replace && allowContextMenu))
                 {
                     Container.Select(_selectionType.Value);

--- a/Nodify/EditorStates/ContainerDraggingState.cs
+++ b/Nodify/EditorStates/ContainerDraggingState.cs
@@ -56,9 +56,9 @@ namespace Nodify
             if (gestures.Drag.Matches(e.Source, e))
             {
                 // Suppress the context menu if the mouse moved beyond the defined drag threshold
-                if (e.ChangedButton == MouseButton.Right)
+                if (e.ChangedButton == MouseButton.Right && Editor.ContextMenu != null)
                 {
-                    double dragThreshold = NodifyEditor.HandleRightClickAfterPanningThreshold * NodifyEditor.HandleRightClickAfterPanningThreshold;
+                    double dragThreshold = NodifyEditor.MouseActionSuppressionThreshold * NodifyEditor.MouseActionSuppressionThreshold;
                     double dragDistance = (Editor.MouseLocation - _initialMousePosition).LengthSquared;
 
                     if (dragDistance > dragThreshold)

--- a/Nodify/EditorStates/EditorDefaultState.cs
+++ b/Nodify/EditorStates/EditorDefaultState.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Input;
 
 namespace Nodify
@@ -53,18 +54,23 @@ namespace Nodify
         public override void HandleMouseWheel(MouseWheelEventArgs e)
         {
             EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
-            if (gestures.PanWithMouseWheel)
+            if (gestures.PanWithMouseWheel && Keyboard.Modifiers == gestures.PanHorizontalModifierKey)
             {
-                if (Keyboard.Modifiers == gestures.PanHorizontalModifierKey)
-                {
-                    Editor.ViewportLocation = new Point(Editor.ViewportLocation.X - e.Delta / Editor.ViewportZoom, Editor.ViewportLocation.Y);
-                    e.Handled = true;
-                }
-                else if (Keyboard.Modifiers == gestures.PanVerticalModifierKey)
-                {
-                    Editor.ViewportLocation = new Point(Editor.ViewportLocation.X, Editor.ViewportLocation.Y - e.Delta / Editor.ViewportZoom);
-                    e.Handled = true;
-                }
+                double offset = Math.Sign(e.Delta) * Mouse.MouseWheelDeltaForOneLine / 2 / Editor.ViewportZoom;
+                Editor.UpdatePanning(new Vector(offset, 0d));
+                e.Handled = true;
+            }
+            else if (gestures.PanWithMouseWheel && Keyboard.Modifiers == gestures.PanVerticalModifierKey)
+            {
+                double offset = Math.Sign(e.Delta) * Mouse.MouseWheelDeltaForOneLine / 2 / Editor.ViewportZoom;
+                Editor.UpdatePanning(new Vector(0d, offset));
+                e.Handled = true;
+            }
+            else if (gestures.ZoomModifierKey == Keyboard.Modifiers)
+            {
+                double zoom = Math.Pow(2.0, e.Delta / 3.0 / Mouse.MouseWheelDeltaForOneLine);
+                Editor.ZoomAtPosition(zoom, Editor.MouseLocation);
+                e.Handled = true;
             }
         }
     }

--- a/Nodify/EditorStates/EditorPanningState.cs
+++ b/Nodify/EditorStates/EditorPanningState.cs
@@ -58,11 +58,13 @@ namespace Nodify
             EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
             if (gestures.Pan.Matches(e.Source, e))
             {
-                // Handle right click if panning and moved the mouse more than threshold so context menu doesn't open
-                if (e.ChangedButton == MouseButton.Right)
+                // Suppress the context menu if the mouse moved beyond the defined drag threshold or the editor is selecting
+                if (e.ChangedButton == MouseButton.Right && Editor.ContextMenu != null)
                 {
-                    double contextMenuTreshold = NodifyEditor.HandleRightClickAfterPanningThreshold * NodifyEditor.HandleRightClickAfterPanningThreshold;
-                    if ((_currentMousePosition - _initialMousePosition).LengthSquared > contextMenuTreshold)
+                    double dragThreshold = NodifyEditor.MouseActionSuppressionThreshold * NodifyEditor.MouseActionSuppressionThreshold;
+                    double dragDistance = (_currentMousePosition - _initialMousePosition).LengthSquared;
+
+                    if (dragDistance > dragThreshold || Editor.IsSelecting)
                     {
                         e.Handled = true;
                     }

--- a/Nodify/ItemContainer.cs
+++ b/Nodify/ItemContainer.cs
@@ -222,6 +222,12 @@ namespace Nodify
         public static bool AllowDraggingCancellation { get; set; } = true;
 
         /// <summary>
+        /// Indicates whether right-click on the container should preserve the current selection. 
+        /// </summary>
+        /// <remarks>Has no effect if the container has a context menu.</remarks>
+        public static bool PreserveSelectionOnRightClick { get; set; }
+
+        /// <summary>
         /// The <see cref="NodifyEditor"/> that owns this <see cref="ItemContainer"/>.
         /// </summary>
         public NodifyEditor Editor { get; }

--- a/Nodify/NodifyEditor.Panning.cs
+++ b/Nodify/NodifyEditor.Panning.cs
@@ -76,12 +76,6 @@ namespace Nodify
         public static bool AllowPanningCancellation { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum number of pixels allowed to move the mouse before cancelling the mouse event.
-        /// Useful for <see cref="ContextMenu"/>s to appear if mouse only moved a bit or not at all.
-        /// </summary>
-        public static double HandleRightClickAfterPanningThreshold { get; set; } = 12d;
-
-        /// <summary>
         /// Gets or sets how often the new <see cref="ViewportLocation"/> is calculated in milliseconds when <see cref="DisableAutoPanning"/> is false.
         /// </summary>
         public static double AutoPanningTickRate { get; set; } = 1;
@@ -119,11 +113,9 @@ namespace Nodify
         /// <param name="amount">The amount to pan the viewport.</param>
         /// <remarks>
         /// This method adjusts the current <see cref="ViewportLocation"/> incrementally based on the provided amount.
-        /// It should only be called while a panning operation is active (see <see cref="BeginPanning(Point)"/>).
         /// </remarks>
         public void UpdatePanning(Vector amount)
         {
-            Debug.Assert(IsPanning);
             ViewportLocation -= amount;
         }
 

--- a/Nodify/NodifyEditor.Scrolling.cs
+++ b/Nodify/NodifyEditor.Scrolling.cs
@@ -85,13 +85,13 @@ namespace Nodify
 
         void IScrollInfo.SetHorizontalOffset(double offset)
         {
-            _horizontalOffset = offset;
+            _horizontalOffset = double.IsInfinity(offset) ? 0d : offset;
             UpdateViewportLocationOnScroll();
         }
 
         void IScrollInfo.SetVerticalOffset(double offset)
         {
-            _verticalOffset = offset;
+            _verticalOffset = double.IsInfinity(offset) ? 0d : offset;
             UpdateViewportLocationOnScroll();
         }
 

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -472,6 +472,12 @@ namespace Nodify
         public static double FitToScreenExtentMargin { get; set; } = 30;
 
         /// <summary>
+        /// Gets or sets the maximum distance, in pixels, that the mouse can move before suppressing certain mouse actions. 
+        /// This is useful for suppressing actions like showing a <see cref="ContextMenu"/> if the mouse has moved significantly.
+        /// </summary>
+        public static double MouseActionSuppressionThreshold { get; set; } = 12d;
+
+        /// <summary>
         /// Tells if the <see cref="NodifyEditor"/> is doing operations on multiple items at once.
         /// </summary>
         public bool IsBulkUpdatingItems { get; protected set; }
@@ -793,12 +799,6 @@ namespace Nodify
             {
                 ReleaseMouseCapture();
             }
-
-            // Disable context menu if selecting
-            if (IsSelecting)
-            {
-                e.Handled = true;
-            }
         }
 
         /// <inheritdoc />
@@ -809,26 +809,15 @@ namespace Nodify
         }
 
         /// <inheritdoc />
-        protected override void OnLostMouseCapture(MouseEventArgs e)
-            => PopAllStates();
-
-        /// <inheritdoc />
         protected override void OnMouseWheel(MouseWheelEventArgs e)
         {
+            MouseLocation = e.GetPosition(ItemsHost);
             State.HandleMouseWheel(e);
-
-            if (!e.Handled && EditorGestures.Mappings.Editor.ZoomModifierKey == Keyboard.Modifiers)
-            {
-                double zoom = Math.Pow(2.0, e.Delta / 3.0 / Mouse.MouseWheelDeltaForOneLine);
-                ZoomAtPosition(zoom, e.GetPosition(ItemsHost));
-
-                // Handle it for nested editors
-                if (e.Source is NodifyEditor)
-                {
-                    e.Handled = true;
-                }
-            }
         }
+
+        /// <inheritdoc />
+        protected override void OnLostMouseCapture(MouseEventArgs e)
+            => PopAllStates();
 
         protected override void OnKeyUp(KeyEventArgs e)
             => State.HandleKeyUp(e);


### PR DESCRIPTION
### 📝 Description of the Change

Suppress context menu for common actions. 

- moved mouse wheel logic from `NodifyEditor` to the `EditorDefaultState`.
- added `PreserveSelectionOnRightClick` to `ItemContainer`.
- renamed `HandleRightClickAfterPanningThreshold` to `MouseActionSuppressionThreshold` in `NodifyEditor`
- fixed a couple of bugs

Related: #146

### 🐛 Possible Drawbacks

There is some code duplication introduced, which may need refactoring in future iterations.
