### PR TITLE
Replace selection within the same transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 > - Features:
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor
 >	- Added UpdateCuttingLine to NodifyEditor
->	- Added BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
+>	- Added Select, BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
 >	- Added IsDragging, BeginDragging, UpdateDragging, EndDragging and CancelDragging to NodifyEditor
 >	- Added AlignSelection and AlignContainers methods to NodifyEditor
 >	- Added HasCustomContextMenu dependency property to NodifyEditor and ItemContainer
@@ -29,7 +29,8 @@
 >	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured
 >	- Fixed an issue where the Home button caused the editor to fail to display items when contained within a ScrollViewer
 >	- Fixed an issue where connector optimization did not work when SelectedItems was not data-bound
->	- Fixed an issue where EditorCommands.Align caused multiple arrange invalidations, one for each aligned container
+>	- Fixed EditorCommands.Align to perform a single arrange invalidation instead of one for each aligned container
+>	- Fixed ItemContainer.Select and NodifyEditor.SelectArea to clear the existing selection and select the containers within the same transaction
 	
 #### **Version 6.6.0**
 

--- a/Examples/Nodify.Shapes/Canvas/CanvasView.xaml
+++ b/Examples/Nodify.Shapes/Canvas/CanvasView.xaml
@@ -44,9 +44,8 @@
                              ConnectionCompletedCommand="{Binding CreateConnectionCommand}"
                              ItemsDragStartedCommand="{Binding MoveShapesStartedCommand}"
                              ItemsDragCompletedCommand="{Binding MoveShapesCompletedCommand}"
-                             ItemsSelectStartedCommand="{Binding SelectShapesStartedCommand}"
-                             ItemsSelectCompletedCommand="{Binding SelectShapesCompletedCommand}"
                              RemoveConnectionCommand="{Binding RemoveConnectionCommand}"
+                             SelectionChanged="Editor_SelectionChanged"
                              MouseDown="Editor_MouseDown"
                              MouseMove="Editor_MouseMove"
                              MouseUp="Editor_MouseUp"
@@ -248,8 +247,6 @@
                     </Style.Resources>
                     <Setter Property="Location"
                             Value="{Binding Location}" />
-                    <Setter Property="IsSelected"
-                            Value="{Binding IsSelected}" />
                     <Setter Property="SelectedBrush"
                             Value="{Binding BorderColor, Converter={StaticResource ColorToSolidColorBrushConverter}}" />
                     <Setter Property="SelectedBorderThickness"

--- a/Examples/Nodify.Shapes/Canvas/CanvasView.xaml.cs
+++ b/Examples/Nodify.Shapes/Canvas/CanvasView.xaml.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Nodify.Shapes.Canvas.UndoRedo;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -102,6 +104,23 @@ namespace Nodify.Shapes.Canvas
         private void Minimap_Zoom(object sender, ZoomEventArgs e)
         {
             Editor.ZoomAtPosition(e.Zoom, e.Location);
+        }
+
+        private void Editor_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var canvasVM = (CanvasViewModel)DataContext;
+            var selectedNodes = e.AddedItems.Cast<ShapeViewModel>().ToList();
+            var deselectedNodes = e.RemovedItems.Cast<ShapeViewModel>().ToList();
+
+            string batchLabel = selectedNodes.Count > 0 ? "Select shapes" : "Deselect shapes";
+            using (canvasVM.UndoRedo.Batch(batchLabel))
+            {
+                var selectNodes = new SelectShapesAction(selectedNodes, canvasVM);
+                var deselectNodes = new DeselectShapesAction(deselectedNodes, canvasVM);
+
+                canvasVM.UndoRedo.Record(deselectNodes);
+                canvasVM.UndoRedo.Record(selectNodes);
+            }
         }
     }
 }

--- a/Examples/Nodify.Shapes/Canvas/CanvasViewModel.cs
+++ b/Examples/Nodify.Shapes/Canvas/CanvasViewModel.cs
@@ -22,8 +22,6 @@ namespace Nodify.Shapes.Canvas
 
         public ICommand MoveShapesStartedCommand { get; }
         public ICommand MoveShapesCompletedCommand { get; }
-        public ICommand SelectShapesStartedCommand { get; }
-        public ICommand SelectShapesCompletedCommand { get; }
         public ICommand ResizeShapeStartedCommand { get; }
         public ICommand ResizeShapeCompletedCommand { get; }
         public ICommand CreateConnectionCommand { get; }
@@ -47,9 +45,6 @@ namespace Nodify.Shapes.Canvas
 
             MoveShapesStartedCommand = new DelegateCommand(MoveShapesStartedHandler);
             MoveShapesCompletedCommand = new DelegateCommand(MoveShapesCompletedHandler);
-
-            SelectShapesStartedCommand = new DelegateCommand(SelectShapesStartedHandler);
-            SelectShapesCompletedCommand = new DelegateCommand(SelectShapesCompletedHandler);
 
             ResizeShapeStartedCommand = new DelegateCommand(ResizeShapeStartedHandler);
             ResizeShapeCompletedCommand = new DelegateCommand(ResizeShapeCompletedHandler);
@@ -91,23 +86,6 @@ namespace Nodify.Shapes.Canvas
             }
 
             ShapeToolbar.Show();
-        }
-
-        // TODO: This does not fire for single selection (ItemContainer click), therefore I added IsSelected to ShapeViewModel.
-        private void SelectShapesStartedHandler()
-        {
-            // The workaround is to record all IsSelected changes into one history item using History.Pause and History.Resume
-            UndoRedo.Pause("Select shapes");
-            //UndoRedo.ExecuteAction(new SelectShapesAction(this));
-        }
-
-        private void SelectShapesCompletedHandler()
-        {
-            UndoRedo.Resume();
-            //if (UndoRedo.Current is SelectShapesAction selectShapes)
-            //{
-            //    selectShapes.SaveSelection();
-            //}
         }
 
         private void ResizeShapeStartedHandler()

--- a/Examples/Nodify.Shapes/Canvas/Shapes/ShapeViewModel.cs
+++ b/Examples/Nodify.Shapes/Canvas/Shapes/ShapeViewModel.cs
@@ -9,7 +9,6 @@ namespace Nodify.Shapes.Canvas
     {
         public ShapeViewModel(IActionsHistory history) : base(history)
         {
-            RecordProperty<ShapeViewModel>(x => x.IsSelected);
             RecordProperty<ShapeViewModel>(x => x.Color);
             RecordProperty<ShapeViewModel>(x => x.Text);
         }
@@ -63,13 +62,6 @@ namespace Nodify.Shapes.Canvas
         {
             get => _text;
             set => SetProperty(ref _text, value);
-        }
-
-        private bool _isSelected;
-        public bool IsSelected
-        {
-            get => _isSelected;
-            set => SetProperty(ref _isSelected, value);
         }
 
         public ConnectorViewModel LeftConnector { get; } = new ConnectorViewModel(ConnectorPosition.Left);

--- a/Examples/Nodify.Shapes/Canvas/UndoRedo/SelectShapesAction.cs
+++ b/Examples/Nodify.Shapes/Canvas/UndoRedo/SelectShapesAction.cs
@@ -1,41 +1,59 @@
 ﻿using Nodify.UndoRedo;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Nodify.Shapes.Canvas.UndoRedo
 {
     public class SelectShapesAction : IAction
     {
-        private readonly CanvasViewModel _canvas;
-        private readonly List<ShapeViewModel> _initialSelection;
-        private List<ShapeViewModel>? _finalSelection;
-
-        public SelectShapesAction(CanvasViewModel canvas)
-        {
-            _canvas = canvas;
-            _initialSelection = _canvas.SelectedShapes.ToList();
-        }
-
         public string? Label => "Select shapes";
+
+        private readonly IReadOnlyCollection<ShapeViewModel> _nodes;
+        private readonly CanvasViewModel _canvas;
+
+        public SelectShapesAction(IReadOnlyCollection<ShapeViewModel> nodes, CanvasViewModel canvas)
+        {
+            _nodes = nodes;
+            _canvas = canvas;
+        }
 
         public void Execute()
         {
-            if (_finalSelection != null)
-            {
-                _canvas.SelectedShapes.Clear();
-                _canvas.SelectedShapes.AddRange(_finalSelection);
-            }
+            _canvas.SelectedShapes.AddRange(_nodes);
         }
 
         public void Undo()
         {
-            _canvas.SelectedShapes.Clear();
-            _canvas.SelectedShapes.AddRange(_initialSelection);
+            _canvas.SelectedShapes.RemoveRange(_nodes);
         }
 
-        public void SaveSelection()
+        public override string? ToString()
+            => Label;
+    }
+
+    public class DeselectShapesAction : IAction
+    {
+        public string? Label => "Deselect shapes";
+
+        private readonly IReadOnlyCollection<ShapeViewModel> _nodes;
+        private readonly CanvasViewModel _canvas;
+
+        public DeselectShapesAction(IReadOnlyCollection<ShapeViewModel> nodes, CanvasViewModel canvas)
         {
-            _finalSelection = _canvas.SelectedShapes.ToList();
+            _nodes = nodes;
+            _canvas = canvas;
         }
+
+        public void Execute()
+        {
+            _canvas.SelectedShapes.RemoveRange(_nodes);
+        }
+
+        public void Undo()
+        {
+            _canvas.SelectedShapes.AddRange(_nodes);
+        }
+
+        public override string? ToString()
+            => Label;
     }
 }

--- a/Nodify/ItemContainer.cs
+++ b/Nodify/ItemContainer.cs
@@ -364,8 +364,7 @@ namespace Nodify
                     IsSelected = !IsSelected;
                     break;
                 case SelectionType.Replace:
-                    Editor.UnselectAll();
-                    IsSelected = true;
+                    Editor.Select(this);
                 break;
             }
         }

--- a/Nodify/NodifyEditor.Selecting.cs
+++ b/Nodify/NodifyEditor.Selecting.cs
@@ -76,14 +76,14 @@ namespace Nodify
                 ItemsSelectStartedCommand.Execute(DataContext);
         }
 
-        /// <summary>Invoked when a selection operation is started.</summary>
+        /// <summary>Invoked when a selection operation is started (see <see cref="BeginSelecting(SelectionType)"/>).</summary>
         public ICommand? ItemsSelectStartedCommand
         {
             get => (ICommand?)GetValue(ItemsSelectStartedCommandProperty);
             set => SetValue(ItemsSelectStartedCommandProperty, value);
         }
 
-        /// <summary>Invoked when a selection operation is completed.</summary>
+        /// <summary>Invoked when a selection operation is completed (see <see cref="EndSelecting"/>).</summary>
         public ICommand? ItemsSelectCompletedCommand
         {
             get => (ICommand?)GetValue(ItemsSelectCompletedCommandProperty);
@@ -216,42 +216,6 @@ namespace Nodify
 
         #region Selection
 
-        internal void ApplyPreviewingSelection()
-        {
-            Debug.Assert(IsSelecting);
-
-            ItemCollection items = Items;
-            IList selected = base.SelectedItems;
-
-            BeginUpdateSelectedItems();
-            for (var i = 0; i < items.Count; i++)
-            {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
-                if (container.IsPreviewingSelection == true && container.IsSelectable)
-                {
-                    selected.Add(items[i]);
-                }
-                else if (container.IsPreviewingSelection == false)
-                {
-                    selected.Remove(items[i]);
-                }
-                container.IsPreviewingSelection = null;
-            }
-            EndUpdateSelectedItems();
-        }
-
-        internal void ClearPreviewingSelection()
-        {
-            Debug.Assert(IsSelecting);
-
-            ItemCollection items = Items;
-            for (var i = 0; i < items.Count; i++)
-            {
-                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
-                container.IsPreviewingSelection = null;
-            }
-        }
-
         /// <summary>
         /// Inverts the <see cref="ItemContainer"/>s selection in the specified <paramref name="area"/>.
         /// </summary>
@@ -293,16 +257,16 @@ namespace Nodify
         /// <param name="fit">True to check if the <paramref name="area"/> contains the <see cref="ItemContainer"/>. <br />False to check if <paramref name="area"/> intersects the <see cref="ItemContainer"/>.</param>
         public void SelectArea(Rect area, bool append = false, bool fit = false)
         {
+            IsSelecting = true;
+            BeginUpdateSelectedItems();
+
+            IList selected = base.SelectedItems;
             if (!append)
             {
-                UnselectAll();
+                selected.Clear();
             }
 
             ItemCollection items = Items;
-            IList selected = base.SelectedItems;
-
-            IsSelecting = true;
-            BeginUpdateSelectedItems();
             for (var i = 0; i < items.Count; i++)
             {
                 var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
@@ -311,8 +275,22 @@ namespace Nodify
                     selected.Add(items[i]);
                 }
             }
+
             EndUpdateSelectedItems();
             IsSelecting = false;
+        }
+
+        /// <summary>
+        /// Clears the current selection and selects the specified <see cref="ItemContainer"/> within the same selection transaction.
+        /// </summary>
+        /// <param name="container"></param>
+        public void Select(ItemContainer container)
+        {
+            BeginUpdateSelectedItems();
+            var selected = base.SelectedItems;
+            selected.Clear();
+            selected.Add(container.DataContext);
+            EndUpdateSelectedItems();
         }
 
         /// <summary>
@@ -359,6 +337,7 @@ namespace Nodify
                 selector.SelectAll();
             }
         }
+
         /// <summary>
         /// Initiates a selection operation from the specified location.
         /// </summary>
@@ -420,7 +399,7 @@ namespace Nodify
         /// <remarks>This method has no effect if there's no selection operation in progress.</remarks>
         public void CancelSelecting()
         {
-            if(!AllowSelectionCancellation)
+            if (!AllowSelectionCancellation)
             {
                 EndSelecting();
                 return;
@@ -430,6 +409,38 @@ namespace Nodify
             {
                 ClearPreviewingSelection();
                 IsSelecting = false;
+            }
+        }
+
+        private void ApplyPreviewingSelection()
+        {
+            ItemCollection items = Items;
+            IList selected = base.SelectedItems;
+
+            BeginUpdateSelectedItems();
+            for (var i = 0; i < items.Count; i++)
+            {
+                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                if (container.IsPreviewingSelection == true && container.IsSelectable)
+                {
+                    selected.Add(items[i]);
+                }
+                else if (container.IsPreviewingSelection == false)
+                {
+                    selected.Remove(items[i]);
+                }
+                container.IsPreviewingSelection = null;
+            }
+            EndUpdateSelectedItems();
+        }
+
+        private void ClearPreviewingSelection()
+        {
+            ItemCollection items = Items;
+            for (var i = 0; i < items.Count; i++)
+            {
+                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                container.IsPreviewingSelection = null;
             }
         }
 


### PR DESCRIPTION
### 📝 Description of the Change

Fixed `ItemContainer.Select` and `NodifyEditor.SelectArea` to clear the existing selection and select the containers within the same transaction.

New NodifyEditor methods:
- `Select`

Updated the Shapes application to use the `SelectionChanged` event, demonstrating a more robust approach to recording selection changes for undo-redo functionality.

![demonstration](https://github.com/user-attachments/assets/f3cd3770-b4b1-4054-9fe6-91c0d7b96818)

### 🐛 Possible Drawbacks

None.
