### PR TITLE
Add HasCustomContextMenu to NodifyEditor and ItemContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 >	- Added UpdateCuttingLine to NodifyEditor
 >	- Added BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
 >	- Added IsDragging, BeginDragging, UpdateDragging, EndDragging and CancelDragging to NodifyEditor
->	- Added AlignSelection and AlignContainers to NodifyEditor
+>	- Added AlignSelection and AlignContainers methods to NodifyEditor
+>	- Added HasCustomContextMenu dependency property to NodifyEditor and ItemContainer
 >	- Added Select, BeginDragging, UpdateDragging, EndDragging and CancelDragging to ItemContainer
 >	- Added PreserveSelectionOnRightClick configuration field to ItemContainer
 > - Bugfixes:

--- a/Examples/Nodify.Calculator/EditorView.xaml
+++ b/Examples/Nodify.Calculator/EditorView.xaml
@@ -135,6 +135,7 @@
                              ConnectionTemplate="{StaticResource ConnectionTemplate}"
                              Background="{StaticResource SmallGridLinesDrawingBrush}"
                              ItemContainerStyle="{StaticResource ItemContainerStyle}"
+                             HasCustomContextMenu="True"
                              GridCellSize="15"
                              AllowDrop="True"
                              Drop="OnDropNode"

--- a/Examples/Nodify.Calculator/EditorView.xaml.cs
+++ b/Examples/Nodify.Calculator/EditorView.xaml.cs
@@ -16,7 +16,7 @@ namespace Nodify.Calculator
 
         private void OpenOperationsMenu(object sender, MouseButtonEventArgs e)
         {
-            if (!e.Handled && e.OriginalSource is NodifyEditor editor && !editor.IsPanning && editor.DataContext is CalculatorViewModel calculator)
+            if (!e.Handled && e.OriginalSource is NodifyEditor editor && editor.DataContext is CalculatorViewModel calculator)
             {
                 e.Handled = true;
                 calculator.OperationsMenu.OpenAt(editor.MouseLocation);

--- a/Nodify/EditorStates/ContainerDefaultState.cs
+++ b/Nodify/EditorStates/ContainerDefaultState.cs
@@ -69,7 +69,7 @@ namespace Nodify
                 // explicit context menu or is configured to preserve the selection on right-click, the selection 
                 // remains unchanged. This ensures that the context menu applies to the entire selection rather 
                 // than only the clicked item.
-                bool hasContextMenu = Container.ContextMenu != null || ItemContainer.PreserveSelectionOnRightClick;
+                bool hasContextMenu = Container.HasContextMenu || ItemContainer.PreserveSelectionOnRightClick;
                 bool allowContextMenu = e.ChangedButton == MouseButton.Right && Container.IsSelected && hasContextMenu;
                 if (!(_selectionType == SelectionType.Replace && allowContextMenu))
                 {

--- a/Nodify/EditorStates/ContainerDraggingState.cs
+++ b/Nodify/EditorStates/ContainerDraggingState.cs
@@ -56,7 +56,7 @@ namespace Nodify
             if (gestures.Drag.Matches(e.Source, e))
             {
                 // Suppress the context menu if the mouse moved beyond the defined drag threshold
-                if (e.ChangedButton == MouseButton.Right && Container.HasContextMenu)
+                if (e.ChangedButton == MouseButton.Right && (Container.HasContextMenu || Editor.HasContextMenu))
                 {
                     double dragThreshold = NodifyEditor.MouseActionSuppressionThreshold * NodifyEditor.MouseActionSuppressionThreshold;
                     double dragDistance = (Editor.MouseLocation - _initialMousePosition).LengthSquared;

--- a/Nodify/EditorStates/ContainerDraggingState.cs
+++ b/Nodify/EditorStates/ContainerDraggingState.cs
@@ -56,7 +56,7 @@ namespace Nodify
             if (gestures.Drag.Matches(e.Source, e))
             {
                 // Suppress the context menu if the mouse moved beyond the defined drag threshold
-                if (e.ChangedButton == MouseButton.Right && Editor.ContextMenu != null)
+                if (e.ChangedButton == MouseButton.Right && Container.HasContextMenu)
                 {
                     double dragThreshold = NodifyEditor.MouseActionSuppressionThreshold * NodifyEditor.MouseActionSuppressionThreshold;
                     double dragDistance = (Editor.MouseLocation - _initialMousePosition).LengthSquared;

--- a/Nodify/EditorStates/EditorCuttingState.cs
+++ b/Nodify/EditorStates/EditorCuttingState.cs
@@ -39,7 +39,7 @@ namespace Nodify
             if (gestures.Cutting.Matches(e.Source, e))
             {
                 // Suppress the context menu if the mouse moved beyond the defined drag threshold
-                if (e.ChangedButton == MouseButton.Right && Editor.ContextMenu != null)
+                if (e.ChangedButton == MouseButton.Right && Editor.HasContextMenu)
                 {
                     double dragThreshold = NodifyEditor.MouseActionSuppressionThreshold * NodifyEditor.MouseActionSuppressionThreshold;
                     double dragDistance = (Editor.MouseLocation - _initialPosition).LengthSquared;

--- a/Nodify/EditorStates/EditorPanningState.cs
+++ b/Nodify/EditorStates/EditorPanningState.cs
@@ -59,7 +59,7 @@ namespace Nodify
             if (gestures.Pan.Matches(e.Source, e))
             {
                 // Suppress the context menu if the mouse moved beyond the defined drag threshold or the editor is selecting
-                if (e.ChangedButton == MouseButton.Right && Editor.ContextMenu != null)
+                if (e.ChangedButton == MouseButton.Right && Editor.HasContextMenu)
                 {
                     double dragThreshold = NodifyEditor.MouseActionSuppressionThreshold * NodifyEditor.MouseActionSuppressionThreshold;
                     double dragDistance = (_currentMousePosition - _initialMousePosition).LengthSquared;

--- a/Nodify/EditorStates/EditorPushingItemsState.cs
+++ b/Nodify/EditorStates/EditorPushingItemsState.cs
@@ -63,7 +63,7 @@ namespace Nodify
             if (gestures.PushItems.Matches(e.Source, e))
             {
                 // Suppress the context menu if the mouse moved beyond the defined drag threshold
-                if (e.ChangedButton == MouseButton.Right && Editor.ContextMenu != null)
+                if (e.ChangedButton == MouseButton.Right && Editor.HasContextMenu)
                 {
                     double dragThreshold = NodifyEditor.MouseActionSuppressionThreshold * NodifyEditor.MouseActionSuppressionThreshold;
                     double dragDistance = (Editor.MouseLocation - _initialPosition).LengthSquared;

--- a/Nodify/EditorStates/EditorSelectingState.cs
+++ b/Nodify/EditorStates/EditorSelectingState.cs
@@ -61,7 +61,7 @@ namespace Nodify
             if (gestures.Select.Matches(e.Source, e))
             {
                 // Suppress the context menu if the mouse moved beyond the defined drag threshold
-                if (e.ChangedButton == MouseButton.Right && Editor.ContextMenu != null)
+                if (e.ChangedButton == MouseButton.Right && Editor.HasContextMenu)
                 {
                     double dragThreshold = NodifyEditor.MouseActionSuppressionThreshold * NodifyEditor.MouseActionSuppressionThreshold;
                     double dragDistance = (Editor.MouseLocation - _initialPosition).LengthSquared;

--- a/Nodify/ItemContainer.cs
+++ b/Nodify/ItemContainer.cs
@@ -33,6 +33,18 @@ namespace Nodify
         private static readonly DependencyPropertyKey IsPreviewingLocationPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsPreviewingLocation), typeof(bool), typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.False));
         public static readonly DependencyProperty IsPreviewingLocationProperty = IsPreviewingLocationPropertyKey.DependencyProperty;
         public static readonly DependencyProperty IsDraggableProperty = DependencyProperty.Register(nameof(IsDraggable), typeof(bool), typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.True));
+        public static readonly DependencyProperty HasCustomContextMenuProperty = NodifyEditor.HasCustomContextMenuProperty.AddOwner(typeof(ItemContainer));
+
+        private static void OnLocationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var item = (ItemContainer)d;
+            item.OnLocationChanged();
+
+            if (item.Editor.IsLoaded && !item.Editor.IsBulkUpdatingItems)
+            {
+                item.Editor.ItemsHost.InvalidateArrange();
+            }
+        }
 
         /// <summary>
         /// Gets or sets the brush used when the <see cref="PendingConnection.IsOverElementProperty"/> attached property is true for this <see cref="ItemContainer"/>.
@@ -135,16 +147,20 @@ namespace Nodify
             set => SetValue(IsDraggableProperty, value);
         }
 
-        private static void OnLocationChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Gets or sets a value indicating whether the container uses a custom context menu.
+        /// </summary>
+        /// <remarks>When set to true, the container handles the right-click event for specific operations.</remarks>
+        public bool HasCustomContextMenu
         {
-            var item = (ItemContainer)d;
-            item.OnLocationChanged();
-
-            if (item.Editor.IsLoaded && !item.Editor.IsBulkUpdatingItems)
-            {
-                item.Editor.ItemsHost.InvalidateArrange();
-            }
+            get => (bool)GetValue(HasCustomContextMenuProperty);
+            set => SetValue(HasCustomContextMenuProperty, value);
         }
+
+        /// <summary>
+        /// Gets a value indicating whether the container has a context menu.
+        /// </summary>
+        public bool HasContextMenu => ContextMenu != null || HasCustomContextMenu;
 
         #endregion
 

--- a/Nodify/NodifyEditor.cs
+++ b/Nodify/NodifyEditor.cs
@@ -349,6 +349,7 @@ namespace Nodify
         public static readonly DependencyProperty PendingConnectionProperty = DependencyProperty.Register(nameof(PendingConnection), typeof(object), typeof(NodifyEditor));
         public static readonly DependencyProperty GridCellSizeProperty = DependencyProperty.Register(nameof(GridCellSize), typeof(uint), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.UInt1, OnGridCellSizeChanged, OnCoerceGridCellSize));
         public static readonly DependencyProperty DisableZoomingProperty = DependencyProperty.Register(nameof(DisableZooming), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False));
+        public static readonly DependencyProperty HasCustomContextMenuProperty = DependencyProperty.Register(nameof(HasCustomContextMenu), typeof(bool), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.False));
         public static readonly DependencyProperty DecoratorsProperty = DependencyProperty.Register(nameof(Decorators), typeof(IEnumerable), typeof(NodifyEditor));
 
         private static object OnCoerceGridCellSize(DependencyObject d, object value)
@@ -400,6 +401,21 @@ namespace Nodify
             get => (bool)GetValue(DisableZoomingProperty);
             set => SetValue(DisableZoomingProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the editor uses a custom context menu.
+        /// </summary>
+        /// <remarks>When set to true, the editor handles the right-click event for specific operations.</remarks>
+        public bool HasCustomContextMenu
+        {
+            get => (bool)GetValue(HasCustomContextMenuProperty);
+            set => SetValue(HasCustomContextMenuProperty, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the editor has a context menu.
+        /// </summary>
+        public bool HasContextMenu => ContextMenu != null || HasCustomContextMenu;
 
         #endregion
 


### PR DESCRIPTION
### 📝 Description of the Change

Added `HasCustomContextMenu` to `NodifyEditor` and `ItemContainer`. This property prevents custom menus, such as the `OperationsView` in the Calculator app, from appearing when completing operations triggered by the `Right Mouse Button`.

### 🐛 Possible Drawbacks

None.
