### PR TITLE
Fixed StepConnection applying SourceOffset in the wrong direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 >	- Added InputGestures dependency property to NodifyEditor and Minimap to specify which gestures mappings to use
 >	- Added ActualGestures to Minimap, NodifyEditor and its elements
 > - Bugfixes:
+>	- Fixed StepConnection applying SourceOffset in the wrong direction in some cases
 
 #### **Version 7.2.0**
 

--- a/Nodify/Connections/StepConnection.cs
+++ b/Nodify/Connections/StepConnection.cs
@@ -251,16 +251,6 @@ namespace Nodify
                     : new Point(0, Math.Sign(target.Y - source.Y));
             }
 
-            static Point GetConnectorDirection(ConnectorPosition position)
-                => position switch
-                {
-                    ConnectorPosition.Top => new Point(0, -1),
-                    ConnectorPosition.Left => new Point(-1, 0),
-                    ConnectorPosition.Bottom => new Point(0, 1),
-                    ConnectorPosition.Right => new Point(1, 0),
-                    _ => default,
-                };
-
             static bool IsOppositePosition(ConnectorPosition sourcePosition, ConnectorPosition targetPosition)
             {
                 return sourcePosition == ConnectorPosition.Left && targetPosition == ConnectorPosition.Right
@@ -268,6 +258,31 @@ namespace Nodify
                     || sourcePosition == ConnectorPosition.Top && targetPosition == ConnectorPosition.Bottom
                     || sourcePosition == ConnectorPosition.Bottom && targetPosition == ConnectorPosition.Top;
             }
+        }
+
+        private static Point GetConnectorDirection(ConnectorPosition position)
+            => position switch
+            {
+                ConnectorPosition.Top => new Point(0, -1),
+                ConnectorPosition.Left => new Point(-1, 0),
+                ConnectorPosition.Bottom => new Point(0, 1),
+                ConnectorPosition.Right => new Point(1, 0),
+                _ => default,
+            };
+
+        protected override (Vector SourceOffset, Vector TargetOffset) GetOffset()
+        {
+            var baseOffset = base.GetOffset();
+
+            var sourceDirection = GetConnectorDirection(SourcePosition);
+            var flippedSourceOffset = new Vector(CopySign(baseOffset.SourceOffset.X, sourceDirection.X), CopySign(baseOffset.SourceOffset.Y, sourceDirection.Y));
+
+            return (flippedSourceOffset, baseOffset.TargetOffset);
+        }
+
+        private static double CopySign(double value, double signSource)
+        {
+            return signSource < 0 ? -Math.Abs(value) : Math.Abs(value);
         }
     }
 }


### PR DESCRIPTION
### 📝 Description of the Change

Fixes `StepConnection` applying `SourceOffset` in the wrong direction in some cases.

<img width="650" height="529" alt="image" src="https://github.com/user-attachments/assets/12cf3a45-1b18-4992-9943-1799d8e67ad3" />

Fixes #261

### 🐛 Possible Drawbacks

None.
