### PR TITLE
Allow calling GetLinePoints of a base class

### DIFF
--- a/Nodify/Connections/CircuitConnection.cs
+++ b/Nodify/Connections/CircuitConnection.cs
@@ -8,11 +8,13 @@ namespace Nodify
     /// <summary>
     /// Represents a line that is controlled by an angle.
     /// </summary>
-    public class CircuitConnection : LineConnection
+    public class CircuitConnection : LineConnection, ILinePoints<Point3>
     {
         protected const double Degrees = Math.PI / 180.0d;
 
         public static readonly DependencyProperty AngleProperty = DependencyProperty.Register(nameof(Angle), typeof(double), typeof(LineConnection), new FrameworkPropertyMetadata(BoxValue.Double45, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        private readonly ILinePoints<Point3> AsLinePoints;
 
         /// <summary>
         /// The angle of the connection in degrees.
@@ -29,9 +31,14 @@ namespace Nodify
             NodifyEditor.CuttingConnectionTypes.Add(typeof(CircuitConnection));
         }
 
+        public CircuitConnection()
+        {
+            AsLinePoints = this;
+        }
+
         protected override ((Point ArrowStartSource, Point ArrowStartTarget), (Point ArrowEndSource, Point ArrowEndTarget)) DrawLineGeometry(StreamGeometryContext context, Point source, Point target)
         {
-            var (p0, p1, p2) = GetLinePoints(source, target);
+            var (p0, p1, p2) = AsLinePoints.GetLinePoints(source, target);
 
             context.BeginFigure(source, false, false);
             if (CornerRadius > 0)
@@ -58,7 +65,7 @@ namespace Nodify
 
         protected override Point GetTextPosition(FormattedText text, Point source, Point target)
         {
-            var (p0, p1, p2) = GetLinePoints(source, target);
+            var (p0, p1, p2) = AsLinePoints.GetLinePoints(source, target);
 
             Vector deltaSource = p1 - p0;
             Vector deltaTarget = p2 - p1;
@@ -73,7 +80,7 @@ namespace Nodify
 
         protected override void DrawDirectionalArrowsGeometry(StreamGeometryContext context, Point source, Point target)
         {
-            var (p0, p1, p2) = GetLinePoints(source, target);
+            var (p0, p1, p2) = AsLinePoints.GetLinePoints(source, target);
 
             double spacing = 1d / (DirectionalArrowsCount + 1);
             for (int i = 1; i <= DirectionalArrowsCount; i++)
@@ -86,7 +93,7 @@ namespace Nodify
             }
         }
 
-        private (Point P0, Point P1, Point P2) GetLinePoints(in Point source, in Point target)
+        Point3 ILinePoints<Point3>.GetLinePoints(in Point source, in Point target)
         {
             double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
             var spacing = new Vector(Spacing * direction, 0d);

--- a/Nodify/Connections/Interfaces/ILinePoints.cs
+++ b/Nodify/Connections/Interfaces/ILinePoints.cs
@@ -5,14 +5,21 @@ namespace Nodify
 {
     public interface ILinePoints<TPoints> where TPoints : struct, IPointTuple
     {
+        /// <summary>
+        /// Allows to call base class version of GetLinePoints
+        /// example:
+        /// BaseClass implements ILinePoints<Point2>
+        /// DerivedClass implements ILinePoints<Point2>
+        /// call '((ILinePoints<Point2>)(BaseClass)derivedClass).GetLinePoints(source, target)'
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="target"></param>
+        /// <returns></returns>
         TPoints GetLinePoints(in Point source, in Point target);
     }
 
     public interface IPointTuple
     {
-        int Length { get; }
-        Point this[int index] { get; }
-        ReadOnlySpan<Point> AsSpan();
     }
 
     public readonly struct Point2 : IPointTuple
@@ -23,10 +30,6 @@ namespace Nodify
         public Point2(Point p0, Point p1) => (P0, P1) = (p0, p1);
 
         public void Deconstruct(out Point p0, out Point p1) => (p0, p1) = (P0, P1);
-
-        public int Length => 2;
-        public Point this[int i] => i switch { 0 => P0, 1 => P1, _ => throw new IndexOutOfRangeException() };
-        public ReadOnlySpan<Point> AsSpan() => new[] { P0, P1 };
 
         public static implicit operator (Point, Point)(Point2 p) => (p.P0, p.P1);
         public static implicit operator Point2((Point, Point) t) => new(t.Item1, t.Item2);
@@ -42,10 +45,6 @@ namespace Nodify
 
         public void Deconstruct(out Point p0, out Point p1, out Point p2) => (p0, p1, p2) = (P0, P1, P2);
 
-        public int Length => 3;
-        public Point this[int i] => i switch { 0 => P0, 1 => P1, 2 => P2, _ => throw new IndexOutOfRangeException() };
-        public ReadOnlySpan<Point> AsSpan() => new[] { P0, P1, P2 };
-
         public static implicit operator (Point, Point, Point)(Point3 p) => (p.P0, p.P1, p.P2);
         public static implicit operator Point3((Point, Point, Point) t) => new(t.Item1, t.Item2, t.Item3);
     }
@@ -60,10 +59,6 @@ namespace Nodify
         public Point4(Point p0, Point p1, Point p2, Point p3) => (P0, P1, P2, P3) = (p0, p1, p2, p3);
 
         public void Deconstruct(out Point p0, out Point p1, out Point p2, out Point p3) => (p0, p1, p2, p3) = (P0, P1, P2, P3);
-
-        public int Length => 4;
-        public Point this[int i] => i switch { 0 => P0, 1 => P1, 2 => P2, 3 => P3, _ => throw new IndexOutOfRangeException() };
-        public ReadOnlySpan<Point> AsSpan() => new[] { P0, P1, P2, P3 };
 
         public static implicit operator (Point, Point, Point, Point)(Point4 p) => (p.P0, p.P1, p.P2, p.P3);
         public static implicit operator Point4((Point, Point, Point, Point) t) => new(t.Item1, t.Item2, t.Item3, t.Item4);

--- a/Nodify/Connections/Interfaces/ILinePoints.cs
+++ b/Nodify/Connections/Interfaces/ILinePoints.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Windows;
+
+namespace Nodify
+{
+    public interface ILinePoints<TPoints> where TPoints : struct, IPointTuple
+    {
+        TPoints GetLinePoints(in Point source, in Point target);
+    }
+
+    public interface IPointTuple
+    {
+        int Length { get; }
+        Point this[int index] { get; }
+        ReadOnlySpan<Point> AsSpan();
+    }
+
+    public readonly struct Point2 : IPointTuple
+    {
+        public Point P0 { get; }
+        public Point P1 { get; }
+
+        public Point2(Point p0, Point p1) => (P0, P1) = (p0, p1);
+
+        public void Deconstruct(out Point p0, out Point p1) => (p0, p1) = (P0, P1);
+
+        public int Length => 2;
+        public Point this[int i] => i switch { 0 => P0, 1 => P1, _ => throw new IndexOutOfRangeException() };
+        public ReadOnlySpan<Point> AsSpan() => new[] { P0, P1 };
+
+        public static implicit operator (Point, Point)(Point2 p) => (p.P0, p.P1);
+        public static implicit operator Point2((Point, Point) t) => new(t.Item1, t.Item2);
+    }
+
+    public readonly struct Point3 : IPointTuple
+    {
+        public Point P0 { get; }
+        public Point P1 { get; }
+        public Point P2 { get; }
+
+        public Point3(Point p0, Point p1, Point p2) => (P0, P1, P2) = (p0, p1, p2);
+
+        public void Deconstruct(out Point p0, out Point p1, out Point p2) => (p0, p1, p2) = (P0, P1, P2);
+
+        public int Length => 3;
+        public Point this[int i] => i switch { 0 => P0, 1 => P1, 2 => P2, _ => throw new IndexOutOfRangeException() };
+        public ReadOnlySpan<Point> AsSpan() => new[] { P0, P1, P2 };
+
+        public static implicit operator (Point, Point, Point)(Point3 p) => (p.P0, p.P1, p.P2);
+        public static implicit operator Point3((Point, Point, Point) t) => new(t.Item1, t.Item2, t.Item3);
+    }
+
+    public readonly struct Point4 : IPointTuple
+    {
+        public Point P0 { get; }
+        public Point P1 { get; }
+        public Point P2 { get; }
+        public Point P3 { get; }
+
+        public Point4(Point p0, Point p1, Point p2, Point p3) => (P0, P1, P2, P3) = (p0, p1, p2, p3);
+
+        public void Deconstruct(out Point p0, out Point p1, out Point p2, out Point p3) => (p0, p1, p2, p3) = (P0, P1, P2, P3);
+
+        public int Length => 4;
+        public Point this[int i] => i switch { 0 => P0, 1 => P1, 2 => P2, 3 => P3, _ => throw new IndexOutOfRangeException() };
+        public ReadOnlySpan<Point> AsSpan() => new[] { P0, P1, P2, P3 };
+
+        public static implicit operator (Point, Point, Point, Point)(Point4 p) => (p.P0, p.P1, p.P2, p.P3);
+        public static implicit operator Point4((Point, Point, Point, Point) t) => new(t.Item1, t.Item2, t.Item3, t.Item4);
+    }
+}

--- a/Nodify/Connections/LineConnection.cs
+++ b/Nodify/Connections/LineConnection.cs
@@ -8,9 +8,11 @@ namespace Nodify
     /// <summary>
     /// Represents a line that has an arrow indicating its <see cref="BaseConnection.Direction"/>.
     /// </summary>
-    public class LineConnection : BaseConnection
+    public class LineConnection : BaseConnection, ILinePoints<Point2>
     {
         public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(nameof(CornerRadius), typeof(double), typeof(LineConnection), new FrameworkPropertyMetadata(BoxValue.Double5, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        private readonly ILinePoints<Point2> AsLinePoints;
 
         /// <summary>
         /// The radius of the corners between the line segments.
@@ -27,9 +29,14 @@ namespace Nodify
             NodifyEditor.CuttingConnectionTypes.Add(typeof(LineConnection));
         }
 
+        public LineConnection()
+        {
+            AsLinePoints = this;
+        }
+
         protected override ((Point ArrowStartSource, Point ArrowStartTarget), (Point ArrowEndSource, Point ArrowEndTarget)) DrawLineGeometry(StreamGeometryContext context, Point source, Point target)
         {
-            var (p0, p1) = GetLinePoints(source, target);
+            var (p0, p1) = AsLinePoints.GetLinePoints(source, target);
 
             context.BeginFigure(source, false, false);
             if (CornerRadius > 0 && Spacing > 0)
@@ -74,7 +81,7 @@ namespace Nodify
 
         protected override void DrawDirectionalArrowsGeometry(StreamGeometryContext context, Point source, Point target)
         {
-            var (p0, p1) = GetLinePoints(source, target);
+            var (p0, p1) = AsLinePoints.GetLinePoints(source, target);
             var direction = p0 - p1;
 
             double spacing = 1d / (DirectionalArrowsCount + 1);
@@ -87,7 +94,7 @@ namespace Nodify
             }
         }
 
-        private (Point P0, Point P1) GetLinePoints(Point source, Point target)
+        Point2 ILinePoints<Point2>.GetLinePoints(in Point source, in Point target)
         {
             double direction = Direction == ConnectionDirection.Forward ? 1d : -1d;
             var spacing = new Vector(Spacing * direction, 0d);

--- a/Nodify/Connections/StepConnection.cs
+++ b/Nodify/Connections/StepConnection.cs
@@ -13,7 +13,7 @@ namespace Nodify
         Right
     }
 
-    public class StepConnection : LineConnection
+    public class StepConnection : LineConnection, ILinePoints<Point4>
     {
         public static readonly DependencyProperty SourcePositionProperty = DependencyProperty.Register(nameof(SourcePosition), typeof(ConnectorPosition), typeof(StepConnection), new FrameworkPropertyMetadata(ConnectorPosition.Right, FrameworkPropertyMetadataOptions.AffectsRender, OnConnectorPositionChanged));
         public static readonly DependencyProperty TargetPositionProperty = DependencyProperty.Register(nameof(TargetPosition), typeof(ConnectorPosition), typeof(StepConnection), new FrameworkPropertyMetadata(ConnectorPosition.Left, FrameworkPropertyMetadataOptions.AffectsRender, OnConnectorPositionChanged));
@@ -26,12 +26,19 @@ namespace Nodify
             connection.CoerceValue(TargetOrientationProperty);
         }
 
+        private readonly ILinePoints<Point4> AsLinePoints;
+
         static StepConnection()
         {
             SourceOrientationProperty.OverrideMetadata(typeof(StepConnection), new FrameworkPropertyMetadata(Orientation.Horizontal, null, CoerceSourceOrientation));
             TargetOrientationProperty.OverrideMetadata(typeof(StepConnection), new FrameworkPropertyMetadata(Orientation.Horizontal, null, CoerceTargetOrientation));
             DirectionProperty.OverrideMetadata(typeof(StepConnection), new FrameworkPropertyMetadata(ConnectionDirection.Forward, null, CoerceConnectionDirection));
             NodifyEditor.CuttingConnectionTypes.Add(typeof(StepConnection));
+        }
+
+        public StepConnection()
+        {
+            AsLinePoints = this;
         }
 
         private static object CoerceSourceOrientation(DependencyObject d, object baseValue)
@@ -78,7 +85,7 @@ namespace Nodify
 
         protected override ((Point ArrowStartSource, Point ArrowStartTarget), (Point ArrowEndSource, Point ArrowEndTarget)) DrawLineGeometry(StreamGeometryContext context, Point source, Point target)
         {
-            var (p0, p1, p2, p3) = GetLinePoints(source, target);
+            var (p0, p1, p2, p3) = AsLinePoints.GetLinePoints(source, target);
 
             if (CornerRadius > 0)
             {
@@ -129,7 +136,7 @@ namespace Nodify
 
         protected override Point GetTextPosition(FormattedText text, Point source, Point target)
         {
-            var (p0, p1, p2, p3) = GetLinePoints(source, target);
+            var (p0, p1, p2, p3) = AsLinePoints.GetLinePoints(source, target);
 
             Vector delta1 = p1 - p0;
             Vector delta2 = p2 - p1;
@@ -154,7 +161,7 @@ namespace Nodify
 
         protected override void DrawDirectionalArrowsGeometry(StreamGeometryContext context, Point source, Point target)
         {
-            var (p0, p1, p2, p3) = GetLinePoints(source, target);
+            var (p0, p1, p2, p3) = AsLinePoints.GetLinePoints(source, target);
 
             double spacing = 1d / (DirectionalArrowsCount + 1);
             for (int i = 1; i <= DirectionalArrowsCount; i++)
@@ -167,7 +174,7 @@ namespace Nodify
             }
         }
 
-        private (Point P0, Point P1, Point P2, Point P3) GetLinePoints(Point source, Point target)
+        Point4 ILinePoints<Point4>.GetLinePoints(in Point source, in Point target)
         {
             var sourceDir = GetConnectorDirection(SourcePosition);
             var targetDir = GetConnectorDirection(TargetPosition);


### PR DESCRIPTION
### 📝 Description of the Change

I've been using nodify and had an issue where I wanted to use the result of GetLinePoints of StepConnection, but since it was private I had to either copy paste the code or use reflection.

This works for both base and derived implementing same and different amounts of points.

example:
```
BaseClass : ILinePoints<Point2>
DerivedClass : ILinePoints<Point2>

((ILinePoints<Point2>)(BaseClass)derivedClass).GetLinePoints(source, target)
```

### 🐛 Possible Drawbacks

Not to my knowledge except the code being a tiny bit less readable.
