### PR TITLE
Fix issue with dragging item containers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 > - Bugfixes:
 >	- Fixed an issue where connections would not gain focus when selected, which could prevent editor keybindings from functioning in certain scenarios
 >	- Resolved an issue where selecting a node did not deselect connections and vice versa
->	- Fixed a bug preventing ItemContainers from being dragged when the mouse could not be captured
+>	- Fixed a bug preventing ItemContainers from being selected when the mouse could not be captured
+>	- Fixed an issue with key detection in Japanese IME environments, causing issues with the MouseGesture
 
 #### **Version 7.0.0**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 > - Bugfixes:
 >	- Fixed an issue where connections would not gain focus when selected, which could prevent editor keybindings from functioning in certain scenarios
 >	- Resolved an issue where selecting a node did not deselect connections and vice versa
+>	- Fixed a bug preventing ItemContainers from being dragged when the mouse could not be captured
 
 #### **Version 7.0.0**
 

--- a/Nodify/Containers/States/Default.cs
+++ b/Nodify/Containers/States/Default.cs
@@ -37,7 +37,7 @@ namespace Nodify.Interactivity
 
                 protected override void OnMouseDown(MouseButtonEventArgs e)
                 {
-                    if (!IsSelectable(e))
+                    if (!Element.IsSelectableLocation(e.GetPosition(Element)))
                     {
                         return;
                     }
@@ -45,7 +45,7 @@ namespace Nodify.Interactivity
                     EditorGestures.ItemContainerGestures gestures = EditorGestures.Mappings.ItemContainer;
                     if (gestures.Drag.Matches(e.Source, e))
                     {
-                        _isDragging = Element.IsDraggable && CaptureMouseSafe();
+                        _isDragging = Element.IsDraggable;
                     }
 
                     if (gestures.Selection.Select.Matches(e.Source, e))
@@ -63,8 +63,8 @@ namespace Nodify.Interactivity
 
                     if (_isDragging || _selectionType.HasValue)
                     {
-                        Element.Focus();
                         e.Handled = true;
+                        CaptureMouseSafe();
                     }
                 }
 
@@ -107,31 +107,14 @@ namespace Nodify.Interactivity
                     _selectionType = null;
                 }
 
-                private bool IsSelectable(MouseButtonEventArgs e)
-                {
-                    if (!Element.IsSelectableLocation(e.GetPosition(Element)))
-                    {
-                        return false;
-                    }
-
-                    if (Mouse.Captured != null && !Element.IsMouseCaptured)
-                    {
-                        return false;
-                    }
-
-                    return true;
-                }
-
-                private bool CaptureMouseSafe()
+                private void CaptureMouseSafe()
                 {
                     // Avoid stealing mouse capture from other elements
                     if (Mouse.Captured == null || Element.IsMouseCaptured)
                     {
+                        Element.Focus();
                         Element.CaptureMouse();
-                        return true;
                     }
-
-                    return false;
                 }
 
                 private static SelectionType GetSelectionTypeForDragging(SelectionType? selectionType)

--- a/Nodify/Containers/States/Default.cs
+++ b/Nodify/Containers/States/Default.cs
@@ -45,7 +45,8 @@ namespace Nodify.Interactivity
                     EditorGestures.ItemContainerGestures gestures = EditorGestures.Mappings.ItemContainer;
                     if (gestures.Drag.Matches(e.Source, e))
                     {
-                        _isDragging = Element.IsDraggable;
+                        // Dragging requires mouse capture
+                        _isDragging = Element.IsDraggable && CanCaptureMouse();
                     }
 
                     if (gestures.Selection.Select.Matches(e.Source, e))
@@ -110,12 +111,15 @@ namespace Nodify.Interactivity
                 private void CaptureMouseSafe()
                 {
                     // Avoid stealing mouse capture from other elements
-                    if (Mouse.Captured == null || Element.IsMouseCaptured)
+                    if (CanCaptureMouse())
                     {
                         Element.Focus();
                         Element.CaptureMouse();
                     }
                 }
+
+                private bool CanCaptureMouse()
+                    => Mouse.Captured == null || Element.IsMouseCaptured;
 
                 private static SelectionType GetSelectionTypeForDragging(SelectionType? selectionType)
                 {

--- a/Nodify/Interactivity/Gestures/MouseGesture.cs
+++ b/Nodify/Interactivity/Gestures/MouseGesture.cs
@@ -99,31 +99,40 @@ namespace Nodify.Interactivity
                 return !IsAnyKeyPressed();
             }
 
-            return Keyboard.GetKeyStates(Key).HasFlag(KeyStates.Down);
+            return Keyboard.IsKeyDown(Key);
         }
 
-        private static readonly Key[] _allKeys = GetValidKeys();
-
-        private static Key[] GetValidKeys()
+        private static readonly Key[] _allKeys = new[]
         {
-            var excludedKeys = new[]
-            {
-                Key.LeftCtrl, Key.RightCtrl,
-                Key.LeftShift, Key.RightShift,
-                Key.LeftAlt, Key.RightAlt,
-                Key.LWin, Key.RWin,
-                Key.None
-            };
+            // Alphanumeric
+            Key.A, Key.B, Key.C, Key.D, Key.E, Key.F, Key.G, Key.H, Key.I, Key.J,
+            Key.K, Key.L, Key.M, Key.N, Key.O, Key.P, Key.Q, Key.R, Key.S, Key.T,
+            Key.U, Key.V, Key.W, Key.X, Key.Y, Key.Z,
+            Key.D0, Key.D1, Key.D2, Key.D3, Key.D4, Key.D5, Key.D6, Key.D7, Key.D8, Key.D9,
 
-#if NET5_0_OR_GREATER
-            return Enum.GetValues<Key>()
-#else
-            return Enum.GetValues(typeof(Key))
-                .Cast<Key>()
-#endif
-                .Where(key => !excludedKeys.Contains(key))
-                .ToArray();
-        }
+            // Punctuation and symbols
+            Key.Oem3, Key.OemMinus, Key.OemPlus, Key.OemOpenBrackets, Key.OemCloseBrackets,
+            Key.Oem5, Key.Oem1, Key.OemQuotes, Key.OemComma, Key.OemPeriod, Key.Oem2,
+
+            // Function keys
+            Key.F1, Key.F2, Key.F3, Key.F4, Key.F5, Key.F6, Key.F7, Key.F8,
+            Key.F9, Key.F10, Key.F11, Key.F12,
+
+            // Navigation
+            Key.Left, Key.Right, Key.Up, Key.Down,
+            Key.PageUp, Key.PageDown, Key.Home, Key.End,
+
+            // Editing
+            Key.Back, Key.Delete, Key.Insert,
+
+            // Special
+            Key.Space, Key.Return, Key.Escape, Key.Tab,
+
+            // Numeric keypad
+            Key.NumPad0, Key.NumPad1, Key.NumPad2, Key.NumPad3, Key.NumPad4,
+            Key.NumPad5, Key.NumPad6, Key.NumPad7, Key.NumPad8, Key.NumPad9,
+            Key.Multiply, Key.Add, Key.Subtract, Key.Divide, Key.Decimal
+        };
 
         /// <summary>
         /// Determines whether any key (excluding modifiers) is currently pressed.


### PR DESCRIPTION
### 📝 Description of the Change

- Fixed a bug that prevented `ItemContainer`s from being dragged in Japanese IME environments.
- Fixed a bug preventing `ItemContainer`s from being selected when the mouse could not be captured

Fixes #199 

### 🐛 Possible Drawbacks

None.