### PR TITLE
Improve connection focus visual

### DIFF
--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -1015,7 +1015,9 @@ namespace Nodify
                 if (drawPen != null)
                 {
                     var widenPen = new Pen(null, _baseConnection.StrokeThickness + drawPen.Thickness + _baseConnection.FocusVisualPadding * 2d);
-                    drawingContext.DrawGeometry(null, drawPen, _baseConnection.DefiningGeometry.GetWidenedPathGeometry(widenPen));
+                    var geometry = _baseConnection.DefiningGeometry;
+                    var expandedGeometry = Geometry.Combine(geometry, geometry.GetWidenedPathGeometry(widenPen), GeometryCombineMode.Union, Transform.Identity);
+                    drawingContext.DrawGeometry(null, drawPen, expandedGeometry.GetOutlinedPathGeometry());
                 }
             }
         }


### PR DESCRIPTION
<!-- 
  ## Hello and welcome!

  Consider creating an issue or link to an existing one before submitting the pull request. Thanks!
-->

### 📝 Description of the Change

While toying around in the playground to understand how to customize connections, I noticed that the focus visual showed artifacts related to how the connection is drawn on screen.
I propose a small change to improve the focus visual so that it displays as a continuous outline.
Since only a single connection will be focused at a time, I believe the added computations are not going to slow down anything in a significant manner, but I might be wrong.

Before:
<img width="879" height="388" alt="image" src="https://github.com/user-attachments/assets/d3d49804-b378-4d6a-a261-5fe54fd7a661" />

After:
<img width="881" height="408" alt="image" src="https://github.com/user-attachments/assets/aa7292a0-36f3-4849-ad59-802d4826bb33" />

### 🐛 Possible Drawbacks

This changes the appearance of the focus visual.
Although quite unlikely IMO, I guess it could have undesired results for some very specific custom connection implementations?
