### PR TITLE
Add a custom MouseGesture with support for key combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 >	- Renamed PushItems to UpdatePushedArea and StartPushingItems to BeginPushingItems in NodifyEditor
 >	- Renamed UnselectAllConnection to UnselectAllConnections in NodifyEditor
 >	- Removed DragStarted, DragDelta and DragCompleted routed events from ItemContainer
+>	- Replaced the System.Windows.Input.MouseGesture with Nodify.MouseGesture
 > - Features:
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor
 >	- Added UpdateCuttingLine to NodifyEditor
@@ -21,6 +22,7 @@
 >	- Added PreserveSelectionOnRightClick configuration field to ItemContainer
 >	- Added State, GetInitialState, PushState, PopState and PopAllStates to Connector
 >	- Added BeginConnecting, UpdatePendingConnection, EndConnecting, CancelConnecting and RemoveConnections methods to Connector
+>	- Added a custom MouseGesture with support for key combinations
 > - Bugfixes:
 >	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured
 >	- Fixed an issue where the Home button caused the editor to fail to display items when contained within a ScrollViewer

--- a/Examples/Nodify.Calculator/EditorView.xaml
+++ b/Examples/Nodify.Calculator/EditorView.xaml
@@ -220,6 +220,7 @@
                                                      PendingConnectionTemplate="{StaticResource PendingConnectionTemplate}"
                                                      ConnectionTemplate="{StaticResource ConnectionTemplate}"
                                                      ItemContainerStyle="{StaticResource ItemContainerStyle}"
+                                                     HasCustomContextMenu="True"
                                                      Background="Transparent"
                                                      GridCellSize="15"
                                                      AllowDrop="True"

--- a/Nodify/Helpers/MultiGesture.cs
+++ b/Nodify/Helpers/MultiGesture.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Input;
+﻿using System;
+using System.Linq;
+using System.Windows.Input;
 
 namespace Nodify
 {
@@ -101,10 +103,113 @@ namespace Nodify
         public static implicit operator InputGestureRef(MouseGesture gesture)
             => new InputGestureRef { Value = gesture };
 
+        public static implicit operator InputGestureRef(System.Windows.Input.MouseGesture gesture)
+            => new InputGestureRef { Value = gesture };
+
         public static implicit operator InputGestureRef(KeyGesture gesture)
             => new InputGestureRef { Value = gesture };
 
         public static implicit operator InputGestureRef(MultiGesture gesture)
             => new InputGestureRef { Value = gesture };
+    }
+
+    /// <summary>
+    /// Represents a mouse gesture that optionally includes a specific key press as part of the gesture.
+    /// </summary>
+    public sealed class MouseGesture : System.Windows.Input.MouseGesture
+    {
+        /// <summary>
+        /// Gets or sets the key that must be pressed to match this gesture.
+        /// </summary>
+        public Key Key { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MouseGesture"/> class with the specified mouse action, modifier keys, and a specific key.
+        /// </summary>
+        /// <param name="action">The action associated with this gesture.</param>
+        /// <param name="modifiers">The modifiers associated with this gesture.</param>
+        /// <param name="key">The key required to match the gesture.</param>
+        public MouseGesture(MouseAction action, ModifierKeys modifiers, Key key) : base(action, modifiers)
+        {
+            Key = key;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MouseGesture"/> class with the specified mouse action and key.
+        /// </summary>
+        /// <param name="action">The action associated with this gesture.</param>
+        /// <param name="key">The key required to match the gesture.</param>
+        public MouseGesture(MouseAction action, Key key) : base(action)
+        {
+            Key = key;
+        }
+
+        /// <inheritdoc />
+        public MouseGesture(MouseAction action, ModifierKeys modifiers) : base(action, modifiers)
+        {
+        }
+
+        /// <inheritdoc />
+        public MouseGesture(MouseAction action) : base(action)
+        {
+        }
+
+        /// <inheritdoc />
+        public MouseGesture()
+        {
+        }
+
+        /// <inheritdoc />
+        public override bool Matches(object targetElement, InputEventArgs inputEventArgs)
+        {
+            if (inputEventArgs is MouseButtonEventArgs || inputEventArgs is MouseWheelEventArgs)
+            {
+                return base.Matches(targetElement, inputEventArgs) && MatchesKeyboard();
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether the required key is pressed or no keys are pressed when <see cref="Key"/> is <see cref="Key.None"/>.
+        /// </summary>
+        private bool MatchesKeyboard()
+        {
+            if (Key is Key.None)
+            {
+                return !IsAnyKeyPressed();
+            }
+
+            return Keyboard.GetKeyStates(Key).HasFlag(KeyStates.Down);
+        }
+
+        private static readonly Key[] _allKeys = GetValidKeys();
+
+        private static Key[] GetValidKeys()
+        {
+            var excludedKeys = new[]
+            {
+                Key.LeftCtrl, Key.RightCtrl,
+                Key.LeftShift, Key.RightShift,
+                Key.LeftAlt, Key.RightAlt,
+                Key.LWin, Key.RWin,
+                Key.None
+            };
+
+#if NET5_0_OR_GREATER
+            return Enum.GetValues<Key>()
+#else
+            return Enum.GetValues(typeof(Key))
+                .Cast<Key>()
+#endif
+                .Where(key => !excludedKeys.Contains(key))
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Determines whether any key (excluding modifiers) is currently pressed.
+        /// </summary>
+        private static bool IsAnyKeyPressed()
+            => _allKeys.Any(Keyboard.IsKeyDown);
     }
 }


### PR DESCRIPTION
### 📝 Description of the Change

Replaced the usage of `System.Windows.Input.MouseGesture` in the `EditorGestures` with a custom `Nodify.MouseGesture` to support mouse button + key combinations (e.g. `LeftClick + Space`), and fixed the crash when matched against event args other than `MouseButtonEventArgs` and `MouseWheelEventArgs`.

Example usage:
`EditorGestures.Mappings.Editor.Pan.Value = new MouseGesture(MouseAction.LeftClick, Key.Space);`

Related #146

### 🐛 Possible Drawbacks

None that I can think of.
