### PR TITLE
Added Connector methods to manage a pending connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 >	- Added HasCustomContextMenu dependency property to NodifyEditor and ItemContainer
 >	- Added Select, BeginDragging, UpdateDragging, EndDragging and CancelDragging to ItemContainer
 >	- Added PreserveSelectionOnRightClick configuration field to ItemContainer
+>	- Added State, GetInitialState, PushState, PopState and PopAllStates to Connector
+>	- Added BeginConnecting, UpdatePendingConnection, EndConnecting, CancelConnecting and RemoveConnections methods to Connector
 > - Bugfixes:
 >	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured
 >	- Fixed an issue where the Home button caused the editor to fail to display items when contained within a ScrollViewer

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -105,6 +105,11 @@ namespace Nodify.Playground
                     "Auto panning edge distance: ",
                     "Distance from edge to trigger auto panning"),
                 new ProxySettingViewModel<bool>(
+                    () => Instance.EnableStickyConnectors,
+                    val => Instance.EnableStickyConnectors = val,
+                    "Enable sticky connectors: ",
+                    "The connection can be completed in two steps (e.g. click to create pending connection, click to connect)"),
+                new ProxySettingViewModel<bool>(
                     () => Instance.SelectableConnections,
                     val => Instance.SelectableConnections = val,
                     "Selectable connections: ",
@@ -226,6 +231,21 @@ namespace Nodify.Playground
                     "Allow cutting cancellation: ",
                     "Right click to cancel cutting."),
                 new ProxySettingViewModel<bool>(
+                    () => Instance.AllowPushItemsCancellation,
+                    val => Instance.AllowPushItemsCancellation = val,
+                    "Allow push nodes cancellation: ",
+                    "Right click to cancel pushing nodes."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowPanningCancellation,
+                    val => Instance.AllowPanningCancellation= val,
+                    "Allow panning cancellation: ",
+                    "Press Escape to cancel panning."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowSelectionCancellation,
+                    val => Instance.AllowSelectionCancellation = val,
+                    "Allow selection cancellation: ",
+                    "Press Escape to cancel selecting."),
+                new ProxySettingViewModel<bool>(
                     () => Instance.AllowDraggingCancellation,
                     val => Instance.AllowDraggingCancellation = val,
                     "Allow dragging cancellation: ",
@@ -285,11 +305,6 @@ namespace Nodify.Playground
                     val => Instance.FitToScreenExtentMargin = val,
                     "Fit to screen extent margin: ",
                     "Adds some margin to the nodes extent when fit to screen"),
-                new ProxySettingViewModel<bool>(
-                    () => Instance.EnableStickyConnectors,
-                    val => Instance.EnableStickyConnectors = val,
-                    "Enable sticky connectors: ",
-                    "The connection can be completed in two steps (e.g. click to create pending connection, click to connect)"),
             };
 
             EnableCuttingLinePreview = true;
@@ -601,6 +616,24 @@ namespace Nodify.Playground
         {
             get => CuttingLine.AllowCuttingCancellation;
             set => CuttingLine.AllowCuttingCancellation = value;
+        }
+
+        public bool AllowPushItemsCancellation
+        {
+            get => NodifyEditor.AllowPushItemsCancellation;
+            set => NodifyEditor.AllowPushItemsCancellation = value;
+        }
+
+        public bool AllowPanningCancellation
+        {
+            get => NodifyEditor.AllowPanningCancellation;
+            set => NodifyEditor.AllowPanningCancellation = value;
+        }
+
+        public bool AllowSelectionCancellation
+        {
+            get => NodifyEditor.AllowSelectionCancellation;
+            set => NodifyEditor.AllowSelectionCancellation = value;
         }
 
         public bool AllowDraggingCancellation

--- a/Nodify/Connections/Connector.cs
+++ b/Nodify/Connections/Connector.cs
@@ -540,6 +540,7 @@ namespace Nodify
         /// <summary>
         /// Removes all connections associated with this connector.
         /// </summary>
+        /// <remarks>This method has no effect if a pending connection is already in progress or the connector is not connected (see <see cref="IsConnected"/>).</remarks>
         public void RemoveConnections()
         {
             if (!IsConnected || IsPendingConnection)

--- a/Nodify/Connections/PendingConnection.cs
+++ b/Nodify/Connections/PendingConnection.cs
@@ -254,7 +254,7 @@ namespace Nodify
             {
                 e.Handled = true;
                 e.Canceled = !StartedCommand?.CanExecute(e.SourceConnector) ?? false;
-                    
+
                 Target = null;
                 IsVisible = !e.Canceled;
                 SourceAnchor = e.Anchor;
@@ -266,7 +266,7 @@ namespace Nodify
                     StartedCommand?.Execute(Source);
                 }
 
-                if(EnablePreview)
+                if (EnablePreview)
                 {
                     PreviewTarget = e.SourceConnector;
                 }
@@ -283,7 +283,7 @@ namespace Nodify
                 if (Editor != null && (EnablePreview || EnableSnapping))
                 {
                     // Look for a potential connector
-                    FrameworkElement? connector = GetPotentialConnector(Editor, AllowOnlyConnectors);
+                    FrameworkElement? connector = GetPotentialConnector(Editor, TargetAnchor, AllowOnlyConnectors);
 
                     // Update the connector's anchor and snap to it if snapping is enabled
                     if (EnableSnapping && connector is Connector target)
@@ -342,7 +342,7 @@ namespace Nodify
                     }
                 }
 
-                if(EnablePreview)
+                if (EnablePreview)
                 {
                     PreviewTarget = null;
                 }
@@ -356,17 +356,18 @@ namespace Nodify
         /// <summary>Searches for a potential connector prioritizing <see cref="Connector"/>s</summary>
         /// <param name="editor">The editor to scan for connectors or item containers.</param>
         /// <param name="allowOnlyConnectors">Will also look for <see cref="ItemContainer"/>s if false.</param>
+        /// <param name="position">A position in the editor to verify intersections.</param>
         /// <returns>A connector, an item container, the editor or null.</returns>
-        internal static FrameworkElement? GetPotentialConnector(NodifyEditor editor, bool allowOnlyConnectors)
+        internal static FrameworkElement? GetPotentialConnector(NodifyEditor editor, Point position, bool allowOnlyConnectors)
         {
-            Connector? connector = editor.ItemsHost.GetElementUnderMouse<Connector>();
+            Connector? connector = editor.ItemsHost.GetElementAtPosition<Connector>(position);
             if (connector != null && connector.Editor == editor)
                 return connector;
 
             if (allowOnlyConnectors)
                 return null;
 
-            var itemContainer = editor.ItemsHost.GetElementUnderMouse<ItemContainer>();
+            var itemContainer = editor.ItemsHost.GetElementAtPosition<ItemContainer>(position);
             if (itemContainer != null && itemContainer.Editor == editor)
                 return itemContainer;
 

--- a/Nodify/EditorStates/ConnectorConnectingState.cs
+++ b/Nodify/EditorStates/ConnectorConnectingState.cs
@@ -36,6 +36,8 @@ namespace Nodify
             {
                 Connector.EndConnecting();
                 PopState();
+
+                e.Handled = true;  // prevent interacting with the container
             }
         }
 

--- a/Nodify/EditorStates/ConnectorConnectingState.cs
+++ b/Nodify/EditorStates/ConnectorConnectingState.cs
@@ -1,0 +1,79 @@
+﻿using System.Windows;
+using System.Windows.Input;
+
+namespace Nodify
+{
+    public class ConnectorConnectingState : ConnectorState
+    {
+        private bool Canceled { get; set; } = Connector.AllowPendingConnectionCancellation;
+
+        public ConnectorConnectingState(Connector connector) : base(connector) { }
+
+        public override void Enter(ConnectorState? from)
+        {
+            Canceled = false;
+            Connector.BeginConnecting();
+        }
+
+        public override void Exit()
+        {
+            // TODO: This is not canceled on LostMouseCapture (add OnLostMouseCapture/OnCancel callback?)
+            if (Canceled)
+            {
+                Connector.CancelConnecting();
+                Connector.ReleaseMouseCapture();
+            }
+            else
+            {
+                Connector.EndConnecting();
+            }
+        }
+
+        public override void HandleMouseDown(MouseButtonEventArgs e)
+        {
+            EditorGestures.ConnectorGestures gestures = EditorGestures.Mappings.Connector;
+            if (Connector.EnableStickyConnections && Connector.IsPendingConnection && !gestures.CancelAction.Matches(e.Source, e))
+            {
+                Connector.EndConnecting();
+                PopState();
+            }
+        }
+
+        public override void HandleMouseMove(MouseEventArgs e)
+        {
+            Vector thumbOffset = e.GetPosition(Connector.Thumb) - new Point(Connector.Thumb.ActualWidth / 2, Connector.Thumb.ActualHeight / 2);
+            Point editorPosition = Connector.Anchor + thumbOffset;
+
+            Connector.UpdatePendingConnection(editorPosition);
+        }
+
+        public override void HandleMouseUp(MouseButtonEventArgs e)
+        {
+            e.Handled = Connector.EnableStickyConnections && Connector.IsPendingConnection;
+
+            EditorGestures.ConnectorGestures gestures = EditorGestures.Mappings.Connector;
+            if (!Connector.EnableStickyConnections && gestures.Connect.Matches(e.Source, e))
+            {
+                e.Handled = true;   // prevents opening context menu
+                PopState();
+            }
+            else if (Connector.AllowPendingConnectionCancellation && Connector.IsPendingConnection && gestures.CancelAction.Matches(e.Source, e))
+            {
+                Canceled = true;
+                e.Handled = true;   // prevents opening context menu
+
+                PopState();
+            }
+        }
+
+        public override void HandleKeyUp(KeyEventArgs e)
+        {
+            EditorGestures.ConnectorGestures gestures = EditorGestures.Mappings.Connector;
+            if (Connector.AllowPendingConnectionCancellation && gestures.CancelAction.Matches(e.Source, e))
+            {
+                Canceled = true;
+                PopState();
+            }
+        }
+    }
+}

--- a/Nodify/EditorStates/ConnectorDefaultState.cs
+++ b/Nodify/EditorStates/ConnectorDefaultState.cs
@@ -15,7 +15,14 @@ namespace Nodify
             }
             else if (gestures.Connect.Matches(e.Source, e))
             {
-                Connector.PushState(new ConnectorConnectingState(Connector));
+                if (Connector.EnableStickyConnections)
+                {
+                    Connector.PushState(new ConnectorConnectingStickyState(Connector));
+                }
+                else
+                {
+                    Connector.PushState(new ConnectorConnectingState(Connector));
+                }
             }
 
             e.Handled = true;   // prevent interacting with the container

--- a/Nodify/EditorStates/ConnectorDefaultState.cs
+++ b/Nodify/EditorStates/ConnectorDefaultState.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows.Input;
+
+namespace Nodify
+{
+    public class ConnectorDefaultState : ConnectorState
+    {
+        public ConnectorDefaultState(Connector connector) : base(connector) { }
+
+        public override void HandleMouseDown(MouseButtonEventArgs e)
+        {
+            EditorGestures.ConnectorGestures gestures = EditorGestures.Mappings.Connector;
+            if (gestures.Disconnect.Matches(e.Source, e))
+            {
+                Connector.RemoveConnections();
+            }
+            else if (gestures.Connect.Matches(e.Source, e))
+            {
+                Connector.PushState(new ConnectorConnectingState(Connector));
+            }
+
+            e.Handled = true;   // prevent interacting with the container
+        }
+    }
+}

--- a/Nodify/EditorStates/ConnectorState.cs
+++ b/Nodify/EditorStates/ConnectorState.cs
@@ -1,0 +1,20 @@
+﻿namespace Nodify
+{
+    public class ConnectorState : InputElementState<ConnectorState>
+    {
+        public ConnectorState(Connector connector)
+        {
+            Connector = connector;
+        }
+
+        /// <summary>The owner of the state.</summary>
+        protected Connector Connector { get; }
+
+        /// <summary>Pushes a new state into the stack.</summary>
+        /// <param name="newState">The new state.</param>
+        public virtual void PushState(ConnectorState newState) => Connector.PushState(newState);
+
+        /// <summary>Pops the current state from the stack.</summary>
+        public virtual void PopState() => Connector.PopState();
+    }
+}

--- a/Nodify/EditorStates/ContainerState.cs
+++ b/Nodify/EditorStates/ContainerState.cs
@@ -1,9 +1,7 @@
-﻿using System.Windows.Input;
-
-namespace Nodify
+﻿namespace Nodify
 {
     /// <summary>The base class for container states.</summary>
-    public abstract class ContainerState
+    public abstract class ContainerState : InputElementState<ContainerState>
     {
         /// <summary>Constructs a new <see cref="ContainerState"/>.</summary>
         /// <param name="container">The owner of the state.</param>
@@ -17,35 +15,6 @@ namespace Nodify
 
         /// <summary>The owner of the state.</summary>
         protected NodifyEditor Editor => Container.Editor;
-
-        /// <inheritdoc cref="ItemContainer.OnMouseDown(MouseButtonEventArgs)"/>
-        public virtual void HandleMouseDown(MouseButtonEventArgs e) { }
-
-        /// <inheritdoc cref="ItemContainer.OnMouseDown(MouseButtonEventArgs)"/>
-        public virtual void HandleMouseUp(MouseButtonEventArgs e) { }
-
-        /// <inheritdoc cref="ItemContainer.OnMouseMove(MouseEventArgs)"/>
-        public virtual void HandleMouseMove(MouseEventArgs e) { }
-
-        /// <inheritdoc cref="ItemContainer.OnMouseWheel(MouseWheelEventArgs)"/>
-        public virtual void HandleMouseWheel(MouseWheelEventArgs e) { }
-
-        /// <inheritdoc cref="ItemContainer.OnKeyUp(KeyEventArgs)"/>
-        public virtual void HandleKeyUp(KeyEventArgs e) { }
-
-        /// <inheritdoc cref="ItemContainer.OnKeyDown(KeyEventArgs)"/>
-        public virtual void HandleKeyDown(KeyEventArgs e) { }
-
-        /// <summary>Called when <see cref="ItemContainer.PushState(ContainerState)"/> or <see cref="ItemContainer.PopState"/> is called.</summary>
-        /// <param name="from">The state we enter from (is null for root state).</param>
-        public virtual void Enter(ContainerState? from) { }
-
-        /// <summary>Called when <see cref="ItemContainer.PopState"/> is called.</summary>
-        public virtual void Exit() { }
-
-        /// <summary>Called when <see cref="ItemContainer.PopState"/> is called.</summary>
-        /// <param name="from">The state we re-enter from.</param>
-        public virtual void ReEnter(ContainerState from) { }
 
         /// <summary>Pushes a new state into the stack.</summary>
         /// <param name="newState">The new state.</param>

--- a/Nodify/EditorStates/EditorState.cs
+++ b/Nodify/EditorStates/EditorState.cs
@@ -3,7 +3,7 @@
 namespace Nodify
 {
     /// <summary>The base class for editor states.</summary>
-    public abstract class EditorState
+    public abstract class EditorState : InputElementState<EditorState>
     {
         /// <summary>Constructs a new <see cref="EditorState"/>.</summary>
         /// <param name="editor">The owner of the state.</param>
@@ -15,38 +15,9 @@ namespace Nodify
         /// <summary>The owner of the state.</summary>
         protected NodifyEditor Editor { get; }
 
-        /// <inheritdoc cref="NodifyEditor.OnMouseDown(MouseButtonEventArgs)"/>
-        public virtual void HandleMouseDown(MouseButtonEventArgs e) { }
-
-        /// <inheritdoc cref="NodifyEditor.OnMouseUp(MouseButtonEventArgs)"/>
-        public virtual void HandleMouseUp(MouseButtonEventArgs e) { }
-
-        /// <inheritdoc cref="NodifyEditor.OnMouseMove(MouseEventArgs)"/>
-        public virtual void HandleMouseMove(MouseEventArgs e) { }
-
-        /// <inheritdoc cref="NodifyEditor.OnMouseWheel(MouseWheelEventArgs)"/>
-        public virtual void HandleMouseWheel(MouseWheelEventArgs e) { }
-
         /// <summary>Handles auto panning when mouse is outside the editor.</summary>
         /// <param name="e">The <see cref="MouseEventArgs"/> that contains the event data.</param>
         public virtual void HandleAutoPanning(MouseEventArgs e) { }
-
-        /// <inheritdoc cref="NodifyEditor.OnKeyUp(KeyEventArgs)"/>
-        public virtual void HandleKeyUp(KeyEventArgs e) { }
-
-        /// <inheritdoc cref="NodifyEditor.OnKeyDown(KeyEventArgs)"/>
-        public virtual void HandleKeyDown(KeyEventArgs e) { }
-
-        /// <summary>Called when <see cref="NodifyEditor.PushState(EditorState)"/> is called.</summary>
-        /// <param name="from">The state we enter from (is null for root state).</param>
-        public virtual void Enter(EditorState? from) { }
-
-        /// <summary>Called when <see cref="NodifyEditor.PopState"/> is called.</summary>
-        public virtual void Exit() { }
-
-        /// <summary>Called when <see cref="NodifyEditor.PopState"/> is called.</summary>
-        /// <param name="from">The state we re-enter from.</param>
-        public virtual void ReEnter(EditorState from) { }
 
         /// <summary>Pushes a new state into the stack.</summary>
         /// <param name="newState">The new state.</param>

--- a/Nodify/EditorStates/InputElementState.cs
+++ b/Nodify/EditorStates/InputElementState.cs
@@ -1,0 +1,35 @@
+﻿using System.Windows;
+using System.Windows.Input;
+
+namespace Nodify
+{
+    public abstract class InputElementState<TState>
+        where TState : InputElementState<TState>
+    {
+        /// <inheritdoc cref="UIElement.OnMouseDown(MouseButtonEventArgs)"/>
+        public virtual void HandleMouseDown(MouseButtonEventArgs e) { }
+
+        /// <inheritdoc cref="UIElement.OnMouseUp(MouseButtonEventArgs)"/>
+        public virtual void HandleMouseUp(MouseButtonEventArgs e) { }
+
+        /// <inheritdoc cref="UIElement.OnMouseMove(MouseEventArgs)"/>
+        public virtual void HandleMouseMove(MouseEventArgs e) { }
+
+        /// <inheritdoc cref="UIElement.OnMouseWheel(MouseWheelEventArgs)"/>
+        public virtual void HandleMouseWheel(MouseWheelEventArgs e) { }
+
+        /// <inheritdoc cref="UIElement.OnKeyUp(KeyEventArgs)"/>
+        public virtual void HandleKeyUp(KeyEventArgs e) { }
+
+        /// <inheritdoc cref="UIElement.OnKeyDown(KeyEventArgs)"/>
+        public virtual void HandleKeyDown(KeyEventArgs e) { }
+
+        /// <param name="from">The state we enter from (is null for root state).</param>
+        public virtual void Enter(TState? from) { }
+
+        public virtual void Exit() { }
+
+        /// <param name="from">The state we re-enter from.</param>
+        public virtual void ReEnter(TState from) { }
+    }
+}

--- a/Nodify/Helpers/DependencyObjectExtensions.cs
+++ b/Nodify/Helpers/DependencyObjectExtensions.cs
@@ -54,7 +54,7 @@ namespace Nodify
             return default;
         }
 
-        public static T? GetElementUnderMouse<T>(this UIElement container)
+        public static T? GetElementAtPosition<T>(this UIElement container, Point position)
             where T : UIElement
         {
             T? result = default;
@@ -80,7 +80,7 @@ namespace Nodify
                     return HitTestResultBehavior.Stop;
                 }
                 return HitTestResultBehavior.Continue;
-            }, new PointHitTestParameters(Mouse.GetPosition(container)));
+            }, new PointHitTestParameters(position));
 
             return result;
         }

--- a/Nodify/NodifyEditor.Panning.cs
+++ b/Nodify/NodifyEditor.Panning.cs
@@ -104,6 +104,7 @@ namespace Nodify
         /// <summary>
         /// Starts the panning operation from the current <see cref="ViewportLocation" />.
         /// </summary>
+        /// <remarks>This method has no effect if a panning operation is already in progress.</remarks>
         public void BeginPanning()
             => BeginPanning(ViewportLocation);
 


### PR DESCRIPTION
### 📝 Description of the Change

Added connector states and extracted methods to support different input sources.

New Connector methods:
- `BeginConnecting`
- `UpdatePendingConnection`
- `EndConnecting`
- `CancelConnecting` 
- `RemoveConnections`

Related: #146

### 🐛 Possible Drawbacks

None.
