### PR TITLE
Improved support for toggled interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@
 >	- Renamed PushItems to UpdatePushedArea and StartPushingItems to BeginPushingItems in NodifyEditor
 >	- Renamed UnselectAllConnection to UnselectAllConnections in NodifyEditor
 >	- Removed DragStarted, DragDelta and DragCompleted routed events from ItemContainer
->	- Replaced the System.Windows.Input.MouseGesture with Nodify.MouseGesture
+>	- Replaced the System.Windows.Input.MouseGesture with Nodify.Interactivity.MouseGesture for default EditorGesture mappings
 >	- Removed State, GetInitialState, PushState, PopState and PopAllStates from NodifyEditor and ItemContainer
 >	- Replaced EditorState and ContainerState with InputElementState
 >	- Moved AllowCuttingCancellation from CuttingLine to NodifyEditor
 >	- Moved AllowDraggingCancellation from ItemContainer to NodifyEditor
 >	- Moved EditorGestures under the Nodify.Interactivity namespace
->	- Moved Editor events under the Nodify.Events namespace
+>	- Moved editor events under the Nodify.Events namespace
 > - Features:
 >	- Added BeginPanning, UpdatePanning, EndPanning, CancelPanning and AllowPanningCancellation to NodifyEditor and Minimap
 >	- Added MouseLocation, ZoomAtPosition and GetLocationInsideMinimap to Minimap
@@ -34,8 +34,8 @@
 >	- Added FindTargetConnector and FindConnectionTarget methods to Connector
 >	- Added a custom MouseGesture with support for key combinations
 >	- Added InputProcessor to NodifyEditor, ItemContainer, Connector, BaseConnection and Minimap, enabling the extension of controls with custom states
->	- Added DragState to simplify creating click-and-drag operations, with support for initiating and completing them using the keyboard
->	- Added InputElementStateStack to manage transitions between states in UI elements
+>	- Added DragState to simplify creating click-and-drag interactions, with support for initiating and completing them using the keyboard
+>	- Added InputElementStateStack, InputElementStateStack.DragState and InputElementStateStack.InputElementState to manage transitions between states in UI elements
 >	- Added InputProcessor.Shared to enable the addition of global input handlers
 >	- Move the viewport to the mouse position when zooming on the Minimap if ResizeToViewport is false
 >	- Added SplitAtLocation and Remove methods to BaseConnection
@@ -43,6 +43,7 @@
 >	- Added AllowZoomingWhilePanning, AllowZoomingWhileSelecting, AllowZoomingWhileCutting and AllowZoomingWhilePushingItems to EditorState
 >	- Added EnableToggledSelectingMode, EnableToggledPanningMode, EnableToggledPushingItemsMode and EnableToggledCuttingMode to EditorState
 >	- Added MinimapState.EnableToggledPanningMode
+>	- Added ContainerState.EnableToggledDraggingMode
 >	- Added Unbind to InputGestureRef and EditorGestures.SelectionGestures
 >	- Added EnableHitTesting to PendingConnection
 > - Bugfixes:
@@ -54,7 +55,8 @@
 >	- Fixed an issue where controls would capture the mouse unnecessarily; they now capture it only in response to a defined gesture
 >	- Fixed an issue where the minimap could update the viewport without having the mouse captured
 >	- Fixed ItemContainer.Select and NodifyEditor.SelectArea to clear the existing selection and select the containers within the same transaction
->	- Fixed an issue where editor operations failed to cancel upon losing mouse capture
+>	- Fixed an issue where editor interactions failed to cancel upon losing mouse capture
+>	- Fixed an issue where selecting a new connection would not clear the previous selection within the same transaction
 	
 #### **Version 6.6.0**
 

--- a/Examples/Nodify.Calculator/EditorView.xaml
+++ b/Examples/Nodify.Calculator/EditorView.xaml
@@ -209,7 +209,8 @@
                             </DataTemplate>
                         </nodify:GroupingNode.HeaderTemplate>
                         <Grid>
-                            <ScrollViewer CanContentScroll="True">
+                            <ScrollViewer CanContentScroll="True"
+                                          Visibility="{Binding IsExpanded, Converter={shared:BooleanToVisibilityConverter}}">
                                 <nodify:NodifyEditor Tag="{Binding DataContext, RelativeSource={RelativeSource Self}}"
                                                      DataContext="{Binding InnerCalculator}"
                                                      ItemsSource="{Binding Operations}"
@@ -242,7 +243,7 @@
                                     </CompositeCollection>
                                 </nodify:NodifyEditor>
                             </ScrollViewer>
-                            
+
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml.cs
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml.cs
@@ -15,6 +15,7 @@ namespace Nodify.Playground
 
         static NodifyEditorView()
         {
+            InputProcessor.Shared<Connector>.ReplaceHandlerFactory<ConnectorState.Connecting>(elem => new CustomConnecting(elem));
             InputProcessor.Shared<Connector>.RegisterHandlerFactory(elem => new RetargetConnections(elem));
         }
 

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -342,6 +342,11 @@ namespace Nodify.Playground
                     "Enable toggled selecting mode: ",
                     "The interaction will be completed in two steps using the same gesture to start and end."),
                 new ProxySettingViewModel<bool>(
+                    () => Instance.EnableToggledDragging,
+                    val => Instance.EnableToggledDragging = val,
+                    "Enable toggled dragging mode: ",
+                    "The interaction will be completed in two steps using the same gesture to start and end."),
+                new ProxySettingViewModel<bool>(
                     () => Instance.EnableMinimapToggledPanning,
                     val => Instance.EnableMinimapToggledPanning = val,
                     "Enable minimap toggled panning mode: ",
@@ -830,6 +835,12 @@ namespace Nodify.Playground
         {
             get => EditorState.EnableToggledSelectingMode;
             set => EditorState.EnableToggledSelectingMode = value;
+        }
+
+        public bool EnableToggledDragging
+        {
+            get => ContainerState.EnableToggledDraggingMode;
+            set => ContainerState.EnableToggledDraggingMode = value;
         }
 
         public bool EnableMinimapToggledPanning

--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -811,7 +811,7 @@ namespace Nodify
             InputProcessor.ProcessEvent(e);
 
             // Release the mouse capture if all the mouse buttons are released
-            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released)
+            if (!InputProcessor.RequiresInputCapture && IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released)
             {
                 ReleaseMouseCapture();
             }
@@ -835,7 +835,7 @@ namespace Nodify
             InputProcessor.ProcessEvent(e);
 
             // Release the mouse capture if all the mouse buttons are released
-            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released)
+            if (!InputProcessor.RequiresInputCapture && IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released)
             {
                 ReleaseMouseCapture();
             }

--- a/Nodify/Connectors/Connector.cs
+++ b/Nodify/Connectors/Connector.cs
@@ -328,7 +328,7 @@ namespace Nodify
 
         #region Gesture Handling
 
-        protected InputProcessor InputProcessor { get; } = new InputProcessor { ProcessHandledEvents = true };
+        protected InputProcessor InputProcessor { get; } = new InputProcessor();
 
         /// <inheritdoc />
         protected override void OnMouseDown(MouseButtonEventArgs e)
@@ -340,7 +340,7 @@ namespace Nodify
             InputProcessor.ProcessEvent(e);
 
             // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
-            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
+            if (!InputProcessor.RequiresInputCapture && IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released)
             {
                 ReleaseMouseCapture();
             }
@@ -364,7 +364,7 @@ namespace Nodify
             InputProcessor.ProcessEvent(e);
 
             // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
-            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
+            if (!InputProcessor.RequiresInputCapture && IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released)
             {
                 ReleaseMouseCapture();
             }
@@ -373,14 +373,6 @@ namespace Nodify
         /// <inheritdoc />
         protected override void OnKeyDown(KeyEventArgs e)
             => InputProcessor.ProcessEvent(e);
-
-        /// <summary>
-        /// Determines whether any toggled interaction is currently in progress.
-        /// </summary>
-        protected virtual bool IsToggledInteractionInProgress()
-        {
-            return ConnectorState.EnableToggledConnectingMode && IsPendingConnection;
-        }
 
         #endregion
 

--- a/Nodify/Containers/ItemContainer.cs
+++ b/Nodify/Containers/ItemContainer.cs
@@ -372,7 +372,7 @@ namespace Nodify
             InputProcessor.ProcessEvent(e);
             
             // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
-            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
+            if (!InputProcessor.RequiresInputCapture && IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released)
             {
                 ReleaseMouseCapture();
             }
@@ -396,7 +396,7 @@ namespace Nodify
             InputProcessor.ProcessEvent(e);
 
             // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
-            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
+            if (!InputProcessor.RequiresInputCapture && IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released)
             {
                 ReleaseMouseCapture();
             }
@@ -405,11 +405,6 @@ namespace Nodify
         /// <inheritdoc />
         protected override void OnKeyDown(KeyEventArgs e)
             => InputProcessor.ProcessEvent(e);
-
-        /// <summary>
-        /// Determines whether any toggled interaction is currently in progress.
-        /// </summary>
-        protected virtual bool IsToggledInteractionInProgress() => false;
 
         #endregion
     }

--- a/Nodify/Containers/States/ContainerState.cs
+++ b/Nodify/Containers/States/ContainerState.cs
@@ -2,6 +2,11 @@
 {
     public static partial class ContainerState
     {
+        /// <summary>
+        /// Determines whether toggled dragging mode is enabled, allowing the user to start and end the interaction in two steps with the same input gesture.
+        /// </summary>
+        public static bool EnableToggledDraggingMode { get; set; }
+
         internal static void RegisterDefaultHandlers()
         {
             InputProcessor.Shared<ItemContainer>.RegisterHandlerFactory(elem => new Default(elem));

--- a/Nodify/Containers/States/Dragging.cs
+++ b/Nodify/Containers/States/Dragging.cs
@@ -9,6 +9,7 @@ namespace Nodify.Interactivity
         internal sealed class Dragging : InputElementStateStack<ItemContainer>.DragState
         {
             protected override bool CanCancel => NodifyEditor.AllowDraggingCancellation;
+            protected override bool IsToggle => EnableToggledDraggingMode;
 
             private Point _previousMousePosition;
 
@@ -20,13 +21,12 @@ namespace Nodify.Interactivity
                 PositionElement = Element.Editor;
             }
 
-            protected override void OnBegin(InputElementStateStack<ItemContainer>.IInputElementState? from)
+            protected override void OnBegin(InputEventArgs e)
             {
                 _previousMousePosition = Element.Editor.MouseLocation;
                 Element.BeginDragging();
             }
 
-            /// <inheritdoc />
             protected override void OnMouseMove(MouseEventArgs e)
             {
                 Element.UpdateDragging(Element.Editor.MouseLocation - _previousMousePosition);

--- a/Nodify/Editor/NodifyEditor.cs
+++ b/Nodify/Editor/NodifyEditor.cs
@@ -831,7 +831,7 @@ namespace Nodify
             InputProcessor.ProcessEvent(e);
 
             // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
-            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
+            if (!InputProcessor.RequiresInputCapture && IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released)
             {
                 ReleaseMouseCapture();
             }
@@ -861,7 +861,7 @@ namespace Nodify
             InputProcessor.ProcessEvent(e);
 
             // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
-            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
+            if (!InputProcessor.RequiresInputCapture && IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released)
             {
                 ReleaseMouseCapture();
             }
@@ -870,17 +870,6 @@ namespace Nodify
         /// <inheritdoc />
         protected override void OnKeyDown(KeyEventArgs e)
             => InputProcessor.ProcessEvent(e);
-
-        /// <summary>
-        /// Determines whether any toggled interaction is currently in progress.
-        /// </summary>
-        protected virtual bool IsToggledInteractionInProgress()
-        {
-            return EditorState.EnableToggledPanningMode && IsPanning
-                || EditorState.EnableToggledSelectingMode && IsSelecting
-                || EditorState.EnableToggledPushingItemsMode && IsPushingItems
-                || EditorState.EnableToggledCuttingMode && IsCutting;
-        }
 
         #endregion
 

--- a/Nodify/Interactivity/DragState.cs
+++ b/Nodify/Interactivity/DragState.cs
@@ -255,6 +255,15 @@ namespace Nodify.Interactivity
 
         #endregion
 
+        /// <summary>
+        /// Retrieves the initial position of the input event relative to the <see cref="PositionElement"/>.
+        /// </summary>
+        /// <param name="e">The <see cref="InputEventArgs"/> representing the input event.</param>
+        /// <remarks>
+        /// This position is used to calculate the drag distance, to determine whether 
+        /// the context menu can appear or if the action is considered a drag operation. The behavior is influenced 
+        /// by the <see cref="NodifyEditor.MouseActionSuppressionThreshold"/>.
+        /// </remarks>
         protected virtual Point GetInitialPosition(InputEventArgs e)
         {
             if (e is MouseEventArgs me)
@@ -265,16 +274,27 @@ namespace Nodify.Interactivity
             return default;
         }
 
+        /// <summary>
+        /// Determines whether input capture can be acquired for the <see cref="InputElementState{TElement}.Element" />.
+        /// </summary>
+        /// <param name="e">The <see cref="InputEventArgs"/> representing the input event.</param>
+        /// <remarks>Must return true if the input is already captured by the current element.</remarks>
         protected virtual bool CanCaptureInput(InputEventArgs e)
             => Mouse.Captured == null || Element.IsMouseCaptured;
 
+        /// <summary>
+        /// Captures input for the element.
+        /// </summary>
+        /// <param name="e">The <see cref="InputEventArgs"/> representing the input event.</param>
         protected virtual void CaptureInput(InputEventArgs e)
             => Element.CaptureMouse();
 
+        /// <summary>
+        /// Determines whether input capture has been lost.
+        /// </summary>
+        /// <param name="e">The <see cref="InputEventArgs"/> representing the input event.</param>
         protected virtual bool IsInputCaptureLost(InputEventArgs e)
-        {
-            return e.RoutedEvent == UIElement.LostMouseCaptureEvent;
-        }
+            => e.RoutedEvent == UIElement.LostMouseCaptureEvent;
 
         /// <summary>
         /// Determines if the given input event represents the release of an input gesture.

--- a/Nodify/Interactivity/IInputHandler.cs
+++ b/Nodify/Interactivity/IInputHandler.cs
@@ -11,6 +11,19 @@ namespace Nodify.Interactivity
         /// Handles a given input event, such as a mouse or keyboard interaction.
         /// </summary>
         /// <param name="e">The <see cref="InputEventArgs"/> representing the input event.</param>
+        /// <remarks>
+        /// This method is invoked when an input event is dispatched to the handler. Implementations should 
+        /// handle the event logic and optionally mark the event as handled.
+        /// </remarks>
         void HandleEvent(InputEventArgs e);
+
+        /// <summary>
+        /// Gets a value indicating whether the handler requires input capture to remain active.
+        /// </summary>
+        /// <remarks>
+        /// This property can be used to determine whether it is safe to release mouse capture, especially during toggled interactions. <br />
+        /// Toggled interactions usually involve two steps, and it is important to keep the input capture active until the interaction is completed.
+        /// </remarks>
+        bool RequiresInputCapture { get; }
     }
 }

--- a/Nodify/Interactivity/InputElementState.cs
+++ b/Nodify/Interactivity/InputElementState.cs
@@ -15,7 +15,7 @@ namespace Nodify.Interactivity
         /// </summary>
         protected TElement Element { get; }
 
-        public virtual bool RequiresInputCapture => false;
+        public bool RequiresInputCapture { get; protected set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InputElementState{TElement}"/> class.

--- a/Nodify/Interactivity/InputElementState.cs
+++ b/Nodify/Interactivity/InputElementState.cs
@@ -15,6 +15,8 @@ namespace Nodify.Interactivity
         /// </summary>
         protected TElement Element { get; }
 
+        public virtual bool RequiresInputCapture => false;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InputElementState{TElement}"/> class.
         /// </summary>

--- a/Nodify/Interactivity/InputElementStateStack.cs
+++ b/Nodify/Interactivity/InputElementStateStack.cs
@@ -18,6 +18,8 @@ namespace Nodify.Interactivity
         /// </summary>
         protected TElement Element { get; }
 
+        public bool RequiresInputCapture => State.RequiresInputCapture;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InputElementStateStack{TElement}"/> class.
         /// </summary>

--- a/Nodify/Interactivity/InputProcessor.Shared.cs
+++ b/Nodify/Interactivity/InputProcessor.Shared.cs
@@ -87,6 +87,17 @@ namespace Nodify.Interactivity
                 => _handlerFactories.RemoveAll(x => x.Key == typeof(THandler));
 
             /// <summary>
+            /// Replaces the registered factory method with another one of the same type.
+            /// </summary>
+            /// <typeparam name="THandler">The type of the input handler to replace.</typeparam>
+            public static void ReplaceHandlerFactory<THandler>(Func<TElement, THandler> factory)
+                where THandler : IInputHandler
+            {
+                int index = _handlerFactories.FindIndex(x => x.Key == typeof(THandler));
+                _handlerFactories[index] = new KeyValuePair<Type, Func<TElement, IInputHandler>>(typeof(THandler), elem => factory(elem));
+            }
+
+            /// <summary>
             /// Clears all registered handler factories, effectively removing all shared input handlers.
             /// </summary>
             public static void ClearHandlerFactories()

--- a/Nodify/Interactivity/InputProcessor.cs
+++ b/Nodify/Interactivity/InputProcessor.cs
@@ -8,7 +8,7 @@ namespace Nodify.Interactivity
     /// </summary>
     public partial class InputProcessor
     {
-        private readonly HashSet<IInputHandler> _handlers = new HashSet<IInputHandler>();
+        private readonly List<IInputHandler> _handlers = new List<IInputHandler>();
 
         /// <summary>
         /// Gets or sets a value indicating whether events that have been handled should be processed.
@@ -36,7 +36,7 @@ namespace Nodify.Interactivity
         /// </summary>
         /// <typeparam name="T">The type of the handler to remove.</typeparam>
         public void RemoveHandlers<T>() where T : IInputHandler
-            => _handlers.RemoveWhere(x => x.GetType() == typeof(T));
+            => _handlers.RemoveAll(x => x.GetType() == typeof(T));
 
         /// <summary>
         /// Clears all registered handlers.
@@ -52,23 +52,24 @@ namespace Nodify.Interactivity
         {
             RequiresInputCapture = false;
 
-            if (ProcessHandledEvents)
+            if (!ProcessHandledEvents)
             {
-                foreach (var handler in _handlers)
+                for (int i = 0; i < _handlers.Count; i++)
                 {
-                    handler.HandleEvent(e);
+                    IInputHandler handler = _handlers[i];
+                    if (!e.Handled)
+                    {
+                        handler.HandleEvent(e);
+                    }
+
                     RequiresInputCapture |= handler.RequiresInputCapture;
                 }
             }
             else
             {
-                foreach (var handler in _handlers)
+                for (int i = 0; i < _handlers.Count; i++)
                 {
-                    if (e.Handled)
-                    {
-                        break;
-                    }
-
+                    IInputHandler handler = _handlers[i];
                     handler.HandleEvent(e);
                     RequiresInputCapture |= handler.RequiresInputCapture;
                 }

--- a/Nodify/Interactivity/InputProcessor.cs
+++ b/Nodify/Interactivity/InputProcessor.cs
@@ -16,6 +16,15 @@ namespace Nodify.Interactivity
         public bool ProcessHandledEvents { get; set; }
 
         /// <summary>
+        /// Gets a value indicating whether the processor has ongoing interactions that require input capture to remain active.
+        /// </summary>
+        /// <remarks>
+        /// This property can be used to determine whether it is safe to release mouse capture, especially during toggled interactions. <br />
+        /// Toggled interactions usually involve two steps, and it is important to keep the input capture active until the interaction is completed.
+        /// </remarks>
+        public bool RequiresInputCapture { get; private set; }
+
+        /// <summary>
         /// Adds an input handler to the processor.
         /// </summary>
         /// <param name="handler">The input handler to add.</param>
@@ -41,11 +50,14 @@ namespace Nodify.Interactivity
         /// <param name="e">The input event arguments to process.</param>
         public void ProcessEvent(InputEventArgs e)
         {
+            RequiresInputCapture = false;
+
             if (ProcessHandledEvents)
             {
                 foreach (var handler in _handlers)
                 {
                     handler.HandleEvent(e);
+                    RequiresInputCapture |= handler.RequiresInputCapture;
                 }
             }
             else
@@ -58,6 +70,7 @@ namespace Nodify.Interactivity
                     }
 
                     handler.HandleEvent(e);
+                    RequiresInputCapture |= handler.RequiresInputCapture;
                 }
             }
         }

--- a/Nodify/Minimap/Minimap.cs
+++ b/Nodify/Minimap/Minimap.cs
@@ -160,7 +160,7 @@ namespace Nodify
             InputProcessor.ProcessEvent(e);
 
             // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
-            if (IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
+            if (!InputProcessor.RequiresInputCapture && IsMouseCaptured && e.RightButton == MouseButtonState.Released && e.LeftButton == MouseButtonState.Released && e.MiddleButton == MouseButtonState.Released)
             {
                 ReleaseMouseCapture();
             }
@@ -190,7 +190,7 @@ namespace Nodify
             InputProcessor.ProcessEvent(e);
 
             // Release the mouse capture if all the mouse buttons are released and there's no interaction in progress
-            if (IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released && !IsToggledInteractionInProgress())
+            if (!InputProcessor.RequiresInputCapture && IsMouseCaptured && Mouse.RightButton == MouseButtonState.Released && Mouse.LeftButton == MouseButtonState.Released && Mouse.MiddleButton == MouseButtonState.Released)
             {
                 ReleaseMouseCapture();
             }
@@ -199,14 +199,6 @@ namespace Nodify
         /// <inheritdoc />
         protected override void OnKeyDown(KeyEventArgs e)
             => InputProcessor.ProcessEvent(e);
-
-        /// <summary>
-        /// Determines whether any toggled interaction is currently in progress.
-        /// </summary>
-        protected virtual bool IsToggledInteractionInProgress()
-        {
-            return MinimapState.EnableToggledPanningMode && IsPanning;
-        }
 
         #endregion
 


### PR DESCRIPTION
### 📝 Description of the Change

Added `RequiresInputCapture` to `InputProcessor` and `IInputHandler`. This property ensures input capture (e.g., mouse capture) remains active during toggled interactions, preventing premature release.

Added `ReplaceHandlerFactory` to `InputProcessor` enabling users to replace built-in input handlers with custom implementations. 

Added the `EnableToggledDragging` property to `ContainerState`, enabling support for toggled dragging interactions. This allows users to perform drag operations in two steps:
- click and drag to initiate
- release the click and continue dragging before finalizing the action with another click

Related #146

### 🐛 Possible Drawbacks

None.
