### PR TITLE
Add ContentPadding to Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 > - Features:
 >	- Added InputGestures dependency property to NodifyEditor and Minimap to specify which gestures mappings to use
 >	- Added ActualGestures to Minimap, NodifyEditor and its elements
+>	- Added ContentPadding dependency property to Node to allow adjusting the spacing between input and output panels
 > - Bugfixes:
 >	- Fixed StepConnection applying SourceOffset in the wrong direction in some cases
 

--- a/Nodify/Nodes/Node.cs
+++ b/Nodify/Nodes/Node.cs
@@ -36,6 +36,7 @@ namespace Nodify
         public static readonly DependencyProperty ContentContainerStyleProperty = DependencyProperty.Register(nameof(ContentContainerStyle), typeof(Style), typeof(Node));
         public static readonly DependencyProperty HeaderContainerStyleProperty = DependencyProperty.Register(nameof(HeaderContainerStyle), typeof(Style), typeof(Node));
         public static readonly DependencyProperty FooterContainerStyleProperty = DependencyProperty.Register(nameof(FooterContainerStyle), typeof(Style), typeof(Node));
+        public static readonly DependencyProperty ContentPaddingProperty = DependencyProperty.Register(nameof(ContentPadding), typeof(Thickness), typeof(Node), new FrameworkPropertyMetadata(new Thickness(16, 0, 16, 0)));
 
         /// <summary>
         /// Gets or sets the brush used for the background of the <see cref="ContentControl.Content"/> of this <see cref="Node"/>.
@@ -143,6 +144,15 @@ namespace Nodify
         {
             get => (Style)GetValue(FooterContainerStyleProperty);
             set => SetValue(FooterContainerStyleProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the padding for the content between the input and output connectors.
+        /// </summary>
+        public Thickness ContentPadding
+        {
+            get => (Thickness)GetValue(ContentPaddingProperty);
+            set => SetValue(ContentPaddingProperty, value);
         }
 
         /// <summary>

--- a/Nodify/Themes/Styles/Node.xaml
+++ b/Nodify/Themes/Styles/Node.xaml
@@ -103,7 +103,7 @@
 
                                     <!--Content-->
                                     <Border Grid.Column="1"
-                                            Padding="16 0 16 0"
+                                            Padding="{TemplateBinding ContentPadding}"
                                             Background="{TemplateBinding ContentBrush}">
                                         <ContentPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />


### PR DESCRIPTION
### 📝 Description of the Change

Add `ContentPadding` dependency property to `Node` to allow adjusting the spacing between `Input` and `Output` connectors.

<img width="302" height="178" alt="image" src="https://github.com/user-attachments/assets/630650fc-5e05-4d81-8777-7193a22758a6" />
<img width="273" height="164" alt="image" src="https://github.com/user-attachments/assets/7879ba2d-83de-48ed-b459-d520bbe963be" />

Related: #266

### 🐛 Possible Drawbacks

None.
