### PR TITLE
Added panning methods to Minimap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 >	- Moved EditorGestures under the Nodify.Interactivity namespace
 > - Features:
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor and Minimap
->	- Added AllowPanningCancellation, MouseLocation, ZoomAtPosition and GetLocationInsideMinimap to Minimap
+>	- Added MouseLocation, ZoomAtPosition and GetLocationInsideMinimap to Minimap
 >	- Added UpdateCuttingLine to NodifyEditor
 >	- Added Select, BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
 >	- Added IsDragging, BeginDragging, UpdateDragging, EndDragging and CancelDragging to NodifyEditor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > - Breaking Changes:
 >	- Made the setter of NodifyEditor.IsPanning private
 >	- Made SelectionHelper internal
+>	- Made Minimap sealed
 >	- Renamed HandleRightClickAfterPanningThreshold to MouseActionSuppressionThreshold in NodifyEditor
 >	- Renamed StartCutting to BeginCutting in NodifyEditor
 >	- Renamed PushItems to UpdatePushedArea and StartPushingItems to BeginPushingItems in NodifyEditor
@@ -17,7 +18,8 @@
 >	- Moved AllowDraggingCancellation from ItemContainer to NodifyEditor
 >	- Moved EditorGestures under the Nodify.Interactivity namespace
 > - Features:
->	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor
+>	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor and Minimap
+>	- Added AllowPanningCancellation, MouseLocation, ZoomAtPosition and GetLocationInsideMinimap to Minimap
 >	- Added UpdateCuttingLine to NodifyEditor
 >	- Added Select, BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
 >	- Added IsDragging, BeginDragging, UpdateDragging, EndDragging and CancelDragging to NodifyEditor
@@ -27,7 +29,7 @@
 >	- Added PreserveSelectionOnRightClick configuration field to ItemContainer
 >	- Added BeginConnecting, UpdatePendingConnection, EndConnecting, CancelConnecting and RemoveConnections methods to Connector
 >	- Added a custom MouseGesture with support for key combinations
->	- Added InputProcessor to NodifyEditor, ItemContainer and Connector, enabling the extension of controls with custom states
+>	- Added InputProcessor to NodifyEditor, ItemContainer, Connector and Minimap, enabling the extension of controls with custom states
 >	- Added DragState to simplify creating click-and-drag operations, with support for initiating and completing them using the keyboard
 >	- Added InputElementStateStack to manage transitions between states in UI elements
 >	- Added InputProcessor.Shared to enable the addition of global input handlers

--- a/Nodify/Editor/NodifyEditor.Panning.cs
+++ b/Nodify/Editor/NodifyEditor.Panning.cs
@@ -125,6 +125,15 @@ namespace Nodify
         }
 
         /// <summary>
+        /// Ends the current panning operation, retaining the current <see cref="ViewportLocation"/>.
+        /// </summary>
+        /// <remarks>This method has no effect if there's no panning operation in progress.</remarks>
+        public void EndPanning()
+        {
+            IsPanning = false;
+        }
+
+        /// <summary>
         /// Cancels the current panning operation and reverts the viewport to its initial location if <see cref="AllowPanningCancellation"/> is true.
         /// Otherwise, it ends the panning operation by calling <see cref="EndPanning"/>.
         /// </summary>
@@ -142,15 +151,6 @@ namespace Nodify
                 ViewportLocation = _initialPanningLocation;
                 IsPanning = false;
             }
-        }
-
-        /// <summary>
-        /// Ends the current panning operation, retaining the current <see cref="ViewportLocation"/>.
-        /// </summary>
-        /// <remarks>This method has no effect if there's no panning operation in progress.</remarks>
-        public void EndPanning()
-        {
-            IsPanning = false;
         }
 
         #region Auto panning

--- a/Nodify/Interactivity/Gestures/EditorGestures.cs
+++ b/Nodify/Interactivity/Gestures/EditorGestures.cs
@@ -314,11 +314,16 @@ namespace Nodify.Interactivity
             public MinimapGestures()
             {
                 DragViewport = new MouseGesture(MouseAction.LeftClick);
+                CancelAction = new AnyGesture(new MouseGesture(MouseAction.RightClick), new KeyGesture(Key.Escape));
                 ZoomModifierKey = ModifierKeys.None;
             }
 
             /// <summary>Gesture to move the viewport inside the <see cref="Minimap" />.</summary>
             public InputGestureRef DragViewport { get; }
+
+            /// <summary>Gesture to cancel the panning operation.</summary>
+            /// <remarks>Defaults to <see cref="MouseAction.RightClick"/> or <see cref="Key.Escape"/>.</remarks>
+            public InputGestureRef CancelAction { get; }
 
             /// <summary>The key modifier required to start zooming by mouse wheel.</summary>
             /// <remarks>Defaults to <see cref="ModifierKeys.None"/>.</remarks>
@@ -329,6 +334,7 @@ namespace Nodify.Interactivity
             public void Apply(MinimapGestures gestures)
             {
                 DragViewport.Value = gestures.DragViewport.Value;
+                CancelAction.Value = gestures.CancelAction.Value;
                 ZoomModifierKey = gestures.ZoomModifierKey;
             }
         }

--- a/Nodify/Interactivity/InputProcessor.Shared.cs
+++ b/Nodify/Interactivity/InputProcessor.Shared.cs
@@ -49,6 +49,10 @@ namespace Nodify.Interactivity
                 {
                     ConnectorState.RegisterDefaultHandlers();
                 }
+                else if (typeof(TElement) == typeof(Minimap))
+                {
+                    MinimapState.RegisterDefaultHandlers();
+                }
             }
 
             public void HandleEvent(InputEventArgs e)

--- a/Nodify/Minimap/MinimapPanel.cs
+++ b/Nodify/Minimap/MinimapPanel.cs
@@ -4,7 +4,7 @@ using System.Windows.Controls;
 
 namespace Nodify
 {
-    internal class MinimapPanel : Panel
+    internal sealed class MinimapPanel : Panel
     {
         public static readonly DependencyProperty ViewportLocationProperty = NodifyEditor.ViewportLocationProperty.AddOwner(typeof(MinimapPanel), new FrameworkPropertyMetadata(BoxValue.Point, FrameworkPropertyMetadataOptions.AffectsMeasure));
         public static readonly DependencyProperty ViewportSizeProperty = NodifyEditor.ViewportSizeProperty.AddOwner(typeof(MinimapPanel), new FrameworkPropertyMetadata(BoxValue.Size, FrameworkPropertyMetadataOptions.AffectsMeasure));

--- a/Nodify/Minimap/States/MinimapState.cs
+++ b/Nodify/Minimap/States/MinimapState.cs
@@ -1,0 +1,11 @@
+﻿namespace Nodify.Interactivity
+{
+    public static partial class MinimapState
+    {
+        internal static void RegisterDefaultHandlers()
+        {
+            InputProcessor.Shared<Minimap>.RegisterHandlerFactory(elem => new Panning(elem));
+            InputProcessor.Shared<Minimap>.RegisterHandlerFactory(elem => new Zooming(elem));
+        }
+    }
+}

--- a/Nodify/Minimap/States/Panning.cs
+++ b/Nodify/Minimap/States/Panning.cs
@@ -1,0 +1,37 @@
+﻿using System.Windows.Input;
+
+namespace Nodify.Interactivity
+{
+    public static partial class MinimapState
+    {
+        /// <summary>
+        /// Represents the panning state of the <see cref="Minimap"/>, allowing the user to pan the viewport by clicking and dragging.
+        /// </summary>
+        public class Panning : DragState<Minimap>
+        {
+            protected override bool CanCancel => Minimap.AllowPanningCancellation;
+            protected override bool CanBegin => !Element.IsReadOnly;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Panning"/> class.
+            /// </summary>
+            /// <param name="minimap">The <see cref="Minimap"/> associated with this state.</param>
+            public Panning(Minimap minimap)
+                : base(minimap, EditorGestures.Mappings.Minimap.DragViewport, EditorGestures.Mappings.Minimap.CancelAction)
+            {
+            }
+
+            protected override void OnBegin(InputEventArgs e)
+                => Element.BeginPanning();
+
+            protected override void OnMouseMove(MouseEventArgs e)
+                => Element.UpdatePanning(Element.MouseLocation);
+
+            protected override void OnEnd(InputEventArgs e)
+                => Element.EndPanning();
+
+            protected override void OnCancel(InputEventArgs e)
+                => Element.CancelPanning();
+        }
+    }
+}

--- a/Nodify/Minimap/States/Zooming.cs
+++ b/Nodify/Minimap/States/Zooming.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Nodify.Interactivity
+{
+    public static partial class MinimapState
+    {
+        /// <summary>
+        /// Represents the zooming state of the <see cref="Minimap"/>.
+        /// This state handles zooming operations using the mouse wheel with an optional modifier key.
+        /// </summary>
+        public class Zooming : InputElementState<Minimap>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Zooming"/> class.
+            /// </summary>
+            /// <param name="minimap">The <see cref="Minimap"/> associated with this state.</param>
+            public Zooming(Minimap minimap) : base(minimap)
+            {
+            }
+
+            protected override void OnMouseWheel(MouseWheelEventArgs e)
+            {
+                if (!Element.IsReadOnly && EditorGestures.Mappings.Minimap.ZoomModifierKey == Keyboard.Modifiers)
+                {
+                    double zoom = Math.Pow(2.0, e.Delta / 3.0 / Mouse.MouseWheelDeltaForOneLine);
+                    Element.ZoomAtPosition(zoom, Element.MouseLocation);
+                    e.Handled = true;
+                }
+            }
+        }
+    }
+}

--- a/Nodify/Minimap/SubtractConverter.cs
+++ b/Nodify/Minimap/SubtractConverter.cs
@@ -4,7 +4,7 @@ using System.Windows.Data;
 
 namespace Nodify
 {
-    internal class SubtractConverter : IMultiValueConverter
+    internal sealed class SubtractConverter : IMultiValueConverter
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {


### PR DESCRIPTION
### 📝 Description of the Change

Adds panning methods to the `Minimap` control and custom input processing via the `InputProcessor.Shared<Minimap>` API.

New methods:
- `BeginPanning`
- `UpdatePanning`
- `EndPanning,`
- `CancelPanning`
- `ZoomAtPosition`
- `GetLocationInsideMinimap`

Allows panning cancellation via the `EditorGestures.Minimap.CancelAction` gesture.

New properties:
- `AllowPanningCancellation`
- `MouseLocation`

Related: #146

### 🐛 Possible Drawbacks

None.
