### PR TITLE
Refactor keyboard navigation to prevent lambda expression crash

### DIFF
--- a/Nodify/Editor/NodifyEditor.KeyboardNavigation.cs
+++ b/Nodify/Editor/NodifyEditor.KeyboardNavigation.cs
@@ -91,8 +91,15 @@ namespace Nodify
             {
                 var viewport = new Rect(ViewportLocation, ViewportSize);
                 var containers = ItemContainers;
-                containerToFocus = containers.FirstOrDefault(container => container.IsSelectableInArea(viewport, isContained: false))
-                    ?? containers.First();
+                
+                foreach (var container in containers)
+                {
+                    if (container != null && container.IsSelectableInArea(viewport, isContained: false))
+                    {
+                        containerToFocus = container;
+                        break;
+                    }
+                }
             }
 
             return containerToFocus != null;


### PR DESCRIPTION
Fixes an crash, when nodes are loaded during editor startup but the NodifyEditor is not visible in the XAML-editor.

  ## Issue

  NodifyEditor crashes on startup, if the Editor is not visible by default (e.g. Visibility="Hidden" in XAML-Editor") but there is already an node added to the editors view model in it's constructor.

In order to re-produce the issue simply following the below instructions:

1. Open the Nodify.Calculator example project in Visual studio
2. Add "Visibility="Hidden"" to the nodify:NodifyEditor (in line 128)
3. In the CalculatorViewModel.cs simply add a new Node at the end of the constructor (like             

```
            Operations.Add(new ExpressionOperationViewModel()
            {
                Location = new Point(100, 100)
            });
```
4. Start application and it should crash.

### 📝 Description of the Change

I simply made a an additional null check instead of the lambda expression to prevent a null-Exception.

### 🐛 Possible Drawbacks

There aren't any drawbacks.
