### PR TITLE
Add pending connection hot keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 >	- Added the KeyComboGesture that requires a trigger key to be held down before pressing a combo key
 >	- Added FocusVisualPen and FocusVisualPadding dependency properties to BaseConnection
 >	- Added default focus visuals for base editor controls that can be included by referencing the FocusVisual.xaml file
+>	- Added MaxHotKeys and HotKeysDisplayMode static configuration field to PendingConnection
+>	- Added HotKeyControl with its corresponding theme resources to display the hotkeys for a pending connection
 > - Bugfixes:
 
 #### **Version 7.0.4**

--- a/Examples/Nodify.Playground/App.xaml
+++ b/Examples/Nodify.Playground/App.xaml
@@ -29,6 +29,23 @@
                 <ResourceDictionary Source="pack://application:,,,/Nodify.Playground;component/Themes/Nodify.xaml" />
                 <ResourceDictionary>
                     <Color x:Key="NodifyEditor.FocusVisualColor">DodgerBlue</Color>
+
+                    <Style TargetType="{x:Type nodify:HotKeyControl}"
+                           BasedOn="{StaticResource {x:Type nodify:HotKeyControl}}">
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type nodify:HotKeyControl}">
+                                    <Border CornerRadius="3"
+                                            Background="OrangeRed">
+                                        <TextBlock Text="{Binding Number, RelativeSource={RelativeSource TemplatedParent}}"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"
+                                                   Foreground="White" />
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/Examples/Nodify.Playground/Editor/NodifyEditorViewModel.cs
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorViewModel.cs
@@ -18,7 +18,8 @@ namespace Nodify.Playground
             DeleteSelectionCommand = new DelegateCommand(DeleteSelection, () => SelectedNodes.Count > 0 || SelectedConnections.Count > 0);
             CommentSelectionCommand = new RequeryCommand(() => Schema.AddCommentAroundNodes(SelectedNodes, "New comment"), () => SelectedNodes.Count > 0);
             DisconnectConnectorCommand = new DelegateCommand<ConnectorViewModel>(c => c.Disconnect());
-            CreateConnectionCommand = new DelegateCommand<object>(target => Schema.TryAddConnection(PendingConnection.Source!, target), target => PendingConnection.Source != null && target != null);
+            CreateConnectionCommand = new DelegateCommand<object>(target => Schema.TryAddConnection(PendingConnection.Source!, target), 
+                target => PendingConnection.Source != null && target != null && Schema.CanAddConnection(PendingConnection.Source, target));
 
             Connections.WhenAdded(c =>
             {

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -228,11 +228,21 @@ namespace Nodify.Playground
 
             _advancedSettings = new List<ISettingViewModel>()
             {
+                new ProxySettingViewModel<uint>(
+                    () => Instance.MaxHotKeys,
+                    val => Instance.MaxHotKeys = val,
+                    "Max hot keys: ",
+                    "The maximum number of generated hot keys"),
+                new ProxySettingViewModel<HotKeysDisplayMode>(
+                    () => Instance.HotKeysDisplayMode,
+                    val => Instance.HotKeysDisplayMode = val,
+                    "Hot keys display mode: ",
+                    "Specifies how hotkeys are displayed for a pending connection."),
                 new ProxySettingViewModel<double>(
                     () => Instance.MouseActionSuppressionThreshold,
                     val => Instance.MouseActionSuppressionThreshold = val,
                     "Context menu suppression threshold: ",
-                    "Disable context menu after mouse moved this far"),
+                    "Disable context menu after mouse moved this far."),
                 new ProxySettingViewModel<bool>(
                     () => Instance.PreserveSelectionOnRightClick,
                     val => Instance.PreserveSelectionOnRightClick = val,
@@ -247,7 +257,7 @@ namespace Nodify.Playground
                     () => Instance.EnableSnappingCorrection,
                     val => Instance.EnableSnappingCorrection = val,
                     "Enable snapping correction: ",
-                    "Correct the final position when moving a selection"),
+                    "Correct the final position when moving a selection."),
                 new ProxySettingViewModel<bool>(
                     () => Instance.EnableCuttingLinePreview,
                     val => Instance.EnableCuttingLinePreview = val,
@@ -713,6 +723,18 @@ namespace Nodify.Playground
         #endregion
 
         #region Advanced settings
+
+        public uint MaxHotKeys
+        {
+            get => PendingConnection.MaxHotKeys;
+            set => PendingConnection.MaxHotKeys = value;
+        }
+
+        public HotKeysDisplayMode HotKeysDisplayMode
+        {
+            get => PendingConnection.HotKeysDisplayMode;
+            set => PendingConnection.HotKeysDisplayMode = value;
+        }
 
         public bool PreserveSelectionOnRightClick
         {

--- a/Examples/Nodify.Shapes/MainWindow.xaml.cs
+++ b/Examples/Nodify.Shapes/MainWindow.xaml.cs
@@ -12,6 +12,8 @@ namespace Nodify.Shapes
         {
             InitializeComponent();
 
+            PendingConnection.HotKeysDisplayMode = HotKeysDisplayMode.All;
+
             EventManager.RegisterClassHandler(
                     typeof(UIElement),
                     Keyboard.PreviewGotKeyboardFocusEvent,

--- a/Nodify/Connectors/HotKeyControl.cs
+++ b/Nodify/Connectors/HotKeyControl.cs
@@ -1,0 +1,21 @@
+﻿using System.Windows.Controls;
+using System.Windows;
+
+namespace Nodify
+{
+    public class HotKeyControl : Control
+    {
+        public static readonly DependencyProperty NumberProperty = DependencyProperty.Register(nameof(Number), typeof(int), typeof(HotKeyControl), new PropertyMetadata(BoxValue.Int0));
+
+        public int Number
+        {
+            get => (int)GetValue(NumberProperty);
+            set => SetValue(NumberProperty, value);
+        }
+
+        static HotKeyControl()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(HotKeyControl), new FrameworkPropertyMetadata(typeof(HotKeyControl)));
+        }
+    }
+}

--- a/Nodify/Interactivity/Gestures/EditorGestures.cs
+++ b/Nodify/Interactivity/Gestures/EditorGestures.cs
@@ -426,7 +426,7 @@ namespace Nodify.Interactivity
             public ConnectorGestures()
             {
                 Disconnect = new AnyGesture(new MouseGesture(MouseAction.LeftClick, ModifierKeys.Alt), new KeyGesture(Key.Delete));
-                Connect = new MouseGesture(MouseAction.LeftClick);
+                Connect = new AnyGesture(new MouseGesture(MouseAction.LeftClick), new KeyGesture(Key.Space));
                 CancelAction = new AnyGesture(new MouseGesture(MouseAction.RightClick), new KeyGesture(Key.Escape));
             }
 

--- a/Nodify/Themes/Brushes.xaml
+++ b/Nodify/Themes/Brushes.xaml
@@ -266,4 +266,18 @@
                      Color="{DynamicResource MinimapItem.BackgroundColor}"
                      Opacity="0.8" />
 
+    <!--HOT KEYS-->
+
+    <SolidColorBrush x:Key="HotKey.BackgroundBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource HotKey.BackgroundColor}" />
+
+    <SolidColorBrush x:Key="HotKey.ForegroundBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource HotKey.ForegroundColor}" />
+
+    <SolidColorBrush x:Key="HotKey.BorderBrush"
+                     o:Freeze="True"
+                     Color="{DynamicResource HotKey.BorderColor}" />
+
 </ResourceDictionary>

--- a/Nodify/Themes/Controls.xaml
+++ b/Nodify/Themes/Controls.xaml
@@ -254,4 +254,18 @@
                 Value="{StaticResource MinimapItem.BackgroundBrush}" />
     </Style>
 
+    <!--HOT KEYS-->
+
+    <Style TargetType="{x:Type local:HotKeyControl}"
+           BasedOn="{StaticResource {x:Type local:HotKeyControl}}">
+        <Setter Property="Background"
+                Value="{StaticResource HotKey.BackgroundBrush}" />
+        <Setter Property="Foreground"
+                Value="{StaticResource HotKey.ForegroundBrush}" />
+        <Setter Property="BorderBrush"
+                Value="{StaticResource HotKey.BorderBrush}" />
+        <Setter Property="BorderThickness"
+                Value="1" />
+    </Style>
+
 </ResourceDictionary>

--- a/Nodify/Themes/Dark.xaml
+++ b/Nodify/Themes/Dark.xaml
@@ -82,5 +82,10 @@
     <Color x:Key="Minimap.ViewportStrokeColor">#74747c</Color>
     <Color x:Key="Minimap.ViewportBackgroundColor">#74747c</Color>
     <Color x:Key="MinimapItem.BackgroundColor">DodgerBlue</Color>
-    
+
+    <!--HOT KEYS-->
+    <Color x:Key="HotKey.BackgroundColor">White</Color>
+    <Color x:Key="HotKey.ForegroundColor">Black</Color>
+    <Color x:Key="HotKey.BorderColor">DodgerBlue</Color>
+
 </ResourceDictionary>

--- a/Nodify/Themes/Light.xaml
+++ b/Nodify/Themes/Light.xaml
@@ -82,5 +82,10 @@
     <Color x:Key="Minimap.ViewportStrokeColor">DodgerBlue</Color>
     <Color x:Key="Minimap.ViewportBackgroundColor">DodgerBlue</Color>
     <Color x:Key="MinimapItem.BackgroundColor">#5c6a98</Color>
+
+    <!--HOT KEYS-->
+    <Color x:Key="HotKey.BackgroundColor">White</Color>
+    <Color x:Key="HotKey.ForegroundColor">Black</Color>
+    <Color x:Key="HotKey.BorderColor">#7EB4EA</Color>
     
 </ResourceDictionary>

--- a/Nodify/Themes/Nodify.xaml
+++ b/Nodify/Themes/Nodify.xaml
@@ -83,4 +83,9 @@
     <Color x:Key="Minimap.ViewportBackgroundColor">#9b44dd</Color>
     <Color x:Key="MinimapItem.BackgroundColor">#FD5618</Color>
 
+    <!--HOT KEYS-->
+    <Color x:Key="HotKey.BackgroundColor">White</Color>
+    <Color x:Key="HotKey.ForegroundColor">Black</Color>
+    <Color x:Key="HotKey.BorderColor">#FD5618</Color>
+
 </ResourceDictionary>

--- a/Nodify/Themes/Styles/Connector.xaml
+++ b/Nodify/Themes/Styles/Connector.xaml
@@ -41,4 +41,33 @@
         </Setter>
     </Style>
 
+    <Style TargetType="{x:Type local:HotKeyControl}">
+        <Setter Property="BorderBrush"
+                Value="DodgerBlue" />
+        <Setter Property="Background"
+                Value="White" />
+        <Setter Property="Foreground"
+                Value="Black" />
+        <Setter Property="Width"
+                Value="16" />
+        <Setter Property="Height"
+                Value="16" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type local:HotKeyControl}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            CornerRadius="3"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Width="{TemplateBinding Width}"
+                            Height="{TemplateBinding Height}">
+                        <TextBlock Text="{Binding Number, RelativeSource={RelativeSource TemplatedParent}}"
+                                   VerticalAlignment="Center"
+                                   HorizontalAlignment="Center" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
 </ResourceDictionary>

--- a/Nodify/Themes/Styles/NodeInput.xaml
+++ b/Nodify/Themes/Styles/NodeInput.xaml
@@ -64,6 +64,7 @@
                                      Focusable="False"
                                      Margin="0 0 5 0"
                                      VerticalAlignment="Center"
+                                     HorizontalAlignment="Center"
                                      Background="Transparent"
                                      BorderBrush="{TemplateBinding BorderBrush}"
                                      Template="{TemplateBinding ConnectorTemplate}" />

--- a/Nodify/Themes/Styles/NodeOutput.xaml
+++ b/Nodify/Themes/Styles/NodeOutput.xaml
@@ -67,6 +67,7 @@
                                      Focusable="False"
                                      Margin="5 0 0 0"
                                      VerticalAlignment="Center"
+                                     HorizontalAlignment="Center"
                                      Background="Transparent"
                                      BorderBrush="{TemplateBinding BorderBrush}"
                                      Template="{TemplateBinding ConnectorTemplate}" />

--- a/Nodify/Utilities/DependencyObjectExtensions.cs
+++ b/Nodify/Utilities/DependencyObjectExtensions.cs
@@ -118,6 +118,36 @@ namespace Nodify
             return result;
         }
 
+        public static IEnumerable<T> GetIntersectingElements<T>(this UIElement container, Rect area, Func<T, Rect> getBounds)
+            where T : Visual
+        {
+            var stack = new Stack<DependencyObject>();
+            stack.Push(container);
+
+            while (stack.Count > 0)
+            {
+                DependencyObject current = stack.Pop();
+                int childrenCount = VisualTreeHelper.GetChildrenCount(current);
+
+                for (int i = 0; i < childrenCount; i++)
+                {
+                    DependencyObject child = VisualTreeHelper.GetChild(current, i);
+
+                    if (child is T tChild)
+                    {
+                        var bounds = getBounds(tChild);
+                        if (bounds.IntersectsWith(area))
+                        {
+                            yield return tChild;
+                            continue;
+                        }
+                    }
+
+                    stack.Push(child);
+                }
+            }
+        }
+
         #region Animation
 
         public static void StartAnimation(this UIElement animatableElement, DependencyProperty dependencyProperty, Point toValue, double animationDurationSeconds, EventHandler? completedEvent = null)


### PR DESCRIPTION
### 📝 Description of the Change

Add hot keys to pending connections.

New configuration fields in `PendingConnection`:
- `MaxHotKeys`:  specifies the maximum number of hotkeys that can be displayed for a pending connection
- `HotKeysDisplayMode`: specifies how hotkeys are displayed for a pending connection

Added the `HotKeyControl` to allow customizing the hot key visual. It has a `Number` dependency property and the `DataContext` is the viewmodel of the connector.

Press `Space` (`EditorGestures.Mappings.Connector.Connect` gesture) on a focused connector to display the hot keys. Press the desired connector number.
Press `Delete` to disconnect the connector.

Closes #196

![hot-keys](https://github.com/user-attachments/assets/4a46fca5-56ce-4dab-a875-9062402daca0)

### 🐛 Possible Drawbacks

None that I can think of.
