### PR TITLE
Fix ItemContainer SelectedBrush with custom BorderBrush

### DIFF
--- a/Nodify/Themes/Styles/ItemContainer.xaml
+++ b/Nodify/Themes/Styles/ItemContainer.xaml
@@ -45,6 +45,31 @@
                             CornerRadius="3">
                         <ContentPresenter />
                     </Border>
+                    <ControlTemplate.Triggers>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsSelected"
+                                           Value="True" />
+                                <Condition Property="IsPreviewingSelection"
+                                           Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{Binding SelectedBrush, RelativeSource={RelativeSource TemplatedParent}}" />
+                        </MultiTrigger>
+                        <Trigger Property="IsPreviewingSelection"
+                                 Value="True">
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{Binding SelectedBrush, RelativeSource={RelativeSource TemplatedParent}}" />
+                        </Trigger>
+                        <Trigger Property="local:PendingConnection.IsOverElement"
+                                 Value="True">
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{Binding HighlightBrush, RelativeSource={RelativeSource TemplatedParent}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
Fixes #70

### Description of the Change

This updates the default `ItemContainer` template so selection, preview-selection, and pending-connection highlight brush changes are applied to the named border inside the control template instead of setting `ItemContainer.BorderBrush` from inherited style triggers.

That keeps a custom `BorderBrush` setter in a `BasedOn` `ItemContainer` style from overriding the selected visual state, while still allowing an explicitly configured `SelectedBrush` to control the selected border color.

Verification performed:

- `dotnet build Nodify\Nodify.csproj -f net8-windows`
- `dotnet build Nodify\Nodify.csproj -f net9-windows --no-restore`
- `dotnet build Nodify\Nodify.csproj -f net10.0-windows --no-restore`
- Temporary WPF smoke check: derived `ItemContainer` style with `BorderBrush=Blue` and `SelectedBrush=Red` rendered the inner border blue when unselected and red when selected.
- `git diff --check`

### Possible Drawbacks

The selected, preview-selected, and highlight states now change the template border's `BorderBrush` rather than the effective `ItemContainer.BorderBrush` dependency property value. This preserves the visual behavior and avoids `BasedOn` style precedence issues, but code that read `ItemContainer.BorderBrush` while selected would now continue to see the configured base brush.
- `dotnet build Examples\Nodify.Calculator\Nodify.Calculator.csproj -f net8-windows`
- `dotnet build Examples\Nodify.Playground\Nodify.Playground.csproj -f net8-windows`
- `dotnet build Examples\Nodify.Shapes\Nodify.Shapes.csproj -f net8-windows`
- `dotnet build Examples\Nodify.StateMachine\Nodify.StateMachine.csproj -f net8-windows`