### PR TITLE
Correct selection behavior for nodes and connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > - Breaking Changes:
 > - Features:
 > - Bugfixes:
+>	- Resolved an issue where selecting a node did not deselect connections and vice versa
 
 #### **Version 7.0.0**
 

--- a/Nodify/Connections/ConnectionsMultiSelector.cs
+++ b/Nodify/Connections/ConnectionsMultiSelector.cs
@@ -44,6 +44,11 @@ namespace Nodify
             set => base.CanSelectMultipleItems = value;
         }
 
+        /// <summary>
+        /// Gets the <see cref="NodifyEditor"/> that owns this <see cref="ConnectionsMultiSelector"/>.
+        /// </summary>
+        public NodifyEditor? Editor { get; private set; }
+
         protected override DependencyObject GetContainerForItemOverride()
             => new ConnectionContainer(this);
 
@@ -66,6 +71,15 @@ namespace Nodify
 #endif
 
             EndUpdateSelectedItems();
+
+            Editor?.UnselectAll();
+        }
+
+        public override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            Editor = this.GetParentOfType<NodifyEditor>();
         }
 
         #region Selection Handlers

--- a/Nodify/Editor/NodifyEditor.Selecting.cs
+++ b/Nodify/Editor/NodifyEditor.Selecting.cs
@@ -292,6 +292,8 @@ namespace Nodify
             selected.Clear();
             selected.Add(container.DataContext);
             EndUpdateSelectedItems();
+
+            UnselectAllConnections();
         }
 
         /// <summary>


### PR DESCRIPTION
### 📝 Description of the Change

This fix ensures that selecting a node will deselect all connections and vice versa when the `SelectionType` is `Replace`, which allows multi-selection as expected.

Fixes #188

### 🐛 Possible Drawbacks

Unexpected change in behavior.
