### PR TITLE
Draw background rectangle for connection labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 #### **In development**
 
-> - Breaking Changes:
 > - Features:
+>	- Added ConnectionTemplateSelector, DecoratorTemplateSelector and PendingConnectionTemplateSelector to NodifyEditor to allow selecting the data template based on custom rules
+>	- Added TextBackground, TextPadding and TextCornerRadius dependency properties to BaseConnection to allow styling the background of the connection text
+>	- Added DrawTextBackground to BaseConnection to allow customizing the drawing of the text background
 > - Bugfixes:
+>	- Fixed focus navigation exception when the editor is collapsed
+>	- Fixed connection focus outline drawing inner overlapping lines
+>	- Fixed connection focus outline not updating on directional arrow animation
 
 #### **Version 7.1.0**
 

--- a/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
+++ b/Examples/Nodify.Playground/Editor/NodifyEditorView.xaml
@@ -77,6 +77,8 @@
                             Value="{StaticResource SquareConnectorColor}" />
                     <Setter Property="OutlineBrush"
                             Value="{StaticResource SquareConnectorOutline}" />
+                    <Setter Property="TextBackground"
+                            Value="{StaticResource SquareConnectorColor}" />
                 </DataTrigger>
                 <DataTrigger Binding="{Binding Input.Shape}"
                              Value="{x:Static local:ConnectorShape.Triangle}">
@@ -86,6 +88,8 @@
                             Value="{StaticResource TriangleConnectorColor}" />
                     <Setter Property="OutlineBrush"
                             Value="{StaticResource TriangleConnectorOutline}" />
+                    <Setter Property="TextBackground"
+                            Value="{StaticResource TriangleConnectorColor}" />
                 </DataTrigger>
                 <Trigger Property="IsMouseDirectlyOver"
                          Value="True">
@@ -129,6 +133,12 @@
                                      Opacity="0.15" />
                 </Setter.Value>
             </Setter>
+            <Setter Property="TextBackground"
+                    Value="{StaticResource Connection.StrokeBrush}" />
+            <Setter Property="TextPadding"
+                    Value="4 2" />
+            <Setter Property="TextCornerRadius"
+                    Value="3" />
             <Setter Property="ToolTip"
                     Value="Double click to split" />
             <Setter Property="Source"

--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -138,6 +138,9 @@ namespace Nodify
         public static readonly DependencyProperty FocusVisualPaddingProperty = DependencyProperty.Register(nameof(FocusVisualPadding), typeof(double), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.Double1, FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty ForegroundProperty = TextBlock.ForegroundProperty.AddOwner(typeof(BaseConnection));
         public static readonly DependencyProperty TextProperty = TextBlock.TextProperty.AddOwner(typeof(BaseConnection), new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.AffectsRender));
+        public static readonly DependencyProperty TextBackgroundProperty = DependencyProperty.Register(nameof(TextBackground), typeof(Brush), typeof(BaseConnection), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender));
+        public static readonly DependencyProperty TextPaddingProperty = DependencyProperty.Register(nameof(TextPadding), typeof(Thickness), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.Thickness2, FrameworkPropertyMetadataOptions.AffectsRender));
+        public static readonly DependencyProperty TextCornerRadiusProperty = DependencyProperty.Register(nameof(TextCornerRadius), typeof(double), typeof(BaseConnection), new FrameworkPropertyMetadata(BoxValue.Double0, FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty FontSizeProperty = TextElement.FontSizeProperty.AddOwner(typeof(BaseConnection));
         public static readonly DependencyProperty FontFamilyProperty = TextElement.FontFamilyProperty.AddOwner(typeof(BaseConnection));
         public static readonly DependencyProperty FontWeightProperty = TextElement.FontWeightProperty.AddOwner(typeof(BaseConnection));
@@ -421,6 +424,36 @@ namespace Nodify
         {
             get => (string?)GetValue(TextProperty);
             set => SetValue(TextProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the padding around the text of the connection. Only applied if <see cref="TextBackground"/> is not null.
+        /// </summary>
+        public Thickness TextPadding
+        {
+            get => (Thickness)GetValue(TextPaddingProperty);
+            set => SetValue(TextPaddingProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the corner radius of the text background. Only applied if <see cref="TextBackground"/> is not null.
+        /// </summary>
+        public double TextCornerRadius
+        {
+            get => (double)GetValue(TextCornerRadiusProperty);
+            set => SetValue(TextCornerRadiusProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the background brush of the text. If null, no background is drawn.
+        /// </summary>
+        /// <remarks>
+        /// Customize the appearance of the text background by setting the <see cref="TextPadding"/> and <see cref="TextCornerRadius"/> properties.
+        /// </remarks>
+        public Brush? TextBackground
+        {
+            get => (Brush?)GetValue(TextBackgroundProperty);
+            set => SetValue(TextBackgroundProperty, value);
         }
 
         /// <inheritdoc cref="TextElement.FontSize" />
@@ -980,13 +1013,40 @@ namespace Nodify
                 var text = new FormattedText(Text, CultureInfo.CurrentUICulture, FlowDirection, typeface, FontSize, Foreground ?? Stroke, dpi);
 
                 (Vector sourceOffset, Vector targetOffset) = GetOffset();
-                drawingContext.DrawText(text, GetTextPosition(text, Source + sourceOffset, Target + targetOffset));
+
+                var textPosition = GetTextPosition(text, Source + sourceOffset, Target + targetOffset);
+
+                if (TextBackground != null)
+                {
+                    var textSize = new Size(text.Width, text.Height);
+                    DrawTextBackground(drawingContext, new Rect(textPosition, textSize));
+                }
+
+                drawingContext.DrawText(text, textPosition);
             }
 
             if (AdornerLayer != null && Container is { IsKeyboardFocused: true })
             {
                 AdornerLayer.Update(this);
             }
+        }
+
+        protected virtual void DrawTextBackground(DrawingContext drawingContext, Rect bounds)
+        {
+            var padding = TextPadding;
+            double radius = TextCornerRadius;
+
+            var rectSize = new Size(bounds.Width + padding.Left + padding.Right, bounds.Height + padding.Bottom + padding.Top);
+            var rect = new Rect(bounds.Location - new Vector(padding.Left, padding.Top), rectSize);
+
+            if (OutlineBrush != null)
+            {
+                var outlineRect = rect;
+                outlineRect.Inflate(OutlineThickness, OutlineThickness);
+                drawingContext.DrawRoundedRectangle(OutlineBrush, null, outlineRect, radius, radius);
+            }
+
+            drawingContext.DrawRoundedRectangle(Stroke, null, rect, radius, radius);
         }
 
         internal void UpdateFocusVisual()

--- a/docs/api/Nodify_BaseConnection.md
+++ b/docs/api/Nodify_BaseConnection.md
@@ -453,6 +453,42 @@ public string Text { get; set; }
   
 [String](https://docs.microsoft.com/en-us/dotnet/api/System.String)  
   
+### TextBackground  
+  
+Gets or sets the background brush of the text. If null, no background is drawn.  
+  
+```csharp  
+public Brush TextBackground { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Brush](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.Brush)  
+  
+### TextCornerRadius  
+  
+Gets or sets the corner radius of the text background. Only applied if [BaseConnection.TextBackground](Nodify_BaseConnection#textbackground) is not null.  
+  
+```csharp  
+public double TextCornerRadius { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Double](https://docs.microsoft.com/en-us/dotnet/api/System.Double)  
+  
+### TextPadding  
+  
+Gets or sets the padding around the text of the connection. Only applied if [BaseConnection.TextBackground](Nodify_BaseConnection#textbackground) is not null.  
+  
+```csharp  
+public Thickness TextPadding { get; set; }  
+```  
+  
+**Property Value**  
+  
+[Thickness](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Thickness)  
+  
 ## Methods  
   
 ### DrawArrowGeometry(StreamGeometryContext, Point, Point, ConnectionDirection, ArrowHeadShape, Orientation)  
@@ -574,6 +610,18 @@ protected virtual void DrawRectangleArrowhead(StreamGeometryContext context, Poi
 `arrowDirection` [ConnectionDirection](Nodify_ConnectionDirection)  
   
 `orientation` [Orientation](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.Orientation)  
+  
+### DrawTextBackground(DrawingContext, Rect)  
+  
+```csharp  
+protected virtual void DrawTextBackground(DrawingContext drawingContext, Rect bounds);  
+```  
+  
+**Parameters**  
+  
+`drawingContext` [DrawingContext](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Media.DrawingContext)  
+  
+`bounds` [Rect](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Rect)  
   
 ### GetIsSelectable(UIElement)  
   

--- a/docs/api/Nodify_NodifyEditor.md
+++ b/docs/api/Nodify_NodifyEditor.md
@@ -462,6 +462,18 @@ public DataTemplate ConnectionTemplate { get; set; }
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
   
+### ConnectionTemplateSelector  
+  
+Gets or sets the custom logic for choosing a template for [BaseConnection](Nodify_BaseConnection).  
+  
+```csharp  
+public DataTemplateSelector ConnectionTemplateSelector { get; set; }  
+```  
+  
+**Property Value**  
+  
+[DataTemplateSelector](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.DataTemplateSelector)  
+  
 ### CuttingCompletedCommand  
   
 Invoked when a cutting operation is completed.  
@@ -569,6 +581,18 @@ public DataTemplate DecoratorTemplate { get; set; }
 **Property Value**  
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
+  
+### DecoratorTemplateSelector  
+  
+Gets or sets the custom logic for choosing a template for [DecoratorContainer](Nodify_DecoratorContainer).  
+  
+```csharp  
+public DataTemplateSelector DecoratorTemplateSelector { get; set; }  
+```  
+  
+**Property Value**  
+  
+[DataTemplateSelector](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.DataTemplateSelector)  
   
 ### DisableAutoPanning  
   
@@ -1015,6 +1039,18 @@ public DataTemplate PendingConnectionTemplate { get; set; }
 **Property Value**  
   
 [DataTemplate](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.DataTemplate)  
+  
+### PendingConnectionTemplateSelector  
+  
+Gets or sets the custom logic for choosing a template for [NodifyEditor.PendingConnection](Nodify_NodifyEditor#pendingconnection).  
+  
+```csharp  
+public DataTemplateSelector PendingConnectionTemplateSelector { get; set; }  
+```  
+  
+**Property Value**  
+  
+[DataTemplateSelector](https://docs.microsoft.com/en-us/dotnet/api/System.Windows.Controls.DataTemplateSelector)  
   
 ### PushedArea  
   


### PR DESCRIPTION
### 📝 Description of the Change

Improve connection text readability by drawing a background rectangle behind it if a `TextBackground` is specified.

New dependency properties:
- `TextBackground`: the background brush of the rectangle (defaults to `null`)
- `TextPadding`: the padding of the background rectangle
- `TextCornerRadius`: the corner radius of the background rectangle

Closes #230

<img width="1123" height="923" alt="image" src="https://github.com/user-attachments/assets/e4ad0980-7aa2-4f29-b3d4-f5616a3c7758" />

### 🐛 Possible Drawbacks

1. Minor visual artifacts when using an `OutlineBrush` with transparency due to overlapping areas.
2. Focus visual does not outline the background rectangle.
