### PR TITLE
Enable custom input processing for BaseConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,12 @@
 >	- Added PreserveSelectionOnRightClick configuration field to ItemContainer
 >	- Added BeginConnecting, UpdatePendingConnection, EndConnecting, CancelConnecting and RemoveConnections methods to Connector
 >	- Added a custom MouseGesture with support for key combinations
->	- Added InputProcessor to NodifyEditor, ItemContainer, Connector and Minimap, enabling the extension of controls with custom states
+>	- Added InputProcessor to NodifyEditor, ItemContainer, Connector, BaseConnection and Minimap, enabling the extension of controls with custom states
 >	- Added DragState to simplify creating click-and-drag operations, with support for initiating and completing them using the keyboard
 >	- Added InputElementStateStack to manage transitions between states in UI elements
 >	- Added InputProcessor.Shared to enable the addition of global input handlers
 >	- Move the viewport to the mouse position when zooming on the Minimap if ResizeToViewport is false
+>	- Added SplitAtLocation and Remove methods to BaseConnection
 > - Bugfixes:
 >	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured
 >	- Fixed an issue where the ItemContainer could open its context menu even when it was not selected

--- a/Nodify/Connections/ConnectionContainer.cs
+++ b/Nodify/Connections/ConnectionContainer.cs
@@ -5,7 +5,7 @@ using System.Windows.Input;
 
 namespace Nodify
 {
-    internal class ConnectionContainer : ContentPresenter
+    internal sealed class ConnectionContainer : ContentPresenter
     {
         #region Dependency properties
 
@@ -83,7 +83,7 @@ namespace Nodify
         /// Called when the <see cref="IsSelected"/> value is changed.
         /// </summary>
         /// <param name="newValue">True if selected, false otherwise.</param>
-        protected void OnSelectedChanged(bool newValue)
+        private void OnSelectedChanged(bool newValue)
         {
             BaseConnection.SetIsSelected(Connection, newValue);
 

--- a/Nodify/Connections/ConnectionsMultiSelector.cs
+++ b/Nodify/Connections/ConnectionsMultiSelector.cs
@@ -6,7 +6,7 @@ using System.Windows.Controls.Primitives;
 
 namespace Nodify
 {
-    internal class ConnectionsMultiSelector : MultiSelector
+    internal sealed class ConnectionsMultiSelector : MultiSelector
     {
         public static readonly DependencyProperty SelectedItemsProperty = NodifyEditor.SelectedItemsProperty.AddOwner(typeof(ConnectionsMultiSelector), new FrameworkPropertyMetadata(default(IList), OnSelectedItemsSourceChanged));
         public static readonly DependencyProperty CanSelectMultipleItemsProperty = NodifyEditor.CanSelectMultipleItemsProperty.AddOwner(typeof(ConnectionsMultiSelector), new FrameworkPropertyMetadata(BoxValue.True, OnCanSelectMultipleItemsChanged, CoerceCanSelectMultipleItems));

--- a/Nodify/Connections/States/ConnectionState.cs
+++ b/Nodify/Connections/States/ConnectionState.cs
@@ -1,0 +1,11 @@
+﻿namespace Nodify.Interactivity
+{
+    public static partial class ConnectionState
+    {
+        internal static void RegisterDefaultHandlers()
+        {
+            InputProcessor.Shared<BaseConnection>.RegisterHandlerFactory(elem => new Disconnect(elem));
+            InputProcessor.Shared<BaseConnection>.RegisterHandlerFactory(elem => new Split(elem));
+        }
+    }
+}

--- a/Nodify/Connections/States/Disconnect.cs
+++ b/Nodify/Connections/States/Disconnect.cs
@@ -1,0 +1,41 @@
+﻿using System.Windows.Input;
+
+namespace Nodify.Interactivity
+{
+    public static partial class ConnectionState
+    {
+        /// <summary>
+        /// Represents a state in which a connection can be disconnected from its connectors based on specific gestures.
+        /// </summary>
+        public class Disconnect : InputElementState<BaseConnection>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Disconnect"/> class.
+            /// </summary>
+            /// <param name="connection">The <see cref="BaseConnection"/> element associated with this state.</param>
+            public Disconnect(BaseConnection connection) : base(connection)
+            {
+            }
+
+            protected override void OnMouseDown(MouseButtonEventArgs e)
+            {
+                EditorGestures.ConnectionGestures gestures = EditorGestures.Mappings.Connection;
+                if (gestures.Disconnect.Matches(e.Source, e))
+                {
+                    Element.Focus();
+                    e.Handled = true;   // prevent interacting with the editor
+                }
+            }
+
+            protected override void OnMouseUp(MouseButtonEventArgs e)
+            {
+                EditorGestures.ConnectionGestures gestures = EditorGestures.Mappings.Connection;
+                if (gestures.Disconnect.Matches(e.Source, e))
+                {
+                    Element.Remove();
+                    e.Handled = true;   // prevent opening context menu
+                }
+            }
+        }
+    }
+}

--- a/Nodify/Connections/States/Split.cs
+++ b/Nodify/Connections/States/Split.cs
@@ -1,0 +1,33 @@
+﻿using System.Windows.Input;
+
+namespace Nodify.Interactivity
+{
+    public static partial class ConnectionState
+    {
+        /// <summary>
+        /// Represents a state in which a connection can be split.
+        /// </summary>
+        public class Split : InputElementState<BaseConnection>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Split"/> class.
+            /// </summary>
+            /// <param name="connection">The <see cref="BaseConnection"/> element associated with this state.</param>
+            public Split(BaseConnection connection) : base(connection)
+            {
+            }
+
+            protected override void OnMouseDown(MouseButtonEventArgs e)
+            {
+                EditorGestures.ConnectionGestures gestures = EditorGestures.Mappings.Connection;
+                if (gestures.Split.Matches(e.Source, e))
+                {
+                    Element.Focus();
+                    Element.SplitAtLocation(e.GetPosition(Element));
+
+                    e.Handled = true;   // prevent interacting with the editor
+                }
+            }
+        }
+    }
+}

--- a/Nodify/Containers/DecoratorsControl.cs
+++ b/Nodify/Containers/DecoratorsControl.cs
@@ -6,7 +6,7 @@ namespace Nodify
     /// <summary>
     /// An <see cref="ItemsControl"/> that works with <see cref="DecoratorContainer"/>s.
     /// </summary>
-    internal class DecoratorsControl : ItemsControl
+    internal sealed class DecoratorsControl : ItemsControl
     {
         /// <inheritdoc />
         protected override bool IsItemItsOwnContainerOverride(object item)

--- a/Nodify/Editor/NodifyEditor.Cutting.cs
+++ b/Nodify/Editor/NodifyEditor.Cutting.cs
@@ -234,7 +234,7 @@ namespace Nodify
             {
                 if (connection is BaseConnection bc)
                 {
-                    bc.OnDisconnect();
+                    bc.Remove();
                 }
             }
         }

--- a/Nodify/Interactivity/InputProcessor.Shared.cs
+++ b/Nodify/Interactivity/InputProcessor.Shared.cs
@@ -53,6 +53,10 @@ namespace Nodify.Interactivity
                 {
                     MinimapState.RegisterDefaultHandlers();
                 }
+                else if(typeof(TElement) == typeof(BaseConnection))
+                {
+                    ConnectionState.RegisterDefaultHandlers();
+                }
             }
 
             public void HandleEvent(InputEventArgs e)

--- a/Nodify/Utilities/UnscaleTransformConverter.cs
+++ b/Nodify/Utilities/UnscaleTransformConverter.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 
 namespace Nodify
 {
-    internal class UnscaleTransformConverter : IValueConverter
+    internal sealed class UnscaleTransformConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
@@ -20,7 +20,7 @@ namespace Nodify
         }
     }
 
-    internal class ScaleDoubleConverter : IMultiValueConverter
+    internal sealed class ScaleDoubleConverter : IMultiValueConverter
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
@@ -34,7 +34,7 @@ namespace Nodify
         }
     }
 
-    internal class ScalePointConverter : IMultiValueConverter
+    internal sealed class ScalePointConverter : IMultiValueConverter
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {


### PR DESCRIPTION
### 📝 Description of the Change

Adds new methods to the `BaseConnection` control and custom input processing via the `InputProcessor.Shared<Minimap>` API.

New methods:
- `SplitAtLocation`
- `Remove`

Related #146

### 🐛 Possible Drawbacks

None.
