### PR TITLE
Fixe the assumption that the ApplicationCommands.SelectAll is a KeyGesture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 > - Breaking Changes:
 > - Features:
+>	- Added AsRef extension method to InputGesture to convert it to an InputGestureRef
 > - Bugfixes:
+>	- Fixed an issue where the gesture used for EditorGestures.Editor.SelectAll extracted from the ApplicationCommands was assumed to be a KeyGesture
 
 #### **Version 7.0.3**
 

--- a/Nodify/Interactivity/Gestures/EditorGestures.cs
+++ b/Nodify/Interactivity/Gestures/EditorGestures.cs
@@ -150,7 +150,7 @@ namespace Nodify.Interactivity
             public NodifyEditorGestures()
             {
                 Selection = new SelectionGestures();
-                SelectAll = (KeyGesture)ApplicationCommands.SelectAll.InputGestures[0];
+                SelectAll = ApplicationCommands.SelectAll.InputGestures[0].AsRef();
                 Cutting = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Alt | ModifierKeys.Shift, true);
                 PushItems = new MouseGesture(MouseAction.LeftClick, ModifierKeys.Control | ModifierKeys.Shift, true);
                 Pan = new AnyGesture(new MouseGesture(MouseAction.RightClick), new MouseGesture(MouseAction.MiddleClick));

--- a/Nodify/Interactivity/Gestures/InputGestureRef.cs
+++ b/Nodify/Interactivity/Gestures/InputGestureRef.cs
@@ -13,6 +13,11 @@ namespace Nodify.Interactivity
 
         private InputGestureRef() { }
 
+        internal InputGestureRef(InputGesture gesture)
+        {
+            Value = gesture;
+        }
+
         public override bool Matches(object targetElement, InputEventArgs inputEventArgs)
         {
             return Value.Matches(targetElement, inputEventArgs);
@@ -35,5 +40,19 @@ namespace Nodify.Interactivity
         /// </summary>
         public void Unbind()
             => Value = MultiGesture.None;
+    }
+
+    /// <summary>
+    /// Extension methods for the <see cref="InputGestureRef"/> class.
+    /// </summary>
+    public static class InputGestureRefExtensions
+    {
+        /// <summary>
+        /// Creates a new <see cref="InputGestureRef"/> from the specified gesture.
+        /// </summary>
+        public static InputGestureRef AsRef(this InputGesture gesture)
+        {
+            return new InputGestureRef(gesture);
+        }
     }
 }


### PR DESCRIPTION
### 📝 Description of the Change

Adds `AsRef` extension method to `InputGesture` to convert it to an `InputGestureRef`.
Fixes the assumption that the `ApplicationCommands.SelectAll` is a `KeyGesture`.

Fixes #212

### 🐛 Possible Drawbacks

None.
