### PR TITLE
Add editor gestures documentation

### DIFF
--- a/docs/Editor-Gestures.md
+++ b/docs/Editor-Gestures.md
@@ -1,0 +1,179 @@
+# Editor gestures
+
+Nodify uses `EditorGestures` to map mouse and keyboard input to built-in editor operations. The default mappings live in `EditorGestures.Mappings`. A `NodifyEditor` can also receive its own mappings through `InputGestures`.
+
+Use per-editor mappings when one editor needs different interaction rules than the rest of the application. Use `EditorGestures.Mappings` only when you want to change the application-wide defaults.
+
+## Per-editor mappings
+
+Create an `EditorGestures` instance in your view model and bind it to `NodifyEditor.InputGestures`.
+
+```csharp
+using Nodify.Interactivity;
+using System.Windows.Input;
+
+public class EditorViewModel
+{
+    public EditorGestures Gestures { get; } = new EditorGestures();
+
+    public EditorViewModel()
+    {
+        Gestures.Editor.Pan.Value = new AnyGesture(
+            new Nodify.Interactivity.MouseGesture(MouseAction.MiddleClick),
+            new Nodify.Interactivity.MouseGesture(MouseAction.LeftClick, Key.Space));
+
+        Gestures.Editor.ZoomModifierKey = ModifierKeys.Control;
+        Gestures.Editor.PanWithMouseWheel = true;
+    }
+}
+```
+
+```xml
+<nodify:NodifyEditor ItemsSource="{Binding Nodes}"
+                     InputGestures="{Binding Gestures}" />
+```
+
+If `InputGestures` is not set, the editor uses `EditorGestures.Mappings`.
+
+## Changing global defaults
+
+Change `EditorGestures.Mappings` when every editor should use the same mappings.
+
+```csharp
+using Nodify.Interactivity;
+using System.Windows.Input;
+
+EditorGestures.Mappings.Editor.ZoomModifierKey = ModifierKeys.Control;
+EditorGestures.Mappings.Editor.PanWithMouseWheel = true;
+EditorGestures.Mappings.Connection.Disconnect.Unbind();
+```
+
+Global defaults can be changed whenever the application needs to switch its default editor interactions. Existing editors that use `EditorGestures.Mappings` pick up those changes through the shared mapping instance.
+
+## Replacing a gesture
+
+Most gesture properties are `InputGestureRef` values. Replace the `Value` property instead of replacing the reference.
+
+```csharp
+Gestures.Editor.Cutting.Value =
+    new Nodify.Interactivity.MouseGesture(MouseAction.LeftClick, ModifierKeys.Alt);
+```
+
+Use `AnyGesture` when more than one input should trigger the same action.
+
+```csharp
+Gestures.Editor.Pan.Value = new AnyGesture(
+    new Nodify.Interactivity.MouseGesture(MouseAction.RightClick),
+    new Nodify.Interactivity.MouseGesture(MouseAction.MiddleClick));
+```
+
+Use `AllGestures` when every gesture in the list must match the same input event before the action is triggered.
+
+Use `Unbind()` to disable an action.
+
+```csharp
+Gestures.Editor.Cutting.Unbind();
+Gestures.Connector.Connect.Unbind();
+Gestures.Connection.Split.Unbind();
+```
+
+## Selection gestures
+
+Selection is made of several related gestures:
+
+- `Replace`
+- `Append`
+- `Remove`
+- `Invert`
+- `Cancel`
+- `Select`
+
+Use `SelectionGestures` when you want to move the full selection group from one mouse button to another.
+
+```csharp
+Gestures.Editor.Selection.Apply(
+    new EditorGestures.SelectionGestures(MouseAction.RightClick));
+```
+
+If item containers should use the same selection behavior, apply the same mapping to `ItemContainer.Selection` and update `ItemContainer.Drag`.
+
+```csharp
+Gestures.Editor.Selection.Apply(
+    new EditorGestures.SelectionGestures(MouseAction.RightClick));
+
+Gestures.ItemContainer.Selection.Apply(Gestures.Editor.Selection);
+Gestures.ItemContainer.Drag.Value = new AnyGesture(
+    Gestures.ItemContainer.Selection.Replace.Value,
+    Gestures.ItemContainer.Selection.Remove.Value,
+    Gestures.ItemContainer.Selection.Append.Value,
+    Gestures.ItemContainer.Selection.Invert.Value);
+```
+
+This keeps selecting and dragging in sync.
+
+## Read-only mode
+
+For a read-only editor, unbind gestures that can modify graph state and leave navigation gestures enabled.
+
+```csharp
+public static void MakeReadOnly(EditorGestures gestures)
+{
+    gestures.Editor.Selection.Unbind();
+    gestures.Editor.SelectAll.Unbind();
+    gestures.Editor.Cutting.Unbind();
+    gestures.Editor.PushItems.Unbind();
+
+    gestures.Editor.Keyboard.ToggleSelected.Unbind();
+    gestures.Editor.Keyboard.DragSelection.Unbind();
+    gestures.Editor.Keyboard.DeselectAll.Unbind();
+
+    gestures.ItemContainer.Selection.Unbind();
+    gestures.ItemContainer.Drag.Unbind();
+
+    gestures.Connection.Disconnect.Unbind();
+    gestures.Connection.Split.Unbind();
+    gestures.Connection.Selection.Unbind();
+
+    gestures.Connector.Connect.Unbind();
+    gestures.Connector.Disconnect.Unbind();
+}
+```
+
+The exact list depends on what your editor is allowed to do. For example, a viewer may keep panning, zooming, keyboard navigation, and minimap navigation enabled.
+
+## Copying and restoring mappings
+
+Use `Apply()` to copy one gesture set into another. This is useful for editor modes such as "locked", "drawing", or "connection editing".
+
+```csharp
+private readonly EditorGestures _activeGestures = new EditorGestures();
+private readonly EditorGestures _backupGestures = new EditorGestures();
+
+public EditorGestures ActiveGestures => _activeGestures;
+
+public void LockEditing()
+{
+    _backupGestures.Apply(_activeGestures);
+    MakeReadOnly(_activeGestures);
+}
+
+public void UnlockEditing()
+{
+    _activeGestures.Apply(_backupGestures);
+}
+```
+
+Bind `ActiveGestures` to `InputGestures`.
+
+## Common gesture targets
+
+The most common groups are:
+
+- `Editor`: panning, zooming, selecting, cutting, pushing, keyboard navigation, fit to screen, reset viewport.
+- `ItemContainer`: selecting and dragging node containers.
+- `Connector`: starting pending connections and disconnecting connectors.
+- `Connection`: selecting, splitting, and disconnecting connections.
+- `GroupingNode`: grouped movement behavior and content selection.
+- `Minimap`: panning, dragging the viewport, zooming, reset viewport.
+
+For the full API, see [`EditorGestures`](api/Nodify_Interactivity_EditorGestures).

--- a/docs/Editor-Overview.md
+++ b/docs/Editor-Overview.md
@@ -7,6 +7,7 @@
   - [Selection API](#selection-api)
 - [Snapping to grid](#snapping)
 - [Pushing items](#pushing-items)
+- [Editor gestures](#editor-gestures)
 - [Commands](#commands)
 - [Editor API](#editor-api)
 
@@ -120,6 +121,10 @@ To initiate the push operation, hold `CTRL+SHIFT` and click with the **Left Mous
 To cancel the push operation, press the `Escape` key or release `CTRL+SHIFT` and click the **Right Mouse Button**. You can configure the default keybindings by modifying the `EditorGestures.Editor.PushItems` gesture. To prevent cancellation, set `NodifyEditor.AllowPushItemsCancellation` to `false`.
 
 The visual appearance of the push area can be customized by setting the `PushedAreaStyle` property.
+
+## Editor gestures
+
+For custom mouse and keyboard mappings, see [Editor gestures](Editor-Gestures).
 
 ## Commands
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -9,7 +9,7 @@ A2: The `Anchor` of the connectors updates only if the `IsConnected` property is
 
 #### Q: Can I change the mouse/key bindings?
 
-A: Yes! You can configure the [editor gestures](https://github.com/miroiu/nodify/blob/master/Nodify/EditorGestures.cs) to your liking.
+A: Yes! You can configure the [editor gestures](Editor-Gestures) to your liking.
 
 ***
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -22,6 +22,7 @@
 - [Selecting items](Editor-Overview#selecting)
 - [Pushing items](Editor-Overview#pushing-items)
 - [Snapping to grid](Editor-Overview#snapping)
+- [Editor gestures](Editor-Gestures)
 - [Commands](Editor-Overview#commands)
 
 [ItemContainer overview](ItemContainer-Overview)


### PR DESCRIPTION
Closes #260.

Adds editor gesture documentation, links it from the sidebar and editor overview, and updates the FAQ pointer.

Validation:
- git diff HEAD~1..HEAD --check
- docs-only change