### PR TITLE
[WIP] Add a new variant of Bezier connection type

### DIFF
--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -201,6 +201,12 @@
                                    CornerRadius="{Binding ConnectionCornerRadius, Source={x:Static local:EditorSettings.Instance}}" />
         </DataTemplate>
 
+        <DataTemplate x:Key="OrientedConnectionTemplate">
+            <nodify:OrientedConnection Style="{StaticResource ConnectionStyle}"
+                                       SourceAngle="{Binding ConnectionSourceAngle, Source={x:Static local:EditorSettings.Instance}}"
+                                       TargetAngle="{Binding ConnectionTargetAngle, Source={x:Static local:EditorSettings.Instance}}"/>
+        </DataTemplate>
+
         <DataTemplate x:Key="ConnectionTemplate">
             <nodify:Connection Style="{StaticResource ConnectionStyle}" />
         </DataTemplate>
@@ -304,6 +310,11 @@
                                      Value="True">
                             <Setter Property="Background"
                                     Value="{StaticResource SmallGridLinesDrawingBrush}" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding ConnectionStyle, Mode=TwoWay, Source={x:Static local:EditorSettings.Instance}}"
+                                     Value="Oriented">
+                            <Setter Property="ConnectionTemplate"
+                                    Value="{StaticResource OrientedConnectionTemplate}" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding ConnectionStyle, Mode=TwoWay, Source={x:Static local:EditorSettings.Instance}}"
                                      Value="Line">

--- a/Examples/Nodify.Playground/EditorSettings.cs
+++ b/Examples/Nodify.Playground/EditorSettings.cs
@@ -7,6 +7,7 @@ namespace Nodify.Playground
     public enum ConnectionStyle
     {
         Default,
+        Oriented,
         Line,
         Circuit,
         Step
@@ -197,6 +198,16 @@ namespace Nodify.Playground
                     () => Instance.ConnectionStrokeThickness,
                     val => Instance.ConnectionStrokeThickness = val,
                     "Connection stroke thickness: "),
+                new ProxySettingViewModel<double>(
+                    () => Instance.ConnectionSourceAngle,
+                    val => Instance.ConnectionSourceAngle = val,
+                    "Connection source angle: ",
+                    "The angle of the source connector."),
+                new ProxySettingViewModel<double>(
+                    () => Instance.ConnectionTargetAngle,
+                    val => Instance.ConnectionTargetAngle = val,
+                    "Connection target angle: ",
+                    "The angle of the source connector."),
                 new ProxySettingViewModel<double>(
                     () => Instance.ConnectionOutlineThickness,
                     val => Instance.ConnectionOutlineThickness = val,
@@ -634,6 +645,20 @@ namespace Nodify.Playground
         {
             get => _connectionTargetOffset;
             set => SetProperty(ref _connectionTargetOffset, value);
+        }
+
+        private double _connectionSourceAngle = 30;
+        public double ConnectionSourceAngle
+        {
+            get => _connectionSourceAngle;
+            set => SetProperty(ref _connectionSourceAngle, value);
+        }
+
+        private double _connectionTargetAngle = 120;
+        public double ConnectionTargetAngle
+        {
+            get => _connectionTargetAngle;
+            set => SetProperty(ref _connectionTargetAngle, value);
         }
 
         private double _connectionStrokeThickness = 3;

--- a/Nodify/Connections/OrientedConnection.cs
+++ b/Nodify/Connections/OrientedConnection.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace Nodify
+{
+    /// <summary>
+    /// Represents a cubic bezier curve with oriented connectors.
+    /// </summary>
+    public class OrientedConnection : BaseConnection
+    {
+        /// <summary>
+        /// Gets or sets the angle of the connection from the source connector.
+        /// </summary>
+        public double SourceAngle
+        {
+            get => (double)GetValue(SourceAngleProperty);
+            set => SetValue(SourceAngleProperty, value);
+        }
+        public static readonly DependencyProperty SourceAngleProperty = DependencyProperty.Register(nameof(SourceAngle), typeof(double), typeof(OrientedConnection), new FrameworkPropertyMetadata(0d, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        /// <summary>
+        /// Gets or sets the angle of the connection from the target connector.
+        /// </summary>
+        public double TargetAngle
+        {
+            get => (double)GetValue(TargetAngleProperty);
+            set => SetValue(TargetAngleProperty, value);
+        }
+
+        public static readonly DependencyProperty TargetAngleProperty = DependencyProperty.Register(nameof(TargetAngle), typeof(double), typeof(OrientedConnection), new FrameworkPropertyMetadata(180d, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        static OrientedConnection()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(OrientedConnection), new FrameworkPropertyMetadata(typeof(OrientedConnection)));
+            NodifyEditor.CuttingConnectionTypes.Add(typeof(OrientedConnection));
+        }
+
+        private const double BaseOffset = 100d;
+        private const double OffsetGrowthRate = 25d;
+        private const double DegreesToRadians = Math.PI / 180;
+
+        /// <summary>Gets the unit vector indicating connection orientation from the source connector.</summary>
+        /// <returns>A unit vector representing the orientation.</returns>
+        protected virtual Vector GetSourceOrientation()
+        {
+            var angle = SourceAngle * DegreesToRadians;
+            return new Vector(Math.Cos(angle), -Math.Sin(angle));
+        }
+
+        /// <summary>Gets the unit vector indicating connection orientation from the target connector.</summary>
+        /// <returns>A unit vector representing the orientation.</returns>
+        protected virtual Vector GetTargetOrientation()
+        {
+            var angle = TargetAngle * DegreesToRadians;
+            return new Vector(Math.Cos(angle), -Math.Sin(angle));
+        }
+
+        protected override ((Point ArrowStartSource, Point ArrowStartTarget), (Point ArrowEndSource, Point ArrowEndTarget)) DrawLineGeometry(StreamGeometryContext context, Point source, Point target)
+        {
+            var (p0, p1, p2, p3) = GetBezierControlPoints(source, target);
+
+            context.BeginFigure(source, false, false);
+            context.LineTo(p0, true, true);
+            context.BezierTo(p1, p2, p3, true, true);
+            context.LineTo(target, true, true);
+
+            return ((target, source), (source, target));
+        }
+
+        protected override void DrawDirectionalArrowsGeometry(StreamGeometryContext context, Point source, Point target)
+        {
+            var (p0, p1, p2, p3) = GetBezierControlPoints(source, target);
+
+            double spacing = 1d / (DirectionalArrowsCount + 1);
+            for (int i = 1; i <= DirectionalArrowsCount; i++)
+            {
+                double t = (spacing * i + DirectionalArrowsOffset).WrapToRange(0d, 1d);
+                var to = InterpolateCubicBezier(p0, p1, p2, p3, t);
+                var direction = GetBezierTangent(p0, p1, p2, p3, t);
+
+                DrawDirectionalArrowheadGeometry(context, direction, to);
+            }
+        }
+
+        protected override void DrawDefaultArrowhead(StreamGeometryContext context, Point source, Point target, ConnectionDirection arrowDirection = ConnectionDirection.Forward, Orientation orientation = Orientation.Horizontal)
+        {
+            var connectionDirection = Direction;
+            // Reverse the caller logic to determine which of the source or target arrow we are drawing.
+            var x = arrowDirection == connectionDirection ? GetTargetOrientation() : GetSourceOrientation();
+            // Reverse the direction if we need to draw a backward connection.
+            if (connectionDirection == ConnectionDirection.Backward) x = -x;
+            var y = new Vector(x.Y, -x.X);
+
+            var headWidth = ArrowSize.Width * x;
+            var headHeight = ArrowSize.Height / 2 * y;
+            var headMiddle = target + headWidth;
+
+            var from = headMiddle + headHeight;
+            var to = headMiddle - headHeight;
+
+            context.BeginFigure(target, true, true);
+            context.LineTo(from, true, true);
+            context.LineTo(to, true, true);
+        }
+
+        protected override Point GetTextPosition(FormattedText text, Point source, Point target)
+        {
+            var (p0, p1, p2, p3) = GetBezierControlPoints(source, target);
+            var textCenter = new Vector(text.Width / 2, text.Height / 2);
+            return InterpolateCubicBezier(p0, p1, p2, p3, 0.5) - textCenter;
+        }
+
+        private (Point P0, Point P1, Point P2, Point P3) GetBezierControlPoints(Point source, Point target)
+        {
+            var sourceOrientation = GetSourceOrientation();
+            var targetOrientation = GetTargetOrientation();
+
+            Point startPoint = source + Spacing * sourceOrientation;
+            Point endPoint = target + Spacing * targetOrientation;
+
+            Vector delta = target - source;
+            double height = Math.Abs(delta.Y);
+            double width = Math.Abs(delta.X);
+
+            // Smooth curve when distance is lower than base offset
+            double smooth = Math.Min(BaseOffset, height);
+            // Calculate offset based on distance
+            double offset = Math.Max(smooth, width / 2d);
+            // Grow slowly with distance
+            offset = Math.Min(BaseOffset + Math.Sqrt(width * OffsetGrowthRate), offset);
+
+            var controlPoint = offset;
+
+            // Avoid sharp bend if orientation different (when close to each other)
+            if (TargetOrientation != SourceOrientation)
+            {
+                controlPoint *= 0.5;
+            }
+
+            Point p0 = startPoint;
+            Point p1 = startPoint + controlPoint * sourceOrientation;
+            Point p2 = endPoint + controlPoint * targetOrientation;
+            Point p3 = endPoint;
+
+            return (p0, p1, p2, p3);
+        }
+
+        private static Vector GetBezierTangent(Point P0, Point P1, Point P2, Point P3, double t)
+        {
+            // Calculate the derivatives of the Bezier curve equation and negate the result
+            return -(-3 * (1 - t) * (1 - t) * (Vector)P0 +
+                    (3 * (1 - t) * (1 - t) * (Vector)P1 - 6 * t * (1 - t) * (Vector)P1) +
+                    (6 * t * (1 - t) * (Vector)P2 - 3 * t * t * (Vector)P2) +
+                    3 * t * t * (Vector)P3);
+        }
+
+        protected static Point InterpolateCubicBezier(Point P0, Point P1, Point P2, Point P3, double t)
+        {
+            // B = (1 − t)^3 * P0 + 3 * t * (1 − t)^2 * P1 + 3 * t^2 * (1 − t) * P2 + t^3 * P3
+            return (Point)
+                 ((Vector)P0 * (1 - t) * (1 - t) * (1 - t)
+                + (Vector)P1 * 3 * t * (1 - t) * (1 - t)
+                + (Vector)P2 * 3 * t * t * (1 - t)
+                + (Vector)P3 * t * t * t);
+        }
+    }
+
+}

--- a/Nodify/Themes/Styles/Connection.xaml
+++ b/Nodify/Themes/Styles/Connection.xaml
@@ -29,6 +29,22 @@
                 Value="20" />
     </Style>
 
+    <Style TargetType="{x:Type local:OrientedConnection}"
+           BasedOn="{StaticResource {x:Type local:BaseConnection}}">
+        <Setter Property="StrokeThickness"
+                Value="3" />
+        <Setter Property="Stroke"
+                Value="DodgerBlue" />
+        <Setter Property="Fill"
+                Value="DodgerBlue" />
+        <Setter Property="Spacing"
+                Value="20" />
+        <Setter Property="SourceAngle"
+                Value="0" />
+        <Setter Property="TargetAngle"
+                Value="180" />
+    </Style>
+
     <Style TargetType="{x:Type local:LineConnection}"
            BasedOn="{StaticResource {x:Type local:BaseConnection}}">
         <Setter Property="StrokeThickness"


### PR DESCRIPTION
<!-- 
  ## Hello and welcome!

  Consider creating an issue or link to an existing one before submitting the pull request. Thanks!
-->

### 📝 Description of the Change

The current connection system is rather opinionated in terms of how the lines are oriented towards connectors, which makes getting a different look relatively difficult.
This change introduces a `OrientedConnection`, which is heavily based on `Connection` but allows 360° free orientation of the start and end segments of the line. (The idea being similar to what `StepConnection` does with `ConnectorPosition`, but more flexible)
It can be used as-is, or we can discuss how to improve it *or* how to move some of the logic into Nodify's pre-existing base classes.

See: https://github.com/miroiu/nodify/issues/249

<img width="785" height="431" alt="image" src="https://github.com/user-attachments/assets/edda2856-1be5-45be-9de9-aa5146b21571" />

### 🐛 Possible Drawbacks

This implementation entirely overrides the `Orientation` properties.
It does take into account the `Direction` property, but as the `GetOffset` method, the locations may end up weird. (I honestly don't know how the logic here should be adapted, so I'll gladly take feedback on this)

Currently, angles are expressed in an absolute way, similarly to how `ConnectorPosition` is absolute. Another way to handle things would be as a rotation from the "default" 0°/90°/180°/270° orientation of connectors, or something similar. I went with the absolute angles implementation because it is the most straightforward one, but this is somethign really easy to adapt if one wants another logic.
