### PR TITLE
Add the possibility to register global input handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 >	- Added InputProcessor to NodifyEditor, ItemContainer and Connector, enabling the extension of controls with custom states
 >	- Added DragState to simplify creating click-and-drag operations, with support for initiating and completing them using the keyboard
 >	- Added InputElementStateStack to manage transitions between states in UI elements
+>	- Added InputProcessor.Shared to enable the addition of global input handlers
 >	- Move the viewport to the mouse position when zooming on the Minimap if ResizeToViewport is false
 > - Bugfixes:
 >	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured

--- a/Nodify/Connectors/Connector.cs
+++ b/Nodify/Connectors/Connector.cs
@@ -172,13 +172,13 @@ namespace Nodify
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(Connector), new FrameworkPropertyMetadata(typeof(Connector)));
             FocusableProperty.OverrideMetadata(typeof(Connector), new FrameworkPropertyMetadata(BoxValue.True));
+
+            ConnectorState.RegisterDefaultHandlers();
         }
 
         public Connector()
         {
-            InputProcessor.AddHandler(new ConnectorState.Disconnect(this));
-            InputProcessor.AddHandler(new ConnectorState.Connecting(this));
-            InputProcessor.AddHandler(new ConnectorState.Default(this));
+            InputProcessor.AddHandler(new InputProcessor.Shared<Connector>(this));
         }
 
         /// <inheritdoc />

--- a/Nodify/Connectors/Connector.cs
+++ b/Nodify/Connectors/Connector.cs
@@ -176,7 +176,7 @@ namespace Nodify
 
         public Connector()
         {
-            InputProcessor.AddHandler(new InputProcessor.Shared<Connector>(this));
+            InputProcessor.AddSharedHandlers(this);
         }
 
         /// <inheritdoc />

--- a/Nodify/Connectors/Connector.cs
+++ b/Nodify/Connectors/Connector.cs
@@ -172,8 +172,6 @@ namespace Nodify
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(Connector), new FrameworkPropertyMetadata(typeof(Connector)));
             FocusableProperty.OverrideMetadata(typeof(Connector), new FrameworkPropertyMetadata(BoxValue.True));
-
-            ConnectorState.RegisterDefaultHandlers();
         }
 
         public Connector()

--- a/Nodify/Connectors/States/ConnectorState.cs
+++ b/Nodify/Connectors/States/ConnectorState.cs
@@ -2,7 +2,7 @@
 {
     public static partial class ConnectorState
     {
-        public static void RegisterDefaultHandlers()
+        internal static void RegisterDefaultHandlers()
         {
             InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new Disconnect(elem));
             InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new Connecting(elem));

--- a/Nodify/Connectors/States/ConnectorState.cs
+++ b/Nodify/Connectors/States/ConnectorState.cs
@@ -1,0 +1,12 @@
+﻿namespace Nodify.Interactivity
+{
+    public static partial class ConnectorState
+    {
+        public static void RegisterDefaultHandlers()
+        {
+            InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new Disconnect(elem));
+            InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new Connecting(elem));
+            InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new Default(elem));
+        }
+    }
+}

--- a/Nodify/Containers/ItemContainer.cs
+++ b/Nodify/Containers/ItemContainer.cs
@@ -273,8 +273,6 @@ namespace Nodify
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(ItemContainer), new FrameworkPropertyMetadata(typeof(ItemContainer)));
             FocusableProperty.OverrideMetadata(typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.True));
-
-            ContainerState.RegisterDefaultHandlers();
         }
 
         /// <summary>

--- a/Nodify/Containers/ItemContainer.cs
+++ b/Nodify/Containers/ItemContainer.cs
@@ -273,6 +273,8 @@ namespace Nodify
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(ItemContainer), new FrameworkPropertyMetadata(typeof(ItemContainer)));
             FocusableProperty.OverrideMetadata(typeof(ItemContainer), new FrameworkPropertyMetadata(BoxValue.True));
+
+            ContainerState.RegisterDefaultHandlers();
         }
 
         /// <summary>
@@ -283,7 +285,7 @@ namespace Nodify
         {
             Editor = editor;
 
-            InputProcessor.AddHandler(new ContainerState.Default(this));
+            InputProcessor.AddHandler(new InputProcessor.Shared<ItemContainer>(this));
         }
 
         /// <inheritdoc />
@@ -359,7 +361,7 @@ namespace Nodify
                     break;
                 case SelectionType.Replace:
                     Editor.Select(this);
-                break;
+                    break;
             }
         }
 

--- a/Nodify/Containers/ItemContainer.cs
+++ b/Nodify/Containers/ItemContainer.cs
@@ -283,7 +283,7 @@ namespace Nodify
         {
             Editor = editor;
 
-            InputProcessor.AddHandler(new InputProcessor.Shared<ItemContainer>(this));
+            InputProcessor.AddSharedHandlers(this);
         }
 
         /// <inheritdoc />

--- a/Nodify/Containers/States/ContainerState.cs
+++ b/Nodify/Containers/States/ContainerState.cs
@@ -2,7 +2,7 @@
 {
     public static partial class ContainerState
     {
-        public static void RegisterDefaultHandlers()
+        internal static void RegisterDefaultHandlers()
         {
             InputProcessor.Shared<ItemContainer>.RegisterHandlerFactory(elem => new Default(elem));
         }

--- a/Nodify/Containers/States/ContainerState.cs
+++ b/Nodify/Containers/States/ContainerState.cs
@@ -1,0 +1,10 @@
+﻿namespace Nodify.Interactivity
+{
+    public static partial class ContainerState
+    {
+        public static void RegisterDefaultHandlers()
+        {
+            InputProcessor.Shared<ItemContainer>.RegisterHandlerFactory(elem => new Default(elem));
+        }
+    }
+}

--- a/Nodify/Editor/EditorCommands.cs
+++ b/Nodify/Editor/EditorCommands.cs
@@ -51,14 +51,14 @@ namespace Nodify
         /// </summary>
         public static RoutedUICommand Align { get; } = new RoutedUICommand("Align", nameof(Align), typeof(EditorCommands));
 
-        internal static void Register(Type type)
+        internal static void RegisterCommandBindings<T>()
         {
-            CommandManager.RegisterClassCommandBinding(type, new CommandBinding(ZoomIn, OnZoomIn, OnQueryStatusZoomIn));
-            CommandManager.RegisterClassCommandBinding(type, new CommandBinding(ZoomOut, OnZoomOut, OnQueryStatusZoomOut));
-            CommandManager.RegisterClassCommandBinding(type, new CommandBinding(SelectAll, OnSelectAll, OnQuerySelectAllStatus));
-            CommandManager.RegisterClassCommandBinding(type, new CommandBinding(BringIntoView, OnBringIntoView, OnQueryBringIntoViewStatus));
-            CommandManager.RegisterClassCommandBinding(type, new CommandBinding(FitToScreen, OnFitToScreen, OnQueryFitToScreenStatus));
-            CommandManager.RegisterClassCommandBinding(type, new CommandBinding(Align, OnAlign, OnQueryAlignStatus));
+            CommandManager.RegisterClassCommandBinding(typeof(T), new CommandBinding(ZoomIn, OnZoomIn, OnQueryStatusZoomIn));
+            CommandManager.RegisterClassCommandBinding(typeof(T), new CommandBinding(ZoomOut, OnZoomOut, OnQueryStatusZoomOut));
+            CommandManager.RegisterClassCommandBinding(typeof(T), new CommandBinding(SelectAll, OnSelectAll, OnQuerySelectAllStatus));
+            CommandManager.RegisterClassCommandBinding(typeof(T), new CommandBinding(BringIntoView, OnBringIntoView, OnQueryBringIntoViewStatus));
+            CommandManager.RegisterClassCommandBinding(typeof(T), new CommandBinding(FitToScreen, OnFitToScreen, OnQueryFitToScreenStatus));
+            CommandManager.RegisterClassCommandBinding(typeof(T), new CommandBinding(Align, OnAlign, OnQueryAlignStatus));
         }
 
         private static void OnQueryAlignStatus(object sender, CanExecuteRoutedEventArgs e)

--- a/Nodify/Editor/NodifyEditor.cs
+++ b/Nodify/Editor/NodifyEditor.cs
@@ -572,7 +572,7 @@ namespace Nodify
 
             SetValue(ViewportTransformPropertyKey, transform);
 
-            InputProcessor.AddHandler(new InputProcessor.Shared<NodifyEditor>(this));
+            InputProcessor.AddSharedHandlers(this);
         }
 
         /// <inheritdoc />

--- a/Nodify/Editor/NodifyEditor.cs
+++ b/Nodify/Editor/NodifyEditor.cs
@@ -553,7 +553,6 @@ namespace Nodify
             FocusableProperty.OverrideMetadata(typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.True));
 
             EditorCommands.RegisterCommandBindings<NodifyEditor>();
-            EditorState.RegisterDefaultHandlers();
         }
 
         /// <summary>

--- a/Nodify/Editor/NodifyEditor.cs
+++ b/Nodify/Editor/NodifyEditor.cs
@@ -552,7 +552,8 @@ namespace Nodify
             DefaultStyleKeyProperty.OverrideMetadata(typeof(NodifyEditor), new FrameworkPropertyMetadata(typeof(NodifyEditor)));
             FocusableProperty.OverrideMetadata(typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.True));
 
-            EditorCommands.Register(typeof(NodifyEditor));
+            EditorCommands.RegisterCommandBindings<NodifyEditor>();
+            EditorState.RegisterDefaultHandlers();
         }
 
         /// <summary>
@@ -572,12 +573,7 @@ namespace Nodify
 
             SetValue(ViewportTransformPropertyKey, transform);
 
-            InputProcessor.AddHandler(new EditorState.Panning(this));
-            InputProcessor.AddHandler(new EditorState.PanningWithMouseWheel(this));
-            InputProcessor.AddHandler(new EditorState.Selecting(this));
-            InputProcessor.AddHandler(new EditorState.Zooming(this));
-            InputProcessor.AddHandler(new EditorState.PushingItems(this));
-            InputProcessor.AddHandler(new EditorState.Cutting(this));
+            InputProcessor.AddHandler(new InputProcessor.Shared<NodifyEditor>(this));
         }
 
         /// <inheritdoc />

--- a/Nodify/Editor/States/Cutting.cs
+++ b/Nodify/Editor/States/Cutting.cs
@@ -2,7 +2,7 @@
 
 namespace Nodify.Interactivity
 {
-    public partial class EditorState
+    public static partial class EditorState
     {
         /// <summary>
         /// Represents the cutting state in the <see cref="NodifyEditor"/>, allowing users to cut connections between elements using a drag gesture.

--- a/Nodify/Editor/States/EditorState.cs
+++ b/Nodify/Editor/States/EditorState.cs
@@ -1,0 +1,15 @@
+﻿namespace Nodify.Interactivity
+{
+    public static partial class EditorState
+    {
+        public static void RegisterDefaultHandlers()
+        {
+            InputProcessor.Shared<NodifyEditor>.RegisterHandlerFactory(elem => new Panning(elem));
+            InputProcessor.Shared<NodifyEditor>.RegisterHandlerFactory(elem => new PanningWithMouseWheel(elem));
+            InputProcessor.Shared<NodifyEditor>.RegisterHandlerFactory(elem => new Selecting(elem));
+            InputProcessor.Shared<NodifyEditor>.RegisterHandlerFactory(elem => new Zooming(elem));
+            InputProcessor.Shared<NodifyEditor>.RegisterHandlerFactory(elem => new PushingItems(elem));
+            InputProcessor.Shared<NodifyEditor>.RegisterHandlerFactory(elem => new Cutting(elem));
+        }
+    }
+}

--- a/Nodify/Editor/States/EditorState.cs
+++ b/Nodify/Editor/States/EditorState.cs
@@ -2,7 +2,7 @@
 {
     public static partial class EditorState
     {
-        public static void RegisterDefaultHandlers()
+        internal static void RegisterDefaultHandlers()
         {
             InputProcessor.Shared<NodifyEditor>.RegisterHandlerFactory(elem => new Panning(elem));
             InputProcessor.Shared<NodifyEditor>.RegisterHandlerFactory(elem => new PanningWithMouseWheel(elem));

--- a/Nodify/Editor/States/PushingItems.cs
+++ b/Nodify/Editor/States/PushingItems.cs
@@ -5,7 +5,7 @@ using System.Windows.Input;
 
 namespace Nodify.Interactivity
 {
-    public partial class EditorState
+    public static partial class EditorState
     {
         /// <summary>
         /// Represents the state of the <see cref="NodifyEditor"/> during a "push items" operation, allowing users to move items within the editor by dragging.

--- a/Nodify/Editor/States/Selecting.cs
+++ b/Nodify/Editor/States/Selecting.cs
@@ -2,7 +2,7 @@
 
 namespace Nodify.Interactivity
 {
-    public partial class EditorState
+    public static partial class EditorState
     {
         /// <summary>
         /// Represents the selecting state of the <see cref="NodifyEditor"/>.

--- a/Nodify/Editor/States/Zooming.cs
+++ b/Nodify/Editor/States/Zooming.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 
 namespace Nodify.Interactivity
 {
-    public partial class EditorState
+    public static partial class EditorState
     {
         /// <summary>
         /// Represents the zooming state of the <see cref="NodifyEditor"/>.

--- a/Nodify/Interactivity/InputProcessor.Shared.cs
+++ b/Nodify/Interactivity/InputProcessor.Shared.cs
@@ -79,10 +79,10 @@ namespace Nodify.Interactivity
             }
 
             /// <summary>
-            /// Removes all registered factory methods for creating input handlers of the specified type.
+            /// Removes the registered factory method for creating input handlers of the specified type.
             /// </summary>
             /// <typeparam name="THandler">The type of the input handler to remove.</typeparam>
-            public static void RemoveHandlerFactories<THandler>()
+            public static void RemoveHandlerFactory<THandler>()
                 => _handlerFactories.RemoveAll(x => x.Key == typeof(THandler));
 
             /// <summary>

--- a/Nodify/Interactivity/InputProcessor.Shared.cs
+++ b/Nodify/Interactivity/InputProcessor.Shared.cs
@@ -92,4 +92,22 @@ namespace Nodify.Interactivity
                 => _handlerFactories.Clear();
         }
     }
+
+    /// <summary>
+    /// Provides extension methods for the <see cref="InputProcessor"/> class.
+    /// </summary>
+    public static class InputProcessorExtensions
+    {
+        /// <summary>
+        /// Adds shared input handlers for the specified UI element instance to the input processor.
+        /// </summary>
+        /// <typeparam name="TElement">The type of the UI element for which shared input handlers are being added.</typeparam>
+        /// <param name="inputProcessor">The input processor to which the shared handlers will be added.</param>
+        /// <param name="instance">The UI element instance associated with the shared handlers.</param>
+        public static void AddSharedHandlers<TElement>(this InputProcessor inputProcessor, TElement instance)
+            where TElement : FrameworkElement
+        {
+            inputProcessor.AddHandler(new InputProcessor.Shared<TElement>(instance));
+        }
+    }
 }

--- a/Nodify/Interactivity/InputProcessor.Shared.cs
+++ b/Nodify/Interactivity/InputProcessor.Shared.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Input;
+
+namespace Nodify.Interactivity
+{
+    public sealed partial class InputProcessor
+    {
+        /// <summary>
+        /// A shared input processor that allows registering and managing global input handlers for a specific type of UI element.
+        /// </summary>
+        /// <typeparam name="TElement">The type of the UI element that the input handlers will be associated with.</typeparam>
+        public sealed class Shared<TElement> : IInputHandler
+            where TElement : FrameworkElement
+        {
+            private static readonly Dictionary<Type, Func<TElement, IInputHandler>> _handlerFactories = new Dictionary<Type, Func<TElement, IInputHandler>>();
+
+            private readonly List<IInputHandler> _handlers = new List<IInputHandler>();
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Shared{TElement}"/> class for the specified UI element.
+            /// </summary>
+            /// <param name="element">The UI element that the shared input handlers will be associated with.</param>
+            public Shared(TElement element)
+            {
+                foreach (var factory in _handlerFactories.Values)
+                {
+                    _handlers.Add(factory(element));
+                }
+            }
+
+            public void HandleEvent(InputEventArgs e)
+            {
+                foreach (var handler in _handlers)
+                {
+                    handler.HandleEvent(e);
+                }
+            }
+
+            /// <summary>
+            /// Registers a factory method for creating an input handler of the specified type.
+            /// </summary>
+            /// <typeparam name="THandler">The type of the input handler to register.</typeparam>
+            /// <param name="factory">A factory method that creates an instance of the input handler for a given UI element.</param>
+            /// <exception cref="InvalidOperationException">
+            /// Thrown if an input handler of the specified type is already registered.
+            /// </exception>
+            public static void RegisterHandlerFactory<THandler>(Func<TElement, THandler> factory)
+                where THandler : IInputHandler
+            {
+                if (_handlerFactories.ContainsKey(typeof(THandler)))
+                {
+                    throw new InvalidOperationException($"An input handler of type '{typeof(THandler)}' has already been registered.");
+                }
+
+                _handlerFactories[typeof(THandler)] = elem => factory(elem);
+            }
+
+            /// <summary>
+            /// Removes the registered factory method for creating input handlers of the specified type.
+            /// </summary>
+            /// <typeparam name="THandler">The type of the input handler to remove.</typeparam>
+            public static void RemoveHandlerFactory<THandler>()
+                => _handlerFactories.Remove(typeof(THandler));
+
+            /// <summary>
+            /// Clears all registered handler factories, effectively removing all shared input handlers.
+            /// </summary>
+            public static void ClearHandlerFactory()
+                => _handlerFactories.Clear();
+        }
+    }
+}

--- a/Nodify/Interactivity/InputProcessor.Shared.cs
+++ b/Nodify/Interactivity/InputProcessor.Shared.cs
@@ -31,6 +31,26 @@ namespace Nodify.Interactivity
                 }
             }
 
+            /// <summary>
+            /// Initializes static members of the <see cref="Shared{TElement}"/> class.
+            /// Ensures default handlers are registered before methods on this class can be used.
+            /// </summary>
+            static Shared()
+            {
+                if (typeof(TElement) == typeof(NodifyEditor))
+                {
+                    EditorState.RegisterDefaultHandlers();
+                }
+                else if (typeof(TElement) == typeof(ItemContainer))
+                {
+                    ContainerState.RegisterDefaultHandlers();
+                }
+                else if (typeof(TElement) == typeof(Connector))
+                {
+                    ConnectorState.RegisterDefaultHandlers();
+                }
+            }
+
             public void HandleEvent(InputEventArgs e)
             {
                 foreach (var handler in _handlers)
@@ -68,7 +88,7 @@ namespace Nodify.Interactivity
             /// <summary>
             /// Clears all registered handler factories, effectively removing all shared input handlers.
             /// </summary>
-            public static void ClearHandlerFactory()
+            public static void ClearHandlerFactories()
                 => _handlerFactories.Clear();
         }
     }

--- a/Nodify/Interactivity/InputProcessor.cs
+++ b/Nodify/Interactivity/InputProcessor.cs
@@ -6,7 +6,7 @@ namespace Nodify.Interactivity
     /// <summary>
     /// Processes input events and delegates them to registered handlers.
     /// </summary>
-    public sealed class InputProcessor
+    public sealed partial class InputProcessor
     {
         private readonly HashSet<IInputHandler> _handlers = new HashSet<IInputHandler>();
 


### PR DESCRIPTION
### 📝 Description of the Change

Adds the possibility to register global input handlers via `InputProcessor.Shared<T>`. Once the desired input handlers are registered, an instance of the shared handler must be added to the `InputProcessor` instance of a UI element.

Example:

```csharp
static MainWindow()
{
    // register a handler factory in a static context
    InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new ConnectorState.Connecting(elem));

    // removes the handler factory for the specified handler type
    InputProcessor.Shared<Connector>.RemoveHandlerFactory<ConnectorState.Connecting>();
}

public Connector()
{
    // use shared handlers for this connector
    InputProcessor.AddSharedHandlers(this);
}
```

The handlers are only constructed once per element, when creating an instance of the shared class (e.g. `new InputProcessor.Shared<Connector>(this)` or using the `InputProcessor.AddSharedHandlers` extension method). 

> [!IMPORTANT] 
> Calling `InputProcessor.Shared.RegisterHandlerFactory` will not add new handlers to existing shared instances.

Methods:
- `RegisterHandlerFactory`
- `RemoveHandlerFactory`
- `ClearHandlerFactories`

Related #146

### 🐛 Possible Drawbacks

None.
