### PR TITLE
Retarget connections in Playground app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 >	- Added Select, BeginDragging, UpdateDragging, EndDragging and CancelDragging to ItemContainer
 >	- Added PreserveSelectionOnRightClick configuration field to ItemContainer
 >	- Added BeginConnecting, UpdatePendingConnection, EndConnecting, CancelConnecting and RemoveConnections methods to Connector
+>	- Added FindTargetConnector and FindConnectionTarget methods to Connector
 >	- Added a custom MouseGesture with support for key combinations
 >	- Added InputProcessor to NodifyEditor, ItemContainer, Connector, BaseConnection and Minimap, enabling the extension of controls with custom states
 >	- Added DragState to simplify creating click-and-drag operations, with support for initiating and completing them using the keyboard
@@ -43,6 +44,7 @@
 >	- Added EnableToggledSelectingMode, EnableToggledPanningMode, EnableToggledPushingItemsMode and EnableToggledCuttingMode to EditorState
 >	- Added MinimapState.EnableToggledPanningMode
 >	- Added Unbind to InputGestureRef and EditorGestures.SelectionGestures
+>	- Added EnableHitTesting to PendingConnection
 > - Bugfixes:
 >	- Fixed an issue where the ItemContainer was selected by releasing the mouse button on it, even when the mouse was not captured
 >	- Fixed an issue where the ItemContainer could open its context menu even when it was not selected

--- a/Examples/Nodify.Playground/Editor/GraphSchema.cs
+++ b/Examples/Nodify.Playground/Editor/GraphSchema.cs
@@ -109,5 +109,25 @@ namespace Nodify.Playground
 
             nodes[0].Graph.Nodes.Add(comment);
         }
+
+        /// <summary>
+        /// Rewires all connections from the source connector to the target connector if possible.
+        /// </summary>
+        /// <remarks>The source must be an input connector.</remarks>
+        public void Rewire(ConnectorViewModel source, ConnectorViewModel target)
+        {
+            if (source == target || source.Flow != ConnectorFlow.Input)
+                return;
+
+            var connectionsToRewire = source.Connections.ToList();
+            foreach (var connection in connectionsToRewire)
+            {
+                if (CanAddConnection(connection.Output, target))
+                {
+                    source.Node.Graph.Connections.Remove(connection);
+                    AddConnection(connection.Output, target);
+                }
+            }
+        }
     }
 }

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml.cs
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Nodify.Events;
+using Nodify.Interactivity;
 using System.Windows.Controls;
 
 namespace Nodify.Playground
@@ -10,6 +11,11 @@ namespace Nodify.Playground
         public NodifyEditorView()
         {
             InitializeComponent();
+        }
+
+        static NodifyEditorView()
+        {
+            InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new ReconnectingConnectors(elem));
         }
 
         private void Minimap_Zoom(object sender, ZoomEventArgs e)

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml.cs
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml.cs
@@ -15,7 +15,7 @@ namespace Nodify.Playground
 
         static NodifyEditorView()
         {
-            InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new ReconnectingConnectors(elem));
+            InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new RetargetConnections(elem));
         }
 
         private void Minimap_Zoom(object sender, ZoomEventArgs e)

--- a/Examples/Nodify.Playground/Editor/ReconnectingConnectors.cs
+++ b/Examples/Nodify.Playground/Editor/ReconnectingConnectors.cs
@@ -1,0 +1,106 @@
+﻿using Nodify.Interactivity;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Nodify.Playground
+{
+    /// <summary>
+    /// Hold CTRL+LeftClick on a connector to start reconnecting it.
+    /// </summary>
+    public class ReconnectingConnectors : DragState<Connector>
+    {
+        public static InputGestureRef Reconnect { get; } = new Interactivity.MouseGesture(MouseAction.LeftClick, ModifierKeys.Control);
+
+        protected override bool CanBegin => ViewModel.IsConnected && ViewModel.Flow == ConnectorFlow.Input;
+
+        private ConnectorViewModel ViewModel => (ConnectorViewModel)Element.DataContext;
+        private Vector _connectorOffset;
+        private Connector? _targetConnector;
+
+        public ReconnectingConnectors(Connector element) : base(element, Reconnect, EditorGestures.Mappings.Connector.CancelAction)
+        {
+        }
+
+        protected override void OnBegin(InputEventArgs e)
+        {
+            _connectorOffset = ViewModel.Node.Orientation == Orientation.Horizontal
+                ? (Vector)EditorSettings.Instance.ConnectionTargetOffset.Value
+                : new Vector(EditorSettings.Instance.ConnectionTargetOffset.Value.Y, EditorSettings.Instance.ConnectionTargetOffset.Value.X);
+        }
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            var position = Element.Editor!.MouseLocation;
+
+            if (EditorSettings.Instance.EnablePendingConnectionHitTesting)
+            {
+                var connector = Element.FindTargetConnector(position);
+                connector?.UpdateAnchor();
+
+                SetTargetConnector(connector);
+                UpdateConnections(connector != null ? connector.Anchor : position + _connectorOffset);
+            }
+            else
+            {
+                UpdateConnections(position + _connectorOffset);
+            }
+        }
+
+        private void UpdateConnections(Point position)
+        {
+            foreach (var connection in ViewModel.Connections)
+            {
+                connection.Input.Anchor = position;
+            }
+        }
+
+        protected override void OnEnd(InputEventArgs e)
+        {
+            var position = Element.Editor!.MouseLocation;
+            var target = Element.FindTargetConnector(position);
+            target?.UpdateAnchor();
+
+            if (target?.DataContext is ConnectorViewModel targetVM && ViewModel != targetVM)
+            {
+                ViewModel.Node.Graph.Schema.Rewire(ViewModel, targetVM);
+            }
+
+            SetTargetConnector(null);
+
+            // Reset the position of connections that were not rewired
+            Element.UpdateAnchor();
+        }
+
+        protected override void OnCancel(InputEventArgs e)
+        {
+            SetTargetConnector(null);
+
+            // Reset the position of connections that were not rewired
+            Element.UpdateAnchor();
+        }
+
+        /// <summary>
+        /// Sets the connection target and updates the visual state of the target element.
+        /// </summary>
+        private void SetTargetConnector(Connector? target)
+        {
+            if (target == _targetConnector)
+            {
+                return;
+            }
+
+            if (_targetConnector != null)
+            {
+                PendingConnection.SetIsOverElement(_targetConnector, false);
+            }
+
+            if (target != null)
+            {
+                PendingConnection.SetIsOverElement(target, true);
+            }
+
+            _targetConnector = target;
+        }
+    }
+}

--- a/Examples/Nodify.Playground/Editor/RetargetConnections.cs
+++ b/Examples/Nodify.Playground/Editor/RetargetConnections.cs
@@ -8,7 +8,7 @@ namespace Nodify.Playground
     /// <summary>
     /// Hold CTRL+LeftClick on a connector to start reconnecting it.
     /// </summary>
-    public class ReconnectingConnectors : DragState<Connector>
+    public class RetargetConnections : DragState<Connector>
     {
         public static InputGestureRef Reconnect { get; } = new Interactivity.MouseGesture(MouseAction.LeftClick, ModifierKeys.Control);
 
@@ -18,7 +18,7 @@ namespace Nodify.Playground
         private Vector _connectorOffset;
         private Connector? _targetConnector;
 
-        public ReconnectingConnectors(Connector element) : base(element, Reconnect, EditorGestures.Mappings.Connector.CancelAction)
+        public RetargetConnections(Connector element) : base(element, Reconnect, EditorGestures.Mappings.Connector.CancelAction)
         {
         }
 

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -232,41 +232,6 @@ namespace Nodify.Playground
                     "Auto panning tick rate: ",
                     "How often is the new position calculated in milliseconds. Disable and enable auto panning for this to have effect."),
                 new ProxySettingViewModel<bool>(
-                    () => Instance.AllowMinimapPanningCancellation,
-                    val => Instance.AllowMinimapPanningCancellation = val,
-                    "Allow minimap panning cancellation: ",
-                    "Right click or escape to cancel panning."),
-                new ProxySettingViewModel<bool>(
-                    () => Instance.AllowCuttingCancellation,
-                    val => Instance.AllowCuttingCancellation = val,
-                    "Allow cutting cancellation: ",
-                    "Right click to cancel cutting."),
-                new ProxySettingViewModel<bool>(
-                    () => Instance.AllowPushItemsCancellation,
-                    val => Instance.AllowPushItemsCancellation = val,
-                    "Allow push nodes cancellation: ",
-                    "Right click to cancel pushing nodes."),
-                new ProxySettingViewModel<bool>(
-                    () => Instance.AllowPanningCancellation,
-                    val => Instance.AllowPanningCancellation= val,
-                    "Allow panning cancellation: ",
-                    "Press Escape to cancel panning."),
-                new ProxySettingViewModel<bool>(
-                    () => Instance.AllowSelectionCancellation,
-                    val => Instance.AllowSelectionCancellation = val,
-                    "Allow selection cancellation: ",
-                    "Press Escape to cancel selecting."),
-                new ProxySettingViewModel<bool>(
-                    () => Instance.AllowDraggingCancellation,
-                    val => Instance.AllowDraggingCancellation = val,
-                    "Allow dragging cancellation: ",
-                    "Right click to cancel dragging."),
-                new ProxySettingViewModel<bool>(
-                    () => Instance.AllowPendingConnectionCancellation,
-                    val => Instance.AllowPendingConnectionCancellation = val,
-                    "Allow pending connection cancellation: ",
-                    "Right click to cancel pending connection."),
-                new ProxySettingViewModel<bool>(
                     () => Instance.EnableSnappingCorrection,
                     val => Instance.EnableSnappingCorrection = val,
                     "Enable snapping correction: ",
@@ -276,6 +241,11 @@ namespace Nodify.Playground
                     val => Instance.EnableCuttingLinePreview = val,
                     "Enable cutting line preview: ",
                     "Applies custom connection style on intersection (hurts performance due to hit testing)."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.EnablePendingConnectionHitTesting,
+                    val => Instance.EnablePendingConnectionHitTesting = val,
+                    "Enable pending connection hit testing: ",
+                    "Disable to improve performance."),
                 new ProxySettingViewModel<bool>(
                     () => Instance.EnableConnectorOptimizations,
                     val => Instance.EnableConnectorOptimizations = val,
@@ -316,6 +286,41 @@ namespace Nodify.Playground
                     val => Instance.FitToScreenExtentMargin = val,
                     "Fit to screen extent margin: ",
                     "Adds some margin to the nodes extent when fit to screen"),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowMinimapPanningCancellation,
+                    val => Instance.AllowMinimapPanningCancellation = val,
+                    "Allow minimap panning cancellation: ",
+                    "Right click or escape to cancel panning."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowCuttingCancellation,
+                    val => Instance.AllowCuttingCancellation = val,
+                    "Allow cutting cancellation: ",
+                    "Right click to cancel cutting."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowPushItemsCancellation,
+                    val => Instance.AllowPushItemsCancellation = val,
+                    "Allow push nodes cancellation: ",
+                    "Right click to cancel pushing nodes."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowPanningCancellation,
+                    val => Instance.AllowPanningCancellation= val,
+                    "Allow panning cancellation: ",
+                    "Press Escape to cancel panning."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowSelectionCancellation,
+                    val => Instance.AllowSelectionCancellation = val,
+                    "Allow selection cancellation: ",
+                    "Press Escape to cancel selecting."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowDraggingCancellation,
+                    val => Instance.AllowDraggingCancellation = val,
+                    "Allow dragging cancellation: ",
+                    "Right click to cancel dragging."),
+                new ProxySettingViewModel<bool>(
+                    () => Instance.AllowPendingConnectionCancellation,
+                    val => Instance.AllowPendingConnectionCancellation = val,
+                    "Allow pending connection cancellation: ",
+                    "Right click to cancel pending connection."),
                 new ProxySettingViewModel<bool>(
                     () => Instance.EnableToggledCutting,
                     val => Instance.EnableToggledCutting = val,
@@ -741,6 +746,12 @@ namespace Nodify.Playground
         {
             get => NodifyEditor.EnableCuttingLinePreview;
             set => NodifyEditor.EnableCuttingLinePreview = value;
+        }
+
+        public bool EnablePendingConnectionHitTesting
+        {
+            get => PendingConnection.EnableHitTesting;
+            set => PendingConnection.EnableHitTesting = value;
         }
 
         public bool EnableConnectorOptimizations

--- a/Nodify/Connectors/States/Connecting.cs
+++ b/Nodify/Connectors/States/Connecting.cs
@@ -36,9 +36,7 @@ namespace Nodify.Interactivity
 
             protected override void OnMouseMove(MouseEventArgs e)
             {
-                Vector thumbOffset = e.GetPosition(Element.Thumb) - new Point(Element.Thumb.ActualWidth / 2, Element.Thumb.ActualHeight / 2);
-                Point editorPosition = Element.Anchor + thumbOffset;
-
+                Point editorPosition = Element.GetLocationInsideEditor(e);  // could also use Element.Editor.MouseLocation
                 Element.UpdatePendingConnection(editorPosition);
             }
         }


### PR DESCRIPTION
### 📝 Description of the Change

Adds an example of how to retarget connections in the Playground application (see `RetargetConnections`) using the new input system. 

Use `CTRL+LeftClick` to retarget connections.

New `Connector` methods:
- `FindTargetConnector`
- `FindConnectionTarget`

New `PendingConnection` flags:
- `EnableHitTesting`

![rewire](https://github.com/user-attachments/assets/d5d43d31-414f-4e05-877a-f959d1bf042e)

Closes #146, #87

### 🐛 Possible Drawbacks

None.
