### PR TITLE
Fixed overrides of arrowhead virtual methods not working for connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 >	- Added AsRef extension method to InputGesture to convert it to an InputGestureRef
 > - Bugfixes:
 >	- Fixed an issue where the gesture used for EditorGestures.Editor.SelectAll extracted from the ApplicationCommands was assumed to be a KeyGesture
+>	- Fixed overrides of DrawDefaultArrowhead and DrawDirectionalArrowheadGeometry virtual methods not working in subclasses of the built in connections
 
 #### **Version 7.0.3**
 

--- a/Nodify/Connections/CircuitConnection.cs
+++ b/Nodify/Connections/CircuitConnection.cs
@@ -82,7 +82,7 @@ namespace Nodify
                 var (segment, to) = InterpolateLine(p0, p1, p2, t);
 
                 var direction = segment.SegmentStart - segment.SegmentEnd;
-                base.DrawDirectionalArrowheadGeometry(context, direction, to);
+                DrawDirectionalArrowheadGeometry(context, direction, to);
             }
         }
 

--- a/Nodify/Connections/Connection.cs
+++ b/Nodify/Connections/Connection.cs
@@ -42,7 +42,7 @@ namespace Nodify
                 var to = InterpolateCubicBezier(p0, p1, p2, p3, t);
                 var direction = GetBezierTangent(p0, p1, p2, p3, t);
 
-                base.DrawDirectionalArrowheadGeometry(context, direction, to);
+                DrawDirectionalArrowheadGeometry(context, direction, to);
             }
         }
 

--- a/Nodify/Connections/LineConnection.cs
+++ b/Nodify/Connections/LineConnection.cs
@@ -68,7 +68,7 @@ namespace Nodify
             }
             else
             {
-                base.DrawDefaultArrowhead(context, source, target, arrowDirection, orientation);
+                DrawDefaultArrowhead(context, source, target, arrowDirection, orientation);
             }
         }
 
@@ -83,7 +83,7 @@ namespace Nodify
                 double t = (spacing * i + DirectionalArrowsOffset).WrapToRange(0d, 1d);
                 var to = InterpolateLineSegment(p0, p1, t);
 
-                base.DrawDirectionalArrowheadGeometry(context, direction, to);
+                DrawDirectionalArrowheadGeometry(context, direction, to);
             }
         }
 

--- a/Nodify/Connections/StepConnection.cs
+++ b/Nodify/Connections/StepConnection.cs
@@ -163,7 +163,7 @@ namespace Nodify
                 var (segment, to) = InterpolateLine(p0, p1, p2, p3, t);
 
                 var direction = segment.SegmentStart - segment.SegmentEnd;
-                base.DrawDirectionalArrowheadGeometry(context, direction, to);
+                DrawDirectionalArrowheadGeometry(context, direction, to);
             }
         }
 


### PR DESCRIPTION
### 📝 Description of the Change

Fix overrides of `DrawDefaultArrowhead` and `DrawDirectionalArrowheadGeometry` virtual methods not working in sub-classes of the built-in connections.

Fixes #220

### 🐛 Possible Drawbacks

None.
