### PR TITLE
Fixed Connection halving the bezier control point of only one end when the orientations differ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > - Breaking Changes:
 > - Features:
 > - Bugfixes:
+>	- Fixed Connection to halve the bezier control points of both ends when the source and target orientations are different
 
 #### **Version 7.3.0**
 

--- a/Nodify/Connections/Connection.cs
+++ b/Nodify/Connections/Connection.cs
@@ -74,13 +74,14 @@ namespace Nodify
             offset = Math.Min(_baseOffset + Math.Sqrt(width * _offsetGrowthRate), offset);
 
             var controlPoint = new Vector(offset * direction, 0d);
-            var controlPointVertical = new Vector(controlPoint.Y, controlPoint.X);
 
             // Avoid sharp bend if orientation different (when close to each other)
             if (TargetOrientation != SourceOrientation)
             {
                 controlPoint *= 0.5;
             }
+
+            var controlPointVertical = new Vector(controlPoint.Y, controlPoint.X);
 
             Point p0 = startPoint;
             Point p1 = startPoint + (SourceOrientation == Orientation.Vertical ? controlPointVertical : controlPoint);


### PR DESCRIPTION
Fixes #281.

### 📝 Description of the Change

`GetBezierControlPoints` derived `controlPointVertical` from `controlPoint` *before* the "avoid sharp bend if orientation different" guard halves it. `Vector` is a struct, so the copy keeps the pre-halving magnitude and the compound assignment only mutates the original. Since "orientations differ" means exactly one end is `Vertical`, that end always read the stale full-length vector while the other read the halved one — the guard did half its job in every case where it fired.

The change moves that one line below the guard, which is where `7439531` originally put it before `3ac13b4` hoisted it while extracting this method out of `DrawLineGeometry`.

Verified with a console harness referencing `Nodify/Nodify.csproj`, reading the control points two independent ways — reflection on the private computation, and `PathGeometry.CreateFromGeometry` over the protected `DefiningGeometry`, which is the path that actually renders. They agree. With `Source=(0,0)`, `Target=(200,100)`, `Spacing=0`, offset modes `None`, both handles now measure 50 where one measured 100 before.

Full solution builds across all eight target frameworks: 0 errors, 26 warnings, which is the same warning count as clean `master`.

### 🐛 Possible Drawbacks

It is a rendering change and I cannot show you a screenshot from this environment, so what I proved is the control-point numbers, not that the resulting curve pleases the eye. If you are used to the current lopsided curve, this will look different — my argument is that it restores your own pre-`3ac13b4` behaviour, not that my taste is better than yours.

Arrow placement and connection-label position shift slightly on mixed-orientation bezier connections as a side effect, since `DrawDirectionalArrowsGeometry` and `GetTextPosition` sample the same curve. Intended — they were sampling a curve built from a stale handle — but it is a second visible change riding along.

Blast radius, measured rather than assumed: `GetBezierControlPoints` is private to `Connection` with exactly three call sites, all in `Connection.cs`. `StepConnection`, `CircuitConnection` and `LineConnection` descend from `LineConnection`/`BaseConnection` and never reach it, so `StepConnection`'s orientation coercion is unaffected. No public API changes.

Not tested: `Spacing > 0`, non-`None` offset modes, and `ConnectionDirection.Backward`. Those feed `startPoint`/`endPoint` and the sign of `direction`, which are upstream of the moved line and unaffected by moving it, but I did not run them.

CHANGELOG.md updated under **In development** → Bugfixes.
