### PR TITLE
Enable toggled interactions for various editor operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 >	- Made Minimap sealed
 >	- Renamed HandleRightClickAfterPanningThreshold to MouseActionSuppressionThreshold in NodifyEditor
 >	- Renamed StartCutting to BeginCutting in NodifyEditor
+>	- Renamed Connector.EnableStickyConnections to ConnectorState.EnabledToggledConnecting
 >	- Renamed PushItems to UpdatePushedArea and StartPushingItems to BeginPushingItems in NodifyEditor
 >	- Renamed UnselectAllConnection to UnselectAllConnections in NodifyEditor
 >	- Removed DragStarted, DragDelta and DragCompleted routed events from ItemContainer
@@ -36,7 +37,8 @@
 >	- Move the viewport to the mouse position when zooming on the Minimap if ResizeToViewport is false
 >	- Added SplitAtLocation and Remove methods to BaseConnection
 >	- Added AllowPanningWhileSelecting, AllowPanningWhileCutting and AllowPanningWhilePushingItems to EditorState
->	- Added AllowZoomingWhileSelecting, AllowZoomingWhileCutting and AllowZoomingWhilePushingItems to EditorState
+>	- Added AllowZoomingWhilePanning, AllowZoomingWhileSelecting, AllowZoomingWhileCutting and AllowZoomingWhilePushingItems to EditorState
+>	- Added EnableToggledSelectingMode, EnableToggledPanningMode, EnableToggledPushingItemsMode and EnableToggledCuttingMode to EditorState
 > - Bugfixes:
 >	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured
 >	- Fixed an issue where the ItemContainer could open its context menu even when it was not selected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 > - Breaking Changes:
 >	- Made the setter of NodifyEditor.IsPanning private
 >	- Made SelectionHelper internal
->	- Made Minimap sealed
 >	- Renamed HandleRightClickAfterPanningThreshold to MouseActionSuppressionThreshold in NodifyEditor
 >	- Renamed StartCutting to BeginCutting in NodifyEditor
 >	- Renamed Connector.EnableStickyConnections to ConnectorState.EnabledToggledConnecting
@@ -39,6 +38,7 @@
 >	- Added AllowPanningWhileSelecting, AllowPanningWhileCutting and AllowPanningWhilePushingItems to EditorState
 >	- Added AllowZoomingWhilePanning, AllowZoomingWhileSelecting, AllowZoomingWhileCutting and AllowZoomingWhilePushingItems to EditorState
 >	- Added EnableToggledSelectingMode, EnableToggledPanningMode, EnableToggledPushingItemsMode and EnableToggledCuttingMode to EditorState
+>	- Added MinimapState.EnableToggledPanningMode
 > - Bugfixes:
 >	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured
 >	- Fixed an issue where the ItemContainer could open its context menu even when it was not selected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 >	- Made SelectionHelper internal
 >	- Renamed HandleRightClickAfterPanningThreshold to MouseActionSuppressionThreshold in NodifyEditor
 >	- Renamed StartCutting to BeginCutting in NodifyEditor
->	- Renamed Connector.EnableStickyConnections to ConnectorState.EnabledToggledConnecting
+>	- Renamed Connector.EnableStickyConnections to ConnectorState.EnabledToggledConnectingMode
 >	- Renamed PushItems to UpdatePushedArea and StartPushingItems to BeginPushingItems in NodifyEditor
 >	- Renamed UnselectAllConnection to UnselectAllConnections in NodifyEditor
 >	- Removed DragStarted, DragDelta and DragCompleted routed events from ItemContainer
@@ -24,7 +24,7 @@
 >	- Added Select, BeginSelecting, UpdateSelection, EndSelecting, CancelSelecting and AllowSelectionCancellation to NodifyEditor
 >	- Added IsDragging, BeginDragging, UpdateDragging, EndDragging and CancelDragging to NodifyEditor
 >	- Added AlignSelection and AlignContainers methods to NodifyEditor
->	- Added HasCustomContextMenu dependency property to NodifyEditor, ItemContainer and Connector
+>	- Added HasCustomContextMenu dependency property to NodifyEditor, ItemContainer, Connector and BaseConnection
 >	- Added Select, BeginDragging, UpdateDragging, EndDragging and CancelDragging to ItemContainer
 >	- Added PreserveSelectionOnRightClick configuration field to ItemContainer
 >	- Added BeginConnecting, UpdatePendingConnection, EndConnecting, CancelConnecting and RemoveConnections methods to Connector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 >	- Added InputProcessor.Shared to enable the addition of global input handlers
 >	- Move the viewport to the mouse position when zooming on the Minimap if ResizeToViewport is false
 >	- Added SplitAtLocation and Remove methods to BaseConnection
+>	- Added AllowPanningWhileSelecting, AllowPanningWhileCutting and AllowPanningWhilePushingItems to EditorState
+>	- Added AllowZoomingWhileSelecting, AllowZoomingWhileCutting and AllowZoomingWhilePushingItems to EditorState
 > - Bugfixes:
 >	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured
 >	- Fixed an issue where the ItemContainer could open its context menu even when it was not selected

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -339,7 +339,7 @@ namespace Nodify.Playground
                 new ProxySettingViewModel<bool>(
                     () => Instance.EnableMinimapToggledPanning,
                     val => Instance.EnableMinimapToggledPanning = val,
-                    "Enable toggled panning mode for the minimap: ",
+                    "Enable minimap toggled panning mode: ",
                     "The interaction will be completed in two steps using the same gesture to start and end."),
             };
 

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Nodify.Interactivity;
+using System.Collections.Generic;
 using System.Windows;
 
 namespace Nodify.Playground
@@ -231,6 +232,11 @@ namespace Nodify.Playground
                     "Auto panning tick rate: ",
                     "How often is the new position calculated in milliseconds. Disable and enable auto panning for this to have effect."),
                 new ProxySettingViewModel<bool>(
+                    () => Instance.AllowMinimapPanningCancellation,
+                    val => Instance.AllowMinimapPanningCancellation = val,
+                    "Allow minimap panning cancellation: ",
+                    "Right click or escape to cancel panning."),
+                new ProxySettingViewModel<bool>(
                     () => Instance.AllowCuttingCancellation,
                     val => Instance.AllowCuttingCancellation = val,
                     "Allow cutting cancellation: ",
@@ -310,6 +316,31 @@ namespace Nodify.Playground
                     val => Instance.FitToScreenExtentMargin = val,
                     "Fit to screen extent margin: ",
                     "Adds some margin to the nodes extent when fit to screen"),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.EnableToggledCutting,
+                    val => Instance.EnableToggledCutting = val,
+                    "Enable toggled cutting mode: ",
+                    "The interaction will be completed in two steps using the same gesture to start and end."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.EnableToggledPushingItems,
+                    val => Instance.EnableToggledPushingItems = val,
+                    "Enable toggled pushing items mode: ",
+                    "The interaction will be completed in two steps using the same gesture to start and end."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.EnableToggledPanning,
+                    val => Instance.EnableToggledPanning = val,
+                    "Enable toggled panning mode: ",
+                    "The interaction will be completed in two steps using the same gesture to start and end."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.EnableToggledSelecting,
+                    val => Instance.EnableToggledSelecting = val,
+                    "Enable toggled selecting mode: ",
+                    "The interaction will be completed in two steps using the same gesture to start and end."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.EnableMinimapToggledPanning,
+                    val => Instance.EnableMinimapToggledPanning = val,
+                    "Enable toggled panning mode for the minimap: ",
+                    "The interaction will be completed in two steps using the same gesture to start and end."),
             };
 
             EnableCuttingLinePreview = true;
@@ -623,6 +654,12 @@ namespace Nodify.Playground
             set => NodifyEditor.AutoPanningTickRate = value;
         }
 
+        public bool AllowMinimapPanningCancellation
+        {
+            get => Minimap.AllowPanningCancellation;
+            set => Minimap.AllowPanningCancellation = value;
+        }
+
         public bool AllowCuttingCancellation
         {
             get => NodifyEditor.AllowCuttingCancellation;
@@ -721,8 +758,38 @@ namespace Nodify.Playground
 
         public bool EnableStickyConnectors
         {
-            get => Connector.EnableStickyConnections;
-            set => Connector.EnableStickyConnections = value;
+            get => ConnectorState.EnableToggledConnectingMode;
+            set => ConnectorState.EnableToggledConnectingMode = value;
+        }
+
+        public bool EnableToggledPanning
+        {
+            get => EditorState.EnableToggledPanningMode;
+            set => EditorState.EnableToggledPanningMode = value;
+        }
+
+        public bool EnableToggledCutting
+        {
+            get => EditorState.EnableToggledCuttingMode;
+            set => EditorState.EnableToggledCuttingMode = value;
+        }
+
+        public bool EnableToggledPushingItems
+        {
+            get => EditorState.EnableToggledPushingItemsMode;
+            set => EditorState.EnableToggledPushingItemsMode = value;
+        }
+
+        public bool EnableToggledSelecting
+        {
+            get => EditorState.EnableToggledSelectingMode;
+            set => EditorState.EnableToggledSelectingMode = value;
+        }
+
+        public bool EnableMinimapToggledPanning
+        {
+            get => MinimapState.EnableToggledPanningMode;
+            set => MinimapState.EnableToggledPanningMode = value;
         }
 
         #endregion

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -341,6 +341,41 @@ namespace Nodify.Playground
                     val => Instance.EnableMinimapToggledPanning = val,
                     "Enable minimap toggled panning mode: ",
                     "The interaction will be completed in two steps using the same gesture to start and end."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowPanningWhileSelecting,
+                    val => Instance.AllowPanningWhileSelecting = val,
+                    "Allow panning while selecting: ",
+                    "Whether panning is allowed while selecting items in the editor."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowPanningWhileCutting,
+                    val => Instance.AllowPanningWhileCutting = val,
+                    "Allow panning while cutting: ",
+                    "Whether panning is allowed while cutting connections in the editor."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowPanningWhilePushingItems,
+                    val => Instance.AllowPanningWhilePushingItems = val,
+                    "Allow panning while pushing items: ",
+                    "Whether panning is allowed while pushing items items in the editor."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowZoomingWhileSelecting,
+                    val => Instance.AllowZoomingWhileSelecting = val,
+                    "Allow zooming while selecting: ",
+                    "Whether zooming is allowed while selecting items in the editor."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowZoomingWhileCutting,
+                    val => Instance.AllowZoomingWhileCutting = val,
+                    "Allow zooming while cutting: ",
+                    "Whether zooming is allowed while cutting connections in the editor."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowZoomingWhilePushingItems,
+                    val => Instance.AllowZoomingWhilePushingItems = val,
+                    "Allow zooming while pushing items: ",
+                    "Whether zooming is allowed while pushing items connections in the editor."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowZoomingWhilePanning,
+                    val => Instance.AllowZoomingWhilePanning = val,
+                    "Allow zooming while panning: ",
+                    "Whether zooming is allowed while panning connections in the editor."),
             };
 
             EnableCuttingLinePreview = true;
@@ -790,6 +825,48 @@ namespace Nodify.Playground
         {
             get => MinimapState.EnableToggledPanningMode;
             set => MinimapState.EnableToggledPanningMode = value;
+        }
+
+        public bool AllowPanningWhileSelecting
+        {
+            get => EditorState.AllowPanningWhileSelecting;
+            set => EditorState.AllowPanningWhileSelecting = value;
+        }
+
+        public bool AllowPanningWhileCutting
+        {
+            get => EditorState.AllowPanningWhileCutting;
+            set => EditorState.AllowPanningWhileCutting = value;
+        }
+
+        public bool AllowPanningWhilePushingItems
+        {
+            get => EditorState.AllowPanningWhilePushingItems;
+            set => EditorState.AllowPanningWhilePushingItems = value;
+        }
+
+        public bool AllowZoomingWhileSelecting
+        {
+            get => EditorState.AllowZoomingWhileSelecting;
+            set => EditorState.AllowZoomingWhileSelecting = value;
+        }
+
+        public bool AllowZoomingWhileCutting
+        {
+            get => EditorState.AllowZoomingWhileCutting;
+            set => EditorState.AllowZoomingWhileCutting = value;
+        }
+
+        public bool AllowZoomingWhilePushingItems
+        {
+            get => EditorState.AllowZoomingWhilePushingItems;
+            set => EditorState.AllowZoomingWhilePushingItems = value;
+        }
+
+        public bool AllowZoomingWhilePanning
+        {
+            get => EditorState.AllowZoomingWhilePanning;
+            set => EditorState.AllowZoomingWhilePanning = value;
         }
 
         #endregion

--- a/Examples/Nodify.StateMachine/MainWindow.xaml
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml
@@ -74,10 +74,13 @@
                                                Spacing="0"
                                                SourceOffsetMode="Edge"
                                                TargetOffsetMode="Edge"
+                                               OutlineThickness="5"
                                                Tag="{Binding}">
                             <nodify:LineConnection.Style>
                                 <Style TargetType="{x:Type nodify:LineConnection}"
                                        BasedOn="{StaticResource {x:Type nodify:LineConnection}}">
+                                    <Setter Property="OutlineBrush"
+                                            Value="Transparent" />
                                     <Setter Property="StrokeThickness"
                                             Value="3" />
                                     <Style.Triggers>
@@ -88,6 +91,15 @@
                                             <Setter Property="StrokeThickness"
                                                     Value="6" />
                                         </DataTrigger>
+                                        <Trigger Property="IsMouseOver"
+                                                 Value="True">
+                                            <Setter Property="OutlineBrush">
+                                                <Setter.Value>
+                                                    <SolidColorBrush Color="{StaticResource LineConnection.StrokeColor}"
+                                                                     Opacity="0.15" />
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Trigger>
                                     </Style.Triggers>
                                 </Style>
                             </nodify:LineConnection.Style>

--- a/Examples/Nodify.StateMachine/MainWindow.xaml.cs
+++ b/Examples/Nodify.StateMachine/MainWindow.xaml.cs
@@ -11,7 +11,7 @@ namespace Nodify.StateMachine
         {
             InitializeComponent();
 
-            Connector.EnableStickyConnections = true;
+            ConnectorState.EnableToggledConnectingMode = true;
             NodifyEditor.EnableCuttingLinePreview = true;
 
             EditorGestures.Mappings.Connection.Disconnect.Value = MultiGesture.None;

--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -144,6 +144,7 @@ namespace Nodify
 
         public static readonly DependencyProperty IsSelectableProperty = DependencyProperty.RegisterAttached("IsSelectable", typeof(bool), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.False));
         public static readonly DependencyProperty IsSelectedProperty = DependencyProperty.RegisterAttached("IsSelected", typeof(bool), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.False, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnIsSelectedChanged));
+        public static readonly DependencyProperty HasCustomContextMenuProperty = NodifyEditor.HasCustomContextMenuProperty.AddOwner(typeof(BaseConnection));
 
         private static void OnIsSelectedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -437,6 +438,21 @@ namespace Nodify
             get => (FontStretch)GetValue(FontStretchProperty);
             set => SetValue(FontStretchProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the connection uses a custom context menu.
+        /// </summary>
+        /// <remarks>When set to true, the connection handles the right-click event for specific interactions.</remarks>
+        public bool HasCustomContextMenu
+        {
+            get => (bool)GetValue(HasCustomContextMenuProperty);
+            set => SetValue(HasCustomContextMenuProperty, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the connection has a context menu.
+        /// </summary>
+        public bool HasContextMenu => ContextMenu != null || HasCustomContextMenu;
 
         #endregion
 

--- a/Nodify/Connections/States/ConnectionState.cs
+++ b/Nodify/Connections/States/ConnectionState.cs
@@ -6,6 +6,7 @@
         {
             InputProcessor.Shared<BaseConnection>.RegisterHandlerFactory(elem => new Disconnect(elem));
             InputProcessor.Shared<BaseConnection>.RegisterHandlerFactory(elem => new Split(elem));
+            InputProcessor.Shared<BaseConnection>.RegisterHandlerFactory(elem => new Default(elem));
         }
     }
 }

--- a/Nodify/Connections/States/Default.cs
+++ b/Nodify/Connections/States/Default.cs
@@ -1,0 +1,31 @@
+﻿using System.Windows.Input;
+
+namespace Nodify.Interactivity
+{
+    public static partial class ConnectionState
+    {
+        /// <summary>
+        /// Represents the default input state for a <see cref="BaseConnection"/>.
+        /// </summary>
+        public class Default : InputElementState<BaseConnection>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Default"/> class.
+            /// </summary>
+            /// <param name="connection">The <see cref="BaseConnection"/> element associated with this state.</param>
+            public Default(BaseConnection connection) : base(connection)
+            {
+            }
+
+            protected override void OnMouseDown(MouseButtonEventArgs e)
+            {
+                // Allow context menu to appear
+                if (e.ChangedButton == MouseButton.Right && Element.HasContextMenu)
+                {
+                    Element.Focus();
+                    e.Handled = true;   // prevents the editor capturing the mouse
+                }
+            }
+        }
+    }
+}

--- a/Nodify/Connectors/Connector.cs
+++ b/Nodify/Connectors/Connector.cs
@@ -105,7 +105,7 @@ namespace Nodify
         /// <summary>
         /// Gets or sets a value indicating whether the connector uses a custom context menu.
         /// </summary>
-        /// <remarks>When set to true, the connector handles the right-click event for specific operations.</remarks>
+        /// <remarks>When set to true, the connector handles the right-click event for specific interactions.</remarks>
         public bool HasCustomContextMenu
         {
             get => (bool)GetValue(HasCustomContextMenuProperty);
@@ -339,8 +339,8 @@ namespace Nodify
         {
             InputProcessor.Process(e);
 
-            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
-            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
+            // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
+            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -363,8 +363,8 @@ namespace Nodify
         {
             InputProcessor.Process(e);
 
-            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
-            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
+            // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
+            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -375,9 +375,9 @@ namespace Nodify
             => InputProcessor.Process(e);
 
         /// <summary>
-        /// Determines whether any toggled operation is currently in progress.
+        /// Determines whether any toggled interaction is currently in progress.
         /// </summary>
-        protected virtual bool IsToggledOperationInProgress()
+        protected virtual bool IsToggledInteractionInProgress()
         {
             return ConnectorState.EnableToggledConnectingMode && IsPendingConnection;
         }

--- a/Nodify/Connectors/Connector.cs
+++ b/Nodify/Connectors/Connector.cs
@@ -157,11 +157,6 @@ namespace Nodify
         /// </summary>
         public static bool AllowPendingConnectionCancellation { get; set; } = true;
 
-        /// <summary>
-        /// Gets or sets whether the connection should be completed in two steps.
-        /// </summary>
-        public static bool EnableStickyConnections { get; set; }
-
         private Point _lastUpdatedContainerPosition;
         private Point _pendingConnectionEndPosition;
         private bool _isHooked;
@@ -344,8 +339,8 @@ namespace Nodify
         {
             InputProcessor.Process(e);
 
-            // Release the mouse capture if all the mouse buttons are released and there's no sticky connection pending
-            if (!IsPendingConnection && IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released)
+            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
+            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -368,22 +363,23 @@ namespace Nodify
         {
             InputProcessor.Process(e);
 
-            if (!IsPendingConnection && IsMouseCaptured)
+            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
+            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
             {
                 ReleaseMouseCapture();
             }
         }
 
         /// <inheritdoc />
-        protected override void OnKeyDown(KeyEventArgs e)
-        {
-            InputProcessor.Process(e);
+        protected override void OnKeyDown(KeyEventArgs e) 
+            => InputProcessor.Process(e);
 
-            // Release the mouse capture if all the mouse buttons are released and there's no sticky connection pending
-            if (!IsPendingConnection && IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released)
-            {
-                ReleaseMouseCapture();
-            }
+        /// <summary>
+        /// Determines whether any toggled operation is currently in progress.
+        /// </summary>
+        protected virtual bool IsToggledOperationInProgress()
+        {
+            return ConnectorState.EnableToggledConnectingMode && IsPendingConnection;
         }
 
         #endregion

--- a/Nodify/Connectors/States/Connecting.cs
+++ b/Nodify/Connectors/States/Connecting.cs
@@ -13,6 +13,7 @@ namespace Nodify.Interactivity
         {
             protected override bool HasContextMenu => Element.HasContextMenu;
             protected override bool CanCancel => Connector.AllowPendingConnectionCancellation;
+            protected override bool IsToggle => EnableToggledConnectingMode;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="Connecting"/> class.
@@ -23,8 +24,6 @@ namespace Nodify.Interactivity
             {
                 PositionElement = Element.Editor ?? (IInputElement)Element;
             }
-
-            protected override bool IsToggle => EnableToggledConnectingMode;
 
             protected override void OnBegin(InputEventArgs e)
                 => Element.BeginConnecting();

--- a/Nodify/Connectors/States/Connecting.cs
+++ b/Nodify/Connectors/States/Connecting.cs
@@ -24,7 +24,7 @@ namespace Nodify.Interactivity
                 PositionElement = Element.Editor ?? (IInputElement)Element;
             }
 
-            protected override bool IsToggle => Connector.EnableStickyConnections;
+            protected override bool IsToggle => EnableToggledConnectingMode;
 
             protected override void OnBegin(InputEventArgs e)
                 => Element.BeginConnecting();

--- a/Nodify/Connectors/States/ConnectorState.cs
+++ b/Nodify/Connectors/States/ConnectorState.cs
@@ -2,6 +2,11 @@
 {
     public static partial class ConnectorState
     {
+        /// <summary>
+        /// Determines whether toggled connecting mode is enabled, allowing the user to start and end the interaction in two steps with the same input gesture.
+        /// </summary>
+        public static bool EnableToggledConnectingMode { get; set; }
+
         internal static void RegisterDefaultHandlers()
         {
             InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new Disconnect(elem));

--- a/Nodify/Containers/ItemContainer.cs
+++ b/Nodify/Containers/ItemContainer.cs
@@ -150,7 +150,7 @@ namespace Nodify
         /// <summary>
         /// Gets or sets a value indicating whether the container uses a custom context menu.
         /// </summary>
-        /// <remarks>When set to true, the container handles the right-click event for specific operations.</remarks>
+        /// <remarks>When set to true, the container handles the right-click event for specific interactions.</remarks>
         public bool HasCustomContextMenu
         {
             get => (bool)GetValue(HasCustomContextMenuProperty);
@@ -376,8 +376,8 @@ namespace Nodify
         {
             InputProcessor.Process(e);
             
-            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
-            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
+            // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
+            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -400,8 +400,8 @@ namespace Nodify
         {
             InputProcessor.Process(e);
 
-            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
-            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
+            // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
+            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -412,9 +412,9 @@ namespace Nodify
             => InputProcessor.Process(e);
 
         /// <summary>
-        /// Determines whether any toggled operation is currently in progress.
+        /// Determines whether any toggled interaction is currently in progress.
         /// </summary>
-        protected virtual bool IsToggledOperationInProgress() => false;
+        protected virtual bool IsToggledInteractionInProgress() => false;
 
         #endregion
     }

--- a/Nodify/Containers/ItemContainer.cs
+++ b/Nodify/Containers/ItemContainer.cs
@@ -375,9 +375,9 @@ namespace Nodify
         protected override void OnMouseUp(MouseButtonEventArgs e)
         {
             InputProcessor.Process(e);
-
-            // Release the mouse capture if all the mouse buttons are released
-            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released)
+            
+            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
+            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -400,8 +400,8 @@ namespace Nodify
         {
             InputProcessor.Process(e);
 
-            // Release the mouse capture if all the mouse buttons are released
-            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released)
+            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
+            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -410,6 +410,11 @@ namespace Nodify
         /// <inheritdoc />
         protected override void OnKeyDown(KeyEventArgs e)
             => InputProcessor.Process(e);
+
+        /// <summary>
+        /// Determines whether any toggled operation is currently in progress.
+        /// </summary>
+        protected virtual bool IsToggledOperationInProgress() => false;
 
         #endregion
     }

--- a/Nodify/Containers/States/Default.cs
+++ b/Nodify/Containers/States/Default.cs
@@ -68,18 +68,6 @@ namespace Nodify.Interactivity
                     }
                 }
 
-                private bool CaptureMouseSafe()
-                {
-                    // Avoid stealing mouse capture from other elements
-                    if (Mouse.Captured == null || Element.IsMouseCaptured)
-                    {
-                        Element.CaptureMouse();
-                        return true;
-                    }
-
-                    return false;
-                }
-
                 /// <inheritdoc />
                 protected override void OnMouseMove(MouseEventArgs e)
                 {
@@ -119,14 +107,6 @@ namespace Nodify.Interactivity
                     _selectionType = null;
                 }
 
-                private static SelectionType GetSelectionTypeForDragging(SelectionType? selectionType)
-                {
-                    // Always select the container when dragging
-                    return selectionType == SelectionType.Remove
-                        ? SelectionType.Replace
-                        : selectionType.GetValueOrDefault(SelectionType.Replace);
-                }
-
                 private bool IsSelectable(MouseButtonEventArgs e)
                 {
                     if (!Element.IsSelectableLocation(e.GetPosition(Element)))
@@ -140,6 +120,26 @@ namespace Nodify.Interactivity
                     }
 
                     return true;
+                }
+
+                private bool CaptureMouseSafe()
+                {
+                    // Avoid stealing mouse capture from other elements
+                    if (Mouse.Captured == null || Element.IsMouseCaptured)
+                    {
+                        Element.CaptureMouse();
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                private static SelectionType GetSelectionTypeForDragging(SelectionType? selectionType)
+                {
+                    // Always select the container when dragging
+                    return selectionType == SelectionType.Remove
+                        ? SelectionType.Replace
+                        : selectionType.GetValueOrDefault(SelectionType.Replace);
                 }
             }
         }

--- a/Nodify/Editor/NodifyEditor.PushingItems.cs
+++ b/Nodify/Editor/NodifyEditor.PushingItems.cs
@@ -9,6 +9,8 @@ namespace Nodify
     [StyleTypedProperty(Property = nameof(PushedAreaStyle), StyleTargetType = typeof(Rectangle))]
     public partial class NodifyEditor
     {
+        #region Dependency properties
+
         public static readonly DependencyProperty PushedAreaStyleProperty = DependencyProperty.Register(nameof(PushedAreaStyle), typeof(Style), typeof(NodifyEditor));
 
         protected static readonly DependencyPropertyKey PushedAreaPropertyKey = DependencyProperty.RegisterReadOnly(nameof(PushedArea), typeof(Rect), typeof(NodifyEditor), new FrameworkPropertyMetadata(BoxValue.Rect));
@@ -55,6 +57,8 @@ namespace Nodify
             get => (Style)GetValue(PushedAreaStyleProperty);
             set => SetValue(PushedAreaStyleProperty, value);
         }
+
+        #endregion
 
         /// <summary>
         /// Gets or sets whether push items cancellation is allowed (see <see cref="EditorGestures.NodifyEditorGestures.CancelAction"/>).

--- a/Nodify/Editor/NodifyEditor.cs
+++ b/Nodify/Editor/NodifyEditor.cs
@@ -407,7 +407,7 @@ namespace Nodify
         /// <summary>
         /// Gets or sets a value indicating whether the editor uses a custom context menu.
         /// </summary>
-        /// <remarks>When set to true, the editor handles the right-click event for specific operations.</remarks>
+        /// <remarks>When set to true, the editor handles the right-click event for specific interactions.</remarks>
         public bool HasCustomContextMenu
         {
             get => (bool)GetValue(HasCustomContextMenuProperty);
@@ -807,8 +807,8 @@ namespace Nodify
             MouseLocation = e.GetPosition(ItemsHost);
             InputProcessor.Process(e);
 
-            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
-            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
+            // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
+            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -837,8 +837,8 @@ namespace Nodify
         {
             InputProcessor.Process(e);
 
-            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
-            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
+            // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
+            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -849,9 +849,9 @@ namespace Nodify
             => InputProcessor.Process(e);
 
         /// <summary>
-        /// Determines whether any toggled operation is currently in progress.
+        /// Determines whether any toggled interaction is currently in progress.
         /// </summary>
-        protected virtual bool IsToggledOperationInProgress()
+        protected virtual bool IsToggledInteractionInProgress()
         {
             return EditorState.EnableToggledPanningMode && IsPanning
                 || EditorState.EnableToggledSelectingMode && IsSelecting

--- a/Nodify/Editor/NodifyEditor.cs
+++ b/Nodify/Editor/NodifyEditor.cs
@@ -807,8 +807,8 @@ namespace Nodify
             MouseLocation = e.GetPosition(ItemsHost);
             InputProcessor.Process(e);
 
-            // Release the mouse capture if all the mouse buttons are released
-            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released)
+            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
+            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -837,8 +837,8 @@ namespace Nodify
         {
             InputProcessor.Process(e);
 
-            // Release the mouse capture if all the mouse buttons are released
-            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released)
+            // Release the mouse capture if all the mouse buttons are released and there's no operation in progress
+            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledOperationInProgress())
             {
                 ReleaseMouseCapture();
             }
@@ -847,6 +847,17 @@ namespace Nodify
         /// <inheritdoc />
         protected override void OnKeyDown(KeyEventArgs e)
             => InputProcessor.Process(e);
+
+        /// <summary>
+        /// Determines whether any toggled operation is currently in progress.
+        /// </summary>
+        protected virtual bool IsToggledOperationInProgress()
+        {
+            return EditorState.EnableToggledPanningMode && IsPanning
+                || EditorState.EnableToggledSelectingMode && IsSelecting
+                || EditorState.EnableToggledPushingItemsMode && IsPushingItems
+                || EditorState.EnableToggledCuttingMode && IsCutting;
+        }
 
         #endregion
 

--- a/Nodify/Editor/States/Cutting.cs
+++ b/Nodify/Editor/States/Cutting.cs
@@ -11,6 +11,7 @@ namespace Nodify.Interactivity
         {
             protected override bool HasContextMenu => Element.HasContextMenu;
             protected override bool CanCancel => NodifyEditor.AllowCuttingCancellation;
+            protected override bool IsToggle => EnableToggledCuttingMode;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="Cutting"/> class.

--- a/Nodify/Editor/States/Cutting.cs
+++ b/Nodify/Editor/States/Cutting.cs
@@ -10,6 +10,7 @@ namespace Nodify.Interactivity
         public class Cutting : DragState<NodifyEditor>
         {
             protected override bool HasContextMenu => Element.HasContextMenu;
+            protected override bool CanBegin => !Element.IsSelecting && !Element.IsPanning && !Element.IsPushingItems;
             protected override bool CanCancel => NodifyEditor.AllowCuttingCancellation;
             protected override bool IsToggle => EnableToggledCuttingMode;
 

--- a/Nodify/Editor/States/EditorState.cs
+++ b/Nodify/Editor/States/EditorState.cs
@@ -10,7 +10,7 @@
         /// <summary>
         /// Gets or sets a value indicating whether panning is allowed while cutting connections in the editor.
         /// </summary>
-        public static bool AllowPanningWhileCutting { get; set; } = true;
+        public static bool AllowPanningWhileCutting { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether panning is allowed while pushing items in the editor.
@@ -31,6 +31,31 @@
         /// Gets or sets a value indicating whether zooming is allowed while pushing items in the editor.
         /// </summary>
         public static bool AllowZoomingWhilePushingItems { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether zooming is allowed while panning the editor viewport.
+        /// </summary>
+        public static bool AllowZoomingWhilePanning { get; set; } = true;
+
+        /// <summary>
+        /// Determines whether toggled selecting mode is enabled, allowing the user to start and end the interaction in two steps with the same input gesture.
+        /// </summary>
+        public static bool EnableToggledSelectingMode { get; set; }
+
+        /// <summary>
+        /// Determines whether toggled panning mode is enabled, allowing the user to start and end the interaction in two steps with the same input gesture.
+        /// </summary>
+        public static bool EnableToggledPanningMode { get; set; }
+
+        /// <summary>
+        /// Determines whether toggled cutting mode is enabled, allowing the user to start and end the interaction in two steps with the same input gesture.
+        /// </summary>
+        public static bool EnableToggledCuttingMode { get; set; }
+
+        /// <summary>
+        /// Determines whether toggled pushing items mode is enabled, allowing the user to start and end the interaction in two steps with the same input gesture.
+        /// </summary>
+        public static bool EnableToggledPushingItemsMode { get; set; }
 
         internal static void RegisterDefaultHandlers()
         {

--- a/Nodify/Editor/States/EditorState.cs
+++ b/Nodify/Editor/States/EditorState.cs
@@ -2,6 +2,36 @@
 {
     public static partial class EditorState
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether panning is allowed while selecting items in the editor.
+        /// </summary>
+        public static bool AllowPanningWhileSelecting { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether panning is allowed while cutting connections in the editor.
+        /// </summary>
+        public static bool AllowPanningWhileCutting { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether panning is allowed while pushing items in the editor.
+        /// </summary>
+        public static bool AllowPanningWhilePushingItems { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether zooming is allowed while selecting items in the editor.
+        /// </summary>
+        public static bool AllowZoomingWhileSelecting { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether zooming is allowed while cutting connections in the editor.
+        /// </summary>
+        public static bool AllowZoomingWhileCutting { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether zooming is allowed while pushing items in the editor.
+        /// </summary>
+        public static bool AllowZoomingWhilePushingItems { get; set; } = true;
+
         internal static void RegisterDefaultHandlers()
         {
             InputProcessor.Shared<NodifyEditor>.RegisterHandlerFactory(elem => new Panning(elem));

--- a/Nodify/Editor/States/Panning.cs
+++ b/Nodify/Editor/States/Panning.cs
@@ -13,9 +13,9 @@ namespace Nodify.Interactivity
         {
             protected override bool HasContextMenu => Element.HasContextMenu;
             protected override bool CanBegin => IsPanningAllowed();
+            protected override bool CanCancel => NodifyEditor.AllowPanningCancellation;
             protected override bool IsToggle => EnableToggledPanningMode;
 
-            protected override bool CanCancel => NodifyEditor.AllowPanningCancellation;
 
             private Point _prevPosition;
 

--- a/Nodify/Editor/States/Panning.cs
+++ b/Nodify/Editor/States/Panning.cs
@@ -12,7 +12,8 @@ namespace Nodify.Interactivity
         public class Panning : DragState<NodifyEditor>
         {
             protected override bool HasContextMenu => Element.HasContextMenu;
-            protected override bool CanBegin => !Element.DisablePanning;
+            protected override bool CanBegin => IsPanningAllowed();
+
             protected override bool CanCancel => NodifyEditor.AllowPanningCancellation;
 
             private Point _prevPosition;
@@ -44,6 +45,14 @@ namespace Nodify.Interactivity
 
             protected override void OnCancel(InputEventArgs e)
                 => Element.CancelPanning();
+
+            private bool IsPanningAllowed()
+            {
+                return !Element.DisablePanning
+                    && (AllowPanningWhileSelecting || !Element.IsSelecting)
+                    && (AllowPanningWhileCutting || !Element.IsCutting)
+                    && (AllowPanningWhilePushingItems || !Element.IsPushingItems);
+            }
         }
 
         /// <summary>

--- a/Nodify/Editor/States/Panning.cs
+++ b/Nodify/Editor/States/Panning.cs
@@ -13,6 +13,7 @@ namespace Nodify.Interactivity
         {
             protected override bool HasContextMenu => Element.HasContextMenu;
             protected override bool CanBegin => IsPanningAllowed();
+            protected override bool IsToggle => EnableToggledPanningMode;
 
             protected override bool CanCancel => NodifyEditor.AllowPanningCancellation;
 

--- a/Nodify/Editor/States/PushingItems.cs
+++ b/Nodify/Editor/States/PushingItems.cs
@@ -14,6 +14,7 @@ namespace Nodify.Interactivity
         {
             protected override bool HasContextMenu => Element.HasContextMenu;
             protected override bool CanCancel => NodifyEditor.AllowPushItemsCancellation;
+            protected override bool IsToggle => EnableToggledPushingItemsMode;
 
             private Point _prevPosition;
 

--- a/Nodify/Editor/States/PushingItems.cs
+++ b/Nodify/Editor/States/PushingItems.cs
@@ -13,6 +13,7 @@ namespace Nodify.Interactivity
         public class PushingItems : DragState<NodifyEditor>
         {
             protected override bool HasContextMenu => Element.HasContextMenu;
+            protected override bool CanBegin => !Element.IsSelecting && !Element.IsPanning && !Element.IsCutting;
             protected override bool CanCancel => NodifyEditor.AllowPushItemsCancellation;
             protected override bool IsToggle => EnableToggledPushingItemsMode;
 

--- a/Nodify/Editor/States/Selecting.cs
+++ b/Nodify/Editor/States/Selecting.cs
@@ -11,8 +11,9 @@ namespace Nodify.Interactivity
         public class Selecting : DragState<NodifyEditor>
         {
             protected override bool HasContextMenu => Element.HasContextMenu;
-            protected override bool CanBegin => Element.CanSelectMultipleItems && !Element.IsPanning;
+            protected override bool CanBegin => Element.CanSelectMultipleItems && !Element.IsPanning && !Element.IsCutting && !Element.IsPushingItems;
             protected override bool CanCancel => NodifyEditor.AllowSelectionCancellation;
+            protected override bool IsToggle => EnableToggledSelectingMode;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="Selecting"/> class.

--- a/Nodify/Editor/States/Zooming.cs
+++ b/Nodify/Editor/States/Zooming.cs
@@ -35,7 +35,8 @@ namespace Nodify.Interactivity
                 return !Element.DisableZooming
                     && (AllowZoomingWhileSelecting || !Element.IsSelecting)
                     && (AllowZoomingWhileCutting || !Element.IsCutting)
-                    && (AllowZoomingWhilePushingItems || !Element.IsPushingItems);
+                    && (AllowZoomingWhilePushingItems || !Element.IsPushingItems)
+                    && (AllowZoomingWhilePanning || !Element.IsPanning);
             }
         }
     }

--- a/Nodify/Editor/States/Zooming.cs
+++ b/Nodify/Editor/States/Zooming.cs
@@ -22,12 +22,20 @@ namespace Nodify.Interactivity
             protected override void OnMouseWheel(MouseWheelEventArgs e)
             {
                 EditorGestures.NodifyEditorGestures gestures = EditorGestures.Mappings.Editor;
-                if (gestures.ZoomModifierKey == Keyboard.Modifiers)
+                if (gestures.ZoomModifierKey == Keyboard.Modifiers && IsZoomingAllowed())
                 {
                     double zoom = Math.Pow(2.0, e.Delta / 3.0 / Mouse.MouseWheelDeltaForOneLine);
                     Element.ZoomAtPosition(zoom, Element.MouseLocation);
                     e.Handled = true;
                 }
+            }
+
+            private bool IsZoomingAllowed()
+            {
+                return !Element.DisableZooming
+                    && (AllowZoomingWhileSelecting || !Element.IsSelecting)
+                    && (AllowZoomingWhileCutting || !Element.IsCutting)
+                    && (AllowZoomingWhilePushingItems || !Element.IsPushingItems);
             }
         }
     }

--- a/Nodify/Interactivity/DragState.cs
+++ b/Nodify/Interactivity/DragState.cs
@@ -4,46 +4,46 @@ using System.Windows.Input;
 namespace Nodify.Interactivity
 {
     /// <summary>
-    /// Represents an abstract base class for managing drag operations within a UI element.
-    /// Provides a framework for handling input gestures such as starting, canceling, and completing drag operations.
+    /// Represents an abstract base class for managing drag interactions within a UI element.
+    /// Provides a framework for handling input gestures such as starting, canceling, and completing drag interactions.
     /// </summary>
     /// <typeparam name="TElement">The type of <see cref="FrameworkElement"/> that owns the state.</typeparam>
     public abstract class DragState<TElement> : InputElementState<TElement>, IInputHandler
         where TElement : FrameworkElement
     {
         /// <summary>
-        /// Gets the gesture used to cancel the drag operation, if defined.
+        /// Gets the gesture used to cancel the drag interaction, if defined.
         /// </summary>
         protected InputGesture? CancelGesture { get; }
 
         /// <summary>
-        /// Gets the gesture used to begin the drag operation.
+        /// Gets the gesture used to begin the drag interaction.
         /// </summary>
         protected InputGesture BeginGesture { get; }
 
         /// <summary>
         /// Indicates whether the element has a context menu associated with it.
         /// </summary>
-        /// <remarks>This property is used to suppress the context menu when a drag operation is performed using the right mouse button.</remarks>
+        /// <remarks>This property is used to suppress the context menu when a drag interaction is performed using the right mouse button.</remarks>
         protected virtual bool HasContextMenu => Element.ContextMenu != null;
 
         /// <summary>
-        /// Determines if the drag operation can begin (see <see cref="OnBegin(InputEventArgs)"/>).
+        /// Determines if the drag interaction can begin (see <see cref="OnBegin(InputEventArgs)"/>).
         /// </summary>
         protected virtual bool CanBegin { get; } = true;
 
         /// <summary>
-        /// Determines if the drag operation can be canceled (see <see cref="OnCancel(InputEventArgs)"/>).
+        /// Determines if the drag interaction can be canceled (see <see cref="OnCancel(InputEventArgs)"/>).
         /// </summary>
         protected virtual bool CanCancel { get; } = true;
 
         /// <summary>
-        /// Indicates if the drag gesture is a toggle, meaning the same gesture can be used to both start and stop the operation.
+        /// Indicates if the drag gesture is a toggle, meaning the same gesture can be used to both start and stop the interaction.
         /// </summary>
         protected virtual bool IsToggle { get; }
 
         /// <summary>
-        /// Gets or sets the UI element used to calculate the mouse position during the drag operation.
+        /// Gets or sets the UI element used to calculate the mouse position during the drag interaction.
         /// </summary>
         protected IInputElement PositionElement { get; set; }
 
@@ -54,7 +54,7 @@ namespace Nodify.Interactivity
         /// Initializes a new instance of the <see cref="DragState{TElement}"/> class with a begin gesture.
         /// </summary>
         /// <param name="element">The element associated with this state.</param>
-        /// <param name="beginGesture">The gesture used to start the drag operation.</param>
+        /// <param name="beginGesture">The gesture used to start the drag interaction.</param>
         public DragState(TElement element, InputGesture beginGesture) : base(element)
         {
             BeginGesture = beginGesture;
@@ -65,8 +65,8 @@ namespace Nodify.Interactivity
         /// Initializes a new instance of the <see cref="DragState{TElement}"/> class with begin and cancel gestures.
         /// </summary>
         /// <param name="element">The element associated with this state.</param>
-        /// <param name="beginGesture">The gesture used to start the drag operation.</param>
-        /// <param name="cancelGesture">The gesture used to cancel the drag operation.</param>
+        /// <param name="beginGesture">The gesture used to start the drag interaction.</param>
+        /// <param name="cancelGesture">The gesture used to cancel the drag interaction.</param>
         public DragState(TElement element, InputGesture beginGesture, InputGesture cancelGesture)
             : this(element, beginGesture)
         {
@@ -196,25 +196,25 @@ namespace Nodify.Interactivity
         }
 
         /// <summary>
-        /// Called when the drag operation begins. Override to provide custom behavior.
+        /// Called when the drag interaction begins. Override to provide custom behavior.
         /// </summary>
-        /// <param name="e">The input event that started the operation.</param>
+        /// <param name="e">The input event that started the interaction.</param>
         protected virtual void OnBegin(InputEventArgs e)
         {
         }
 
         /// <summary>
-        /// Called when the drag operation ends. Override to provide custom behavior.
+        /// Called when the drag interaction ends. Override to provide custom behavior.
         /// </summary>
-        /// <param name="e">The input event that ended the operation.</param>
+        /// <param name="e">The input event that ended the interaction.</param>
         protected virtual void OnEnd(InputEventArgs e)
         {
         }
 
         /// <summary>
-        /// Called when the drag operation is canceled. Override to provide custom behavior.
+        /// Called when the drag interaction is canceled. Override to provide custom behavior.
         /// </summary>
-        /// <param name="e">The input event that canceled the operation.</param>
+        /// <param name="e">The input event that canceled the interaction.</param>
         protected virtual void OnCancel(InputEventArgs e)
         {
         }

--- a/Nodify/Interactivity/InputElementStateStack.DragState.cs
+++ b/Nodify/Interactivity/InputElementStateStack.DragState.cs
@@ -6,7 +6,7 @@ namespace Nodify.Interactivity
     public partial class InputElementStateStack<TElement> where TElement : FrameworkElement
     {
         /// <summary>
-        /// Represents a specialized state for handling drag operations.
+        /// Represents a specialized state for handling drag interactions.
         /// </summary>
         public abstract class DragState : InputElementState, IInputHandler
         {
@@ -26,7 +26,7 @@ namespace Nodify.Interactivity
             protected virtual bool HasContextMenu => Element.ContextMenu != null;
 
             /// <summary>
-            /// Gets or sets whether the drag operation can be canceled.
+            /// Gets or sets whether the drag interaction can be canceled.
             /// </summary>
             protected virtual bool CanCancel { get; } = true;
 
@@ -166,25 +166,25 @@ namespace Nodify.Interactivity
             }
 
             /// <summary>
-            /// Called when the drag operation begins. Override to provide custom behavior.
+            /// Called when the drag interaction begins. Override to provide custom behavior.
             /// </summary>
-            /// <param name="e">The input event that started the operation.</param>
+            /// <param name="e">The input event that started the interaction.</param>
             protected virtual void OnBegin(IInputElementState? from)
             {
             }
 
             /// <summary>
-            /// Called when the drag operation ends. Override to provide custom behavior.
+            /// Called when the drag interaction ends. Override to provide custom behavior.
             /// </summary>
-            /// <param name="e">The input event that ended the operation.</param>
+            /// <param name="e">The input event that ended the interaction.</param>
             protected virtual void OnEnd(InputEventArgs e)
             {
             }
 
             /// <summary>
-            /// Called when the drag operation is canceled. Override to provide custom behavior.
+            /// Called when the drag interaction is canceled. Override to provide custom behavior.
             /// </summary>
-            /// <param name="e">The input event that canceled the operation.</param>
+            /// <param name="e">The input event that canceled the interaction.</param>
             protected virtual void OnCancel(InputEventArgs e)
             {
             }

--- a/Nodify/Interactivity/InputProcessor.cs
+++ b/Nodify/Interactivity/InputProcessor.cs
@@ -6,7 +6,7 @@ namespace Nodify.Interactivity
     /// <summary>
     /// Processes input events and delegates them to registered handlers.
     /// </summary>
-    public sealed partial class InputProcessor
+    public partial class InputProcessor
     {
         private readonly HashSet<IInputHandler> _handlers = new HashSet<IInputHandler>();
 

--- a/Nodify/Minimap/States/MinimapState.cs
+++ b/Nodify/Minimap/States/MinimapState.cs
@@ -2,6 +2,11 @@
 {
     public static partial class MinimapState
     {
+        /// <summary>
+        /// Determines whether toggled panning mode is enabled, allowing the user to start and end the interaction in two steps with the same input gesture.
+        /// </summary>
+        public static bool EnableToggledPanningMode { get; set; }
+
         internal static void RegisterDefaultHandlers()
         {
             InputProcessor.Shared<Minimap>.RegisterHandlerFactory(elem => new Panning(elem));

--- a/Nodify/Minimap/States/Panning.cs
+++ b/Nodify/Minimap/States/Panning.cs
@@ -9,8 +9,9 @@ namespace Nodify.Interactivity
         /// </summary>
         public class Panning : DragState<Minimap>
         {
-            protected override bool CanCancel => Minimap.AllowPanningCancellation;
             protected override bool CanBegin => !Element.IsReadOnly;
+            protected override bool CanCancel => Minimap.AllowPanningCancellation;
+            protected override bool IsToggle => EnableToggledPanningMode;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="Panning"/> class.


### PR DESCRIPTION
### 📝 Description of the Change

This PR consolidates the input system while enabling **toggled interactions** for various editor operations. The new toggled interaction modes can be activated through both mouse and keyboard input combinations when the control has focus.

New `BaseConnection` properties:
- `HasCustomContextMenu`

New `EditorState` configuration:
- `AllowPanningWhileSelecting`
- `AllowPanningWhileCutting`
- `AllowPanningWhilePushingItems`
- `AllowZoomingWhilePanning`
- `AllowZoomingWhileSelecting`
- `AllowZoomingWhileCutting`
- `AllowZoomingWhilePushingItems`
- `EnableToggledSelectingMode`
- `EnableToggledPanningMode`
- `EnableToggledPushingItemsMode`
- `EnableToggledCuttingMode`

New `MinimapState` configuration:
- `EnableToggledPanningMode`

New `ConnectorState` configuration
- `EnabledToggledConnectingMode`

Related #146

### 🐛 Possible Drawbacks

Increased code complexity for maintainers.
