### PR TITLE
Fix editors in the calculator app sharing location and scaling

### DIFF
--- a/Examples/Nodify.Calculator/CalculatorViewModel.cs
+++ b/Examples/Nodify.Calculator/CalculatorViewModel.cs
@@ -91,6 +91,20 @@ namespace Nodify.Calculator
         public PendingConnectionViewModel PendingConnection { get; set; } = new PendingConnectionViewModel();
         public OperationsMenuViewModel OperationsMenu { get; set; }
 
+        private double _zoom = 1.0f;
+        public double Zoom
+        {
+            get => _zoom;
+            set => SetProperty(ref _zoom, value);
+        }
+
+        private Point _location;
+        public Point Location
+        {
+            get => _location;
+            set => SetProperty(ref _location, value);
+        }
+
         public INodifyCommand StartConnectionCommand { get; }
         public INodifyCommand CreateConnectionCommand { get; }
         public INodifyCommand DisconnectConnectorCommand { get; }

--- a/Examples/Nodify.Calculator/EditorView.xaml
+++ b/Examples/Nodify.Calculator/EditorView.xaml
@@ -128,6 +128,8 @@
         <nodify:NodifyEditor DataContext="{Binding Calculator}"
                              ItemsSource="{Binding Operations}"
                              Connections="{Binding Connections}"
+                             ViewportZoom="{Binding Zoom}"
+                             ViewportLocation="{Binding Location}"
                              SelectedItems="{Binding SelectedOperations}"
                              DisconnectConnectorCommand="{Binding DisconnectConnectorCommand}"
                              PendingConnection="{Binding PendingConnection}"


### PR DESCRIPTION
### 📝 Description of the Change

Fixes editors in the calculator app sharing location and scaling due to `TabControl` reusing the view.

Fixes #242

### 🐛 Possible Drawbacks

None.
