### PR TITLE
End operation if cancellation is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 >	- Renamed UnselectAllConnection to UnselectAllConnections in NodifyEditor
 >	- Removed DragStarted, DragDelta and DragCompleted routed events from ItemContainer
 >	- Replaced the System.Windows.Input.MouseGesture with Nodify.MouseGesture
+>	- Moved AllowCuttingCancellation from CuttingLine to NodifyEditor
+>	- Moved AllowDraggingCancellation from ItemContainer to NodifyEditor
 > - Features:
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor
 >	- Added UpdateCuttingLine to NodifyEditor

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -220,6 +220,11 @@ namespace Nodify.Playground
                     val => Instance.MouseActionSuppressionThreshold = val,
                     "Context menu suppression threshold: ",
                     "Disable context menu after mouse moved this far"),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.PreserveSelectionOnRightClick,
+                    val => Instance.PreserveSelectionOnRightClick = val,
+                    "Preserve selection on right click: ",
+                    "Whether right-click on the container should preserve the current selection."),
                 new ProxySettingViewModel<double>(
                     () => Instance.AutoPanningTickRate,
                     val => Instance.AutoPanningTickRate = val,
@@ -600,6 +605,12 @@ namespace Nodify.Playground
 
         #region Advanced settings
 
+        public bool PreserveSelectionOnRightClick
+        {
+            get => ItemContainer.PreserveSelectionOnRightClick;
+            set => ItemContainer.PreserveSelectionOnRightClick = value;
+        }
+
         public double MouseActionSuppressionThreshold
         {
             get => NodifyEditor.MouseActionSuppressionThreshold;
@@ -614,8 +625,8 @@ namespace Nodify.Playground
 
         public bool AllowCuttingCancellation
         {
-            get => CuttingLine.AllowCuttingCancellation;
-            set => CuttingLine.AllowCuttingCancellation = value;
+            get => NodifyEditor.AllowCuttingCancellation;
+            set => NodifyEditor.AllowCuttingCancellation = value;
         }
 
         public bool AllowPushItemsCancellation
@@ -638,8 +649,8 @@ namespace Nodify.Playground
 
         public bool AllowDraggingCancellation
         {
-            get => ItemContainer.AllowDraggingCancellation;
-            set => ItemContainer.AllowDraggingCancellation = value;
+            get => NodifyEditor.AllowDraggingCancellation;
+            set => NodifyEditor.AllowDraggingCancellation = value;
         }
 
         public bool AllowPendingConnectionCancellation

--- a/Nodify/Connections/CuttingLine.cs
+++ b/Nodify/Connections/CuttingLine.cs
@@ -21,11 +21,6 @@ namespace Nodify
             => elem.SetValue(IsOverElementProperty, value);
 
         /// <summary>
-        /// Gets or sets whether cancelling a cutting operation is allowed (see <see cref="EditorGestures.NodifyEditorGestures.CancelAction"/>).
-        /// </summary>
-        public static bool AllowCuttingCancellation { get; set; } = true;
-
-        /// <summary>
         /// Gets or sets the start point.
         /// </summary>
         public Point StartPoint

--- a/Nodify/EditorStates/ContainerDraggingState.cs
+++ b/Nodify/EditorStates/ContainerDraggingState.cs
@@ -9,7 +9,7 @@ namespace Nodify
         private Point _initialMousePosition;
         private Point _previousMousePosition;
         
-        private bool Canceled { get; set; } = ItemContainer.AllowDraggingCancellation;
+        private bool Canceled { get; set; } = NodifyEditor.AllowDraggingCancellation;
 
         /// <summary>Constructs an instance of the <see cref="ContainerDraggingState"/> state.</summary>
         /// <param name="container">The owner of the state.</param>
@@ -69,7 +69,7 @@ namespace Nodify
 
                 PopState();
             }
-            else if (ItemContainer.AllowDraggingCancellation && gestures.CancelAction.Matches(e.Source, e))
+            else if (NodifyEditor.AllowDraggingCancellation && gestures.CancelAction.Matches(e.Source, e))
             {
                 Canceled = true;
                 e.Handled = true;
@@ -82,7 +82,7 @@ namespace Nodify
         public override void HandleKeyUp(KeyEventArgs e)
         {
             EditorGestures.ItemContainerGestures gestures = EditorGestures.Mappings.ItemContainer;
-            if (ItemContainer.AllowDraggingCancellation && gestures.CancelAction.Matches(e.Source, e))
+            if (NodifyEditor.AllowDraggingCancellation && gestures.CancelAction.Matches(e.Source, e))
             {
                 Canceled = true;
                 PopState();

--- a/Nodify/EditorStates/EditorCuttingState.cs
+++ b/Nodify/EditorStates/EditorCuttingState.cs
@@ -6,7 +6,7 @@ namespace Nodify
     public class EditorCuttingState : EditorState
     {
         private Point _initialPosition;
-        private bool Canceled { get; set; } = CuttingLine.AllowCuttingCancellation;
+        private bool Canceled { get; set; } = NodifyEditor.AllowCuttingCancellation;
 
         public EditorCuttingState(NodifyEditor editor) : base(editor)
         {
@@ -52,7 +52,7 @@ namespace Nodify
 
                 PopState();
             }
-            else if (CuttingLine.AllowCuttingCancellation && gestures.CancelAction.Matches(e.Source, e))
+            else if (NodifyEditor.AllowCuttingCancellation && gestures.CancelAction.Matches(e.Source, e))
             {
                 Canceled = true;
                 e.Handled = true;   // prevents opening context menu
@@ -69,7 +69,7 @@ namespace Nodify
         public override void HandleKeyUp(KeyEventArgs e)
         {
             EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
-            if (CuttingLine.AllowCuttingCancellation && gestures.CancelAction.Matches(e.Source, e))
+            if (NodifyEditor.AllowCuttingCancellation && gestures.CancelAction.Matches(e.Source, e))
             {
                 Canceled = true;
                 PopState();

--- a/Nodify/ItemContainer.cs
+++ b/Nodify/ItemContainer.cs
@@ -233,11 +233,6 @@ namespace Nodify
         #region Fields
 
         /// <summary>
-        /// Gets or sets whether cancelling a dragging operation is allowed.
-        /// </summary>
-        public static bool AllowDraggingCancellation { get; set; } = true;
-
-        /// <summary>
         /// Indicates whether right-click on the container should preserve the current selection. 
         /// </summary>
         /// <remarks>Has no effect if the container has a context menu.</remarks>

--- a/Nodify/NodifyEditor.Cutting.cs
+++ b/Nodify/NodifyEditor.Cutting.cs
@@ -10,6 +10,8 @@ namespace Nodify
     [StyleTypedProperty(Property = nameof(CuttingLineStyle), StyleTargetType = typeof(CuttingLine))]
     public partial class NodifyEditor
     {
+        #region Dependency properties
+
         protected static readonly DependencyPropertyKey CuttingLineStartPropertyKey = DependencyProperty.RegisterReadOnly(nameof(CuttingLineStart), typeof(Point), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Point));
         public static readonly DependencyProperty CuttingLineStartProperty = CuttingLineStartPropertyKey.DependencyProperty;
 
@@ -95,6 +97,13 @@ namespace Nodify
             set => SetValue(CuttingCompletedCommandProperty, value);
         }
 
+        #endregion
+
+        /// <summary>
+        /// Gets or sets whether cancelling a cutting operation is allowed (see <see cref="EditorGestures.NodifyEditorGestures.CancelAction"/>).
+        /// </summary>
+        public static bool AllowCuttingCancellation { get; set; } = true;
+
         /// <summary>
         /// Gets or sets whether the cutting line should apply the preview style to the interesected elements.
         /// </summary>
@@ -110,6 +119,13 @@ namespace Nodify
 
         private List<FrameworkElement>? _cuttingLinePreviousConnections;
         private readonly LineGeometry _cuttingLineGeometry = new LineGeometry();
+
+        /// <summary>
+        /// Starts the cutting operation at the current <see cref="MouseLocation"/>. Call <see cref="EndCutting"/> to complete the operation or <see cref="CancelCutting"/> to abort it.
+        /// </summary>
+        /// <remarks>This method has no effect if a cutting operation is already in progress.</remarks>
+        public void BeginCutting()
+            => BeginCutting(MouseLocation);
 
         /// <summary>
         /// Starts the cutting operation at the specified location. Call <see cref="EndCutting"/> to complete the operation or <see cref="CancelCutting"/> to abort it.
@@ -161,18 +177,23 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Cancels the current cutting operation without applying any changes.
+        /// Cancels the current cutting operation without applying any changes if <see cref="AllowCuttingCancellation"/> is true.
+        /// Otherwise, it ends the cutting operation by calling <see cref="EndCutting"/>.
         /// </summary>
         /// <remarks>This method has no effect if there's no cutting operation in progress.</remarks>
         public void CancelCutting()
         {
-            if (!CuttingLine.AllowCuttingCancellation || !IsCutting)
+            if (!AllowCuttingCancellation)
             {
+                EndCutting();
                 return;
             }
 
-            ResetConnectionStyle();
-            IsCutting = false;
+            if (IsCutting)
+            {
+                ResetConnectionStyle();
+                IsCutting = false;
+            }
         }
 
         /// <summary>

--- a/Nodify/NodifyEditor.Dragging.cs
+++ b/Nodify/NodifyEditor.Dragging.cs
@@ -7,6 +7,8 @@ namespace Nodify
 {
     public partial class NodifyEditor
     {
+        #region Dependency properties
+
         public static readonly DependencyProperty ItemsDragStartedCommandProperty = DependencyProperty.Register(nameof(ItemsDragStartedCommand), typeof(ICommand), typeof(NodifyEditor));
         public static readonly DependencyProperty ItemsDragCompletedCommandProperty = DependencyProperty.Register(nameof(ItemsDragCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
 
@@ -66,6 +68,13 @@ namespace Nodify
             private set => SetValue(IsDraggingPropertyKey, value);
         }
 
+        #endregion
+
+        /// <summary>
+        /// Gets or sets whether cancelling a dragging operation is allowed.
+        /// </summary>
+        public static bool AllowDraggingCancellation { get; set; } = true;
+
         /// <summary>
         /// Gets or sets if the current position of containers that are being dragged should not be committed until the end of the dragging operation.
         /// </summary>
@@ -77,7 +86,7 @@ namespace Nodify
         /// Initiates the dragging operation using the currently selected <see cref="ItemContainer" />s.
         /// </summary>
         /// <remarks>This method has no effect if a dragging operation is already in progress.</remarks>
-        public void BeginDragging() 
+        public void BeginDragging()
             => BeginDragging(SelectedContainers);
 
         /// <summary>
@@ -87,7 +96,7 @@ namespace Nodify
         /// <remarks>This method has no effect if a dragging operation is already in progress.</remarks>
         public void BeginDragging(IEnumerable<ItemContainer> containers)
         {
-            if(IsDragging)
+            if (IsDragging)
             {
                 return;
             }
@@ -132,18 +141,23 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Cancels the ongoing dragging operation, reverting any changes made to the positions of the dragged items.
+        /// Cancels the ongoing dragging operation, reverting any changes made to the positions of the dragged items if <see cref="AllowDraggingCancellation"/> is true.
+        /// Otherwise, it ends the dragging operation by calling <see cref="EndDragging"/>.
         /// </summary>
         /// <remarks>This method has no effect if there's no dragging operation in progress.</remarks>
         public void CancelDragging()
         {
-            if (!ItemContainer.AllowDraggingCancellation || !IsDragging)
+            if (!AllowDraggingCancellation)
             {
+                EndDragging();
                 return;
             }
 
-            _draggingStrategy!.Abort();
-            IsDragging = false;
+            if (IsDragging)
+            {
+                _draggingStrategy!.Abort();
+                IsDragging = false;
+            }
         }
 
         private IDraggingStrategy CreateDraggingStrategy(IEnumerable<ItemContainer> containers)

--- a/Nodify/NodifyEditor.PushingItems.cs
+++ b/Nodify/NodifyEditor.PushingItems.cs
@@ -58,6 +58,7 @@ namespace Nodify
         /// <summary>
         /// Gets or sets whether push items cancellation is allowed (see <see cref="EditorGestures.NodifyEditorGestures.CancelAction"/>).
         /// </summary>
+        /// <remarks>Has no effect if <see cref="AllowDraggingCancellation"/> is false.</remarks>
         public static bool AllowPushItemsCancellation { get; set; } = true;
 
         private IPushStrategy? _pushStrategy;
@@ -70,7 +71,7 @@ namespace Nodify
         /// <param name="orientation">The orientation of the <see cref="PushedArea"/>.</param>
         public void BeginPushingItems(Point location, Orientation orientation)
         {
-            if(IsPushingItems)
+            if (IsPushingItems)
             {
                 return;
             }
@@ -114,17 +115,22 @@ namespace Nodify
 
         /// <summary>
         /// Cancels the current pushing operation and reverts the <see cref="PushedArea"/> to its initial state if <see cref="AllowPushItemsCancellation"/> is true.
+        /// Otherwise, it ends the pushing operation by calling <see cref="EndPushingItems"/>.
         /// </summary>
         /// <remarks>This method has no effect if there's no pushing operation in progress.</remarks>
         public void CancelPushingItems()
         {
-            if (!AllowPushItemsCancellation || !IsPushingItems)
+            if (!AllowPushItemsCancellation)
             {
+                EndPushingItems();
                 return;
             }
 
-            PushedArea = _pushStrategy!.Cancel();
-            IsPushingItems = false;
+            if (IsPushingItems)
+            {
+                PushedArea = _pushStrategy!.Cancel();
+                IsPushingItems = false;
+            }
         }
 
         private void UpdatePushedArea()

--- a/Nodify/NodifyEditor.Selecting.cs
+++ b/Nodify/NodifyEditor.Selecting.cs
@@ -26,6 +26,8 @@ namespace Nodify
     [StyleTypedProperty(Property = nameof(SelectionRectangleStyle), StyleTargetType = typeof(Rectangle))]
     public partial class NodifyEditor : MultiSelector
     {
+        #region Dependency properties
+
         public static readonly DependencyProperty ItemsSelectStartedCommandProperty = DependencyProperty.Register(nameof(ItemsSelectStartedCommand), typeof(ICommand), typeof(NodifyEditor));
         public static readonly DependencyProperty ItemsSelectCompletedCommandProperty = DependencyProperty.Register(nameof(ItemsSelectCompletedCommand), typeof(ICommand), typeof(NodifyEditor));
 
@@ -175,6 +177,8 @@ namespace Nodify
             get => (Style)GetValue(SelectionRectangleStyleProperty);
             set => SetValue(SelectionRectangleStyleProperty, value);
         }
+
+        #endregion
 
         /// <summary>
         /// Gets a list of <see cref="ItemContainer"/>s that are selected (see <see cref="SelectedContainersCount"/>).
@@ -410,18 +414,23 @@ namespace Nodify
         }
 
         /// <summary>
-        /// Cancels the current selection operation and reverts any changes made during the selection process. 
+        /// Cancels the current selection operation and reverts any changes made during the selection process if <see cref="AllowSelectionCancellation"/> is true.
+        /// Otherwise, it ends the selection operation by calling <see cref="EndSelecting"/>.
         /// </summary>
         /// <remarks>This method has no effect if there's no selection operation in progress.</remarks>
         public void CancelSelecting()
         {
-            if (!IsSelecting)
+            if(!AllowSelectionCancellation)
             {
+                EndSelecting();
                 return;
             }
 
-            ClearPreviewingSelection();
-            IsSelecting = false;
+            if (IsSelecting)
+            {
+                ClearPreviewingSelection();
+                IsSelecting = false;
+            }
         }
 
         #endregion


### PR DESCRIPTION
### 📝 Description of the Change

End operation if cancellation is not supported.

- Moved AllowCuttingCancellation from CuttingLine to NodifyEditor
- Moved AllowDraggingCancellation from ItemContainer to NodifyEditor

### 🐛 Possible Drawbacks

None.