### PR TITLE
Add editor methods to align containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@
 >	- Added UpdateCuttingLine to NodifyEditor
 >	- Added BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
 >	- Added IsDragging, BeginDragging, UpdateDragging, EndDragging and CancelDragging to NodifyEditor
+>	- Added AlignSelection and AlignContainers to NodifyEditor
 >	- Added Select, BeginDragging, UpdateDragging, EndDragging and CancelDragging to ItemContainer
 >	- Added PreserveSelectionOnRightClick configuration field to ItemContainer
 > - Bugfixes:
 >	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured
 >	- Fixed an issue where the Home button caused the editor to fail to display items when contained within a ScrollViewer
+>	- Fixed an issue where connector optimization did not work when SelectedItems was not data-bound
+>	- Fixed an issue where EditorCommands.Align caused multiple arrange invalidations, one for each aligned container
 	
 #### **Version 6.6.0**
 

--- a/Nodify/Connections/Connector.cs
+++ b/Nodify/Connections/Connector.cs
@@ -252,8 +252,7 @@ namespace Nodify
             // Update only connectors that are connected
             if (Editor != null && IsConnected)
             {
-                bool shouldOptimize = EnableOptimizations && Editor.SelectedItems?.Count > OptimizeMinimumSelectedItems;
-
+                bool shouldOptimize = EnableOptimizations && Editor.SelectedContainersCount >= OptimizeMinimumSelectedItems;
                 if (shouldOptimize)
                 {
                     UpdateAnchorBasedOnLocation(Editor, location);

--- a/Nodify/Helpers/AlignmentHelper.cs
+++ b/Nodify/Helpers/AlignmentHelper.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections.Generic;
+using System;
+using System.Linq;
+using System.Windows;
+
+namespace Nodify
+{
+    internal static class AlignmentHelper
+    {
+        public static void Align(IEnumerable<ItemContainer> values, Alignment alignment, ItemContainer? relativeTo)
+        {
+            var containers = values as IReadOnlyCollection<ItemContainer> ?? values.ToList();
+            switch (alignment)
+            {
+                case Alignment.Top:
+                    AlignTop(containers, relativeTo);
+                    break;
+
+                case Alignment.Left:
+                    AlignLeft(containers, relativeTo);
+                    break;
+
+                case Alignment.Bottom:
+                    AlignBottom(containers, relativeTo);
+                    break;
+
+                case Alignment.Right:
+                    AlignRight(containers, relativeTo);
+                    break;
+
+                case Alignment.Middle:
+                    AlignMiddle(containers, relativeTo);
+                    break;
+
+                case Alignment.Center:
+                    AlignCenter(containers, relativeTo);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(alignment), alignment, null);
+            }
+        }
+
+        private static void AlignTop(IReadOnlyCollection<ItemContainer> containers, ItemContainer? instigator)
+        {
+            double top = instigator?.Location.Y ?? containers.Min(x => x.Location.Y);
+            foreach (var c in containers)
+            {
+                c.Location = new Point(c.Location.X, top);
+            }
+        }
+
+        private static void AlignLeft(IReadOnlyCollection<ItemContainer> containers, ItemContainer? instigator)
+        {
+            double left = instigator?.Location.X ?? containers.Min(x => x.Location.X);
+            foreach (var c in containers)
+            {
+                c.Location = new Point(left, c.Location.Y);
+            }
+        }
+
+        private static void AlignBottom(IReadOnlyCollection<ItemContainer> containers, ItemContainer? instigator)
+        {
+            double bottom = instigator != null ? instigator.Location.Y + instigator.ActualHeight : containers.Max(x => x.Location.Y + x.ActualHeight);
+            foreach (var c in containers)
+            {
+                c.Location = new Point(c.Location.X, bottom - c.ActualHeight);
+            }
+        }
+
+        private static void AlignRight(IReadOnlyCollection<ItemContainer> containers, ItemContainer? instigator)
+        {
+            double right = instigator != null ? instigator.Location.X + instigator.ActualWidth : containers.Max(x => x.Location.X + x.ActualWidth);
+            foreach (var c in containers)
+            {
+                c.Location = new Point(right - c.ActualWidth, c.Location.Y);
+            }
+        }
+
+        private static void AlignMiddle(IReadOnlyCollection<ItemContainer> containers, ItemContainer? instigator)
+        {
+            double mid = instigator != null ? instigator.Location.Y + instigator.ActualHeight / 2 : containers.Average(c => c.Location.Y + c.ActualHeight / 2);
+            foreach (var c in containers)
+            {
+                c.Location = new Point(c.Location.X, mid - c.ActualHeight / 2);
+            }
+        }
+
+        private static void AlignCenter(IReadOnlyCollection<ItemContainer> containers, ItemContainer? instigator)
+        {
+            double center = instigator != null ? instigator.Location.X + instigator.ActualWidth / 2 : containers.Average(c => c.Location.X + c.ActualWidth / 2);
+            foreach (var c in containers)
+            {
+                c.Location = new Point(center - c.ActualWidth / 2, c.Location.Y);
+            }
+        }
+
+    }
+}

--- a/Nodify/Helpers/AlignmentHelper.cs
+++ b/Nodify/Helpers/AlignmentHelper.cs
@@ -94,6 +94,5 @@ namespace Nodify
                 c.Location = new Point(center - c.ActualWidth / 2, c.Location.Y);
             }
         }
-
     }
 }

--- a/Nodify/ItemContainer.cs
+++ b/Nodify/ItemContainer.cs
@@ -140,7 +140,7 @@ namespace Nodify
             var item = (ItemContainer)d;
             item.OnLocationChanged();
 
-            if (!item.Editor.IsBulkUpdatingItems)
+            if (item.Editor.IsLoaded && !item.Editor.IsBulkUpdatingItems)
             {
                 item.Editor.ItemsHost.InvalidateArrange();
             }

--- a/Nodify/NodifyEditor.Dragging.cs
+++ b/Nodify/NodifyEditor.Dragging.cs
@@ -40,7 +40,7 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Invoked when a drag operation starts for the <see cref="SelectedItems"/>, or when <see cref="IsPushingItems"/> is set to true.
+        /// Invoked when a drag operation starts for the <see cref="SelectedContainers"/>, or when <see cref="IsPushingItems"/> is set to true.
         /// </summary>
         public ICommand? ItemsDragStartedCommand
         {
@@ -49,7 +49,7 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Invoked when a drag operation is completed for the <see cref="SelectedItems"/>, or when <see cref="IsPushingItems"/> is set to false.
+        /// Invoked when a drag operation is completed for the <see cref="SelectedContainers"/>, or when <see cref="IsPushingItems"/> is set to false.
         /// </summary>
         public ICommand? ItemsDragCompletedCommand
         {

--- a/Nodify/NodifyEditor.Selecting.cs
+++ b/Nodify/NodifyEditor.Selecting.cs
@@ -177,7 +177,7 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Gets a list of <see cref="ItemContainer"/>s that are selected.
+        /// Gets a list of <see cref="ItemContainer"/>s that are selected (see <see cref="SelectedContainersCount"/>).
         /// </summary>
         /// <remarks>Cache the result before using it to avoid extra allocations.</remarks>
         protected internal IReadOnlyList<ItemContainer> SelectedContainers
@@ -196,6 +196,11 @@ namespace Nodify
                 return selectedContainers;
             }
         }
+
+        /// <summary>
+        /// Gets the number of selected containers, without allocating (see <see cref="SelectedContainers"/>).
+        /// </summary>
+        public int SelectedContainersCount => base.SelectedItems.Count;
 
         /// <summary>
         /// Gets or sets whether cancelling a selection operation is allowed (see <see cref="EditorGestures.SelectionGestures.Cancel"/>).

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -11,6 +11,19 @@ using System.Windows.Media;
 namespace Nodify
 {
     /// <summary>
+    /// Specifies the possible alignment values used by the <see cref="NodifyEditor.AlignSelection(Alignment)"/> method.
+    /// </summary>
+    public enum Alignment
+    {
+        Top,
+        Left,
+        Bottom,
+        Right,
+        Middle,
+        Center
+    }
+
+    /// <summary>
     /// Groups <see cref="ItemContainer"/>s and <see cref="Connection"/>s in an area that you can drag, zoom and select.
     /// </summary>
     [TemplatePart(Name = ElementItemsHost, Type = typeof(Panel))]
@@ -672,6 +685,41 @@ namespace Nodify
                 ZoomAtPosition(zoom, center);
                 BringIntoView(center, animated: false);
             }
+        }
+
+        /// <summary>
+        /// Aligns the selected containers based on the specified alignment.
+        /// </summary>
+        /// <param name="alignment">The alignment type to apply to the selected containers.</param>
+        /// <param name="relativeTo">An optional container to use as a reference for alignment. If null, the alignment is based on the containers themselves.</param>
+        /// <remarks>This method has no effect if a dragging operation is in progress.</remarks>
+        public void AlignSelection(Alignment alignment, ItemContainer? relativeTo = default)
+            => AlignContainers(SelectedContainers, alignment, relativeTo);
+
+        /// <summary>
+        /// Aligns a collection of containers based on the specified alignment.
+        /// </summary>
+        /// <param name="containers">The collection of item containers to align.</param>
+        /// <param name="alignment">The alignment type to apply to the containers.</param>
+        /// <param name="relativeTo">An optional container to use as a reference for alignment. If null, the alignment is based on the containers themselves.</param>
+        /// <remarks>This method has no effect if a dragging operation is in progress.</remarks>
+        public void AlignContainers(IEnumerable<ItemContainer> containers, Alignment alignment, ItemContainer? relativeTo = default)
+        {
+            if (IsDragging)
+            {
+                return;
+            }
+
+            IsDragging = true;
+            IsBulkUpdatingItems = true;
+
+            AlignmentHelper.Align(containers, alignment, relativeTo);
+
+            IsBulkUpdatingItems = false;
+            // Draw the containers at the new position.
+            ItemsHost.InvalidateArrange();
+
+            IsDragging = false;
         }
 
         #endregion


### PR DESCRIPTION
### 📝 Description of the Change

Moved `Align` command logic from `EditorCommands` to new methods in `NodifyEditor`:
- `AlignSelection`
- `AlignContainers` 

Related #146

### 🐛 Possible Drawbacks

None.
