### PR TITLE
Allow selecting nodes and connections behind a grouping node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 >	- Added InputGestures dependency property to NodifyEditor and Minimap to specify which gestures mappings to use
 >	- Added ActualGestures to Minimap, NodifyEditor and its elements
 >	- Added ContentPadding dependency property to Node to allow adjusting the spacing between input and output panels
+>	- Added IsContentHitTestVisible dependency property to GroupingNode to allow selecting nodes and connections behind it when clicking on its content area
+>	- Added ResizeThumbTemplate dependency property to GroupingNode to allow customizing the resize thumb
 > - Bugfixes:
 >	- Fixed StepConnection applying SourceOffset in the wrong direction in some cases
 

--- a/Examples/Nodify.Calculator/EditorView.xaml
+++ b/Examples/Nodify.Calculator/EditorView.xaml
@@ -121,6 +121,46 @@
                     Value="{Binding BorderBrush, Source={StaticResource AnimatedBorderPlaceholder}}" />
             <Setter Property="BorderThickness"
                     Value="2" />
+            <Setter Property="Panel.ZIndex"
+                    Value="1" />
+            <Style.Triggers>
+                <Trigger Property="IsSelected"
+                         Value="True">
+                    <Setter Property="Panel.ZIndex"
+                            Value="2" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <ControlTemplate x:Key="ResizeThumbTemplate"
+                         TargetType="Thumb">
+            <Path Width="14"
+                  Height="14"
+                  Stretch="Fill"
+                  Stroke="#6366f1"
+                  StrokeThickness="2"
+                  Fill="Transparent"
+                  StrokeLineJoin="Round"
+                  VerticalAlignment="Bottom"
+                  HorizontalAlignment="Right"
+                  Margin="2"
+                  Data="M 0,16 L 16,0 L 16,16 Z" />
+        </ControlTemplate>
+
+        <Style x:Key="GroupingNodeStyle"
+               TargetType="nodify:GroupingNode"
+               BasedOn="{StaticResource {x:Type nodify:GroupingNode}}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=nodify:ItemContainer}}"
+                             Value="True">
+                    <Setter Property="Panel.ZIndex"
+                            Value="0" />
+                </DataTrigger>
+            </Style.Triggers>
+            <Setter Property="ResizeThumbTemplate"
+                    Value="{StaticResource ResizeThumbTemplate}" />
+            <Setter Property="IsContentHitTestVisible"
+                    Value="False" />
         </Style>
     </UserControl.Resources>
 
@@ -189,6 +229,7 @@
                     <nodify:GroupingNode Header="{Binding}"
                                          CanResize="{Binding IsExpanded}"
                                          ActualSize="{Binding DesiredSize, Mode=TwoWay}"
+                                         ResizeThumbTemplate="{StaticResource ResizeThumbTemplate}"
                                          MovementMode="Self">
                         <nodify:GroupingNode.HeaderTemplate>
                             <DataTemplate DataType="{x:Type local:OperationGraphViewModel}">
@@ -363,7 +404,8 @@
                 </DataTemplate>
 
                 <DataTemplate DataType="{x:Type local:OperationGroupViewModel}">
-                    <nodify:GroupingNode ActualSize="{Binding GroupSize, Mode=TwoWay}">
+                    <nodify:GroupingNode ActualSize="{Binding GroupSize, Mode=TwoWay}"
+                                         Style="{StaticResource GroupingNodeStyle}">
                         <nodify:GroupingNode.Header>
                             <shared:EditableTextBlock Text="{Binding Title}"
                                                       FontWeight="SemiBold"

--- a/Nodify/Nodes/GroupingNode.cs
+++ b/Nodify/Nodes/GroupingNode.cs
@@ -73,6 +73,8 @@ namespace Nodify
         public static readonly DependencyProperty MovementModeProperty = DependencyProperty.Register(nameof(MovementMode), typeof(GroupingMovementMode), typeof(GroupingNode), new FrameworkPropertyMetadata(GroupMovementBoxed));
         public static readonly DependencyProperty ResizeCompletedCommandProperty = DependencyProperty.Register(nameof(ResizeCompletedCommand), typeof(ICommand), typeof(GroupingNode));
         public static readonly DependencyProperty ResizeStartedCommandProperty = DependencyProperty.Register(nameof(ResizeStartedCommand), typeof(ICommand), typeof(GroupingNode));
+        public static readonly DependencyProperty IsContentHitTestVisibleProperty = DependencyProperty.Register(nameof(IsContentHitTestVisible), typeof(bool), typeof(GroupingNode), new FrameworkPropertyMetadata(BoxValue.True));
+        public static readonly DependencyProperty ResizeThumbTemplateProperty = DependencyProperty.Register(nameof(ResizeThumbTemplate), typeof(ControlTemplate), typeof(GroupingNode));
 
         private static void OnActualSizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -136,6 +138,24 @@ namespace Nodify
         {
             get => (ICommand?)GetValue(ResizeStartedCommandProperty);
             set => SetValue(ResizeStartedCommandProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether the content part of this <see cref="GroupingNode"/> can possibly be returned as a hit test result.
+        /// </summary>
+        public bool IsContentHitTestVisible
+        {
+            get => (bool)GetValue(IsContentHitTestVisibleProperty);
+            set => SetValue(IsContentHitTestVisibleProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the template used for the resize thumb of this <see cref="GroupingNode"/>.
+        /// </summary>
+        public ControlTemplate? ResizeThumbTemplate
+        {
+            get => (ControlTemplate?)GetValue(ResizeThumbTemplateProperty);
+            set => SetValue(ResizeThumbTemplateProperty, value);
         }
 
         #endregion

--- a/Nodify/Themes/Styles/GroupingNode.xaml
+++ b/Nodify/Themes/Styles/GroupingNode.xaml
@@ -4,6 +4,13 @@
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
+    <ControlTemplate x:Key="DefaultResizeThumbTemplate"
+                     TargetType="Thumb">
+        <TextBlock Text="p"
+                   FontFamily="Marlett"
+                   FontSize="18" />
+    </ControlTemplate>
+
     <Style TargetType="{x:Type local:GroupingNode}">
         <Setter Property="Background">
             <Setter.Value>
@@ -27,6 +34,8 @@
                 Value="30" />
         <Setter Property="MinWidth"
                 Value="150" />
+        <Setter Property="ResizeThumbTemplate"
+                Value="{StaticResource DefaultResizeThumbTemplate}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type local:GroupingNode}">
@@ -49,26 +58,22 @@
                             </Border>
 
                             <Grid Grid.Row="1"
+                                  IsHitTestVisible="{TemplateBinding IsContentHitTestVisible}"
                                   Background="{TemplateBinding Background}">
                                 <ContentPresenter x:Name="PART_Content"
                                                   ContentSource="Content" />
-                                <Thumb x:Name="PART_ResizeThumb"
-                                       HorizontalAlignment="Right"
-                                       VerticalAlignment="Bottom"
-                                       Margin="0 0 2 2"
-                                       MinHeight="20"
-                                       Cursor="SizeNWSE"
-                                       Foreground="{TemplateBinding Foreground}"
-                                       Visibility="{TemplateBinding CanResize, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                    <Thumb.Template>
-                                        <ControlTemplate>
-                                            <TextBlock Text="p"
-                                                       FontFamily="Marlett"
-                                                       FontSize="18" />
-                                        </ControlTemplate>
-                                    </Thumb.Template>
-                                </Thumb>
                             </Grid>
+
+                            <Thumb Grid.Row="1"
+                                   x:Name="PART_ResizeThumb"
+                                   HorizontalAlignment="Right"
+                                   VerticalAlignment="Bottom"
+                                   Margin="0 0 2 2"
+                                   MinHeight="20"
+                                   Cursor="SizeNWSE"
+                                   Foreground="{TemplateBinding Foreground}"
+                                   Visibility="{TemplateBinding CanResize, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                   Template="{TemplateBinding ResizeThumbTemplate}" />
                         </Grid>
                     </Border>
                 </ControlTemplate>


### PR DESCRIPTION
### 📝 Description of the Change

This PR adds a few improvements to the `GroupingNode`.

New dependency properties:

- `IsContentHitTestVisible`: allows selecting nodes and connections behind a grouping node when set to `false`
- `ResizeThumbTemplate`: allows customizing the resize thumb of a grouping node

Related: #267

![grouping-node2](https://github.com/user-attachments/assets/15848d9e-bcff-428a-adc1-f1c330e3d22c)

### 🐛 Possible Drawbacks

None.
