### PR TITLE
Raise ItemContainer Selected/Unselected events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 > - Breaking Changes:
 > - Features:
 > - Bugfixes:
+>	- Fixed an issue where the SelectedEvent and UnselectedEvent events on the ItemContainer were not raised when the selection was completed
 
 #### **Version 7.0.2**
 
-> - Breaking Changes:
 > - Features:
 >	- Added EditorGestures.Editor.SelectAll 
 > - Bugfixes:

--- a/Nodify/Editor/NodifyEditor.Selecting.cs
+++ b/Nodify/Editor/NodifyEditor.Selecting.cs
@@ -403,8 +403,8 @@ namespace Nodify
             }
 
             SelectedArea = _selection.End();
-            ApplyPreviewingSelection();
             IsSelecting = false;
+            ApplyPreviewingSelection();
         }
 
         /// <summary>


### PR DESCRIPTION
### 📝 Description of the Change

Fixed an issue where the `SelectedEvent` and `UnselectedEvent` events on the `ItemContainer` were not raised when the marquee selection was completed.

#210 

### 🐛 Possible Drawbacks

Could slightly affect performance when selecting and deselecting a large amount of nodes.
