### PR TITLE
Fix an issue where connections would not gain focus when selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > - Breaking Changes:
 > - Features:
 > - Bugfixes:
+>	- Fixed an issue where connections would not gain focus when selected, which could prevent editor keybindings from functioning in certain scenarios
 
 #### **Version 7.0.0**
 

--- a/Nodify/Connections/ConnectionContainer.cs
+++ b/Nodify/Connections/ConnectionContainer.cs
@@ -75,6 +75,11 @@ namespace Nodify
 
         private SelectionType? _selectionType;
 
+        static ConnectionContainer()
+        {
+            FocusableProperty.OverrideMetadata(typeof(ConnectionContainer), new FrameworkPropertyMetadata(BoxValue.True));
+        }
+
         internal ConnectionContainer(ConnectionsMultiSelector selector)
         {
             Selector = selector;


### PR DESCRIPTION
### 📝 Description of the Change

Fix an issue where connections would not gain focus when selected, which could prevent editor key bindings from functioning in certain scenarios.

Fixes #187 

### 🐛 Possible Drawbacks

None.
