### PR TITLE
Fixed grid snapping rounding toward zero instead of down for negative coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > - Breaking Changes:
 > - Features:
 > - Bugfixes:
+>	- Fixed grid snapping rounding towards zero instead of down for negative coordinates, which snapped items near the origin onto the same location
 
 #### **Version 7.3.0**
 

--- a/Nodify/Editor/NodifyEditor.cs
+++ b/Nodify/Editor/NodifyEditor.cs
@@ -1056,7 +1056,7 @@ namespace Nodify
         /// <returns>The largest multiple of the grid cell size less than or equal to the value.</returns>
         public double SnapToGrid(double value)
         {
-            return (int)value / GridCellSize * GridCellSize;
+            return value.SnapToGrid(GridCellSize);
         }
 
         /// <summary>

--- a/Nodify/Editor/Utilities/DraggingOptimized.cs
+++ b/Nodify/Editor/Utilities/DraggingOptimized.cs
@@ -51,8 +51,8 @@ namespace Nodify
                 // Correct the final position
                 if (NodifyEditor.EnableSnappingCorrection && (r.X != 0 || r.Y != 0))
                 {
-                    result.X = (int)result.X / _gridCellSize * _gridCellSize;
-                    result.Y = (int)result.Y / _gridCellSize * _gridCellSize;
+                    result.X = result.X.SnapToGrid(_gridCellSize);
+                    result.Y = result.Y.SnapToGrid(_gridCellSize);
                 }
 
                 container.Location = result;

--- a/Nodify/Editor/Utilities/DraggingSimple.cs
+++ b/Nodify/Editor/Utilities/DraggingSimple.cs
@@ -49,8 +49,8 @@ namespace Nodify
                 // Correct the final position
                 if (NodifyEditor.EnableSnappingCorrection)
                 {
-                    result.X = (int)result.X / _gridCellSize * _gridCellSize;
-                    result.Y = (int)result.Y / _gridCellSize * _gridCellSize;
+                    result.X = result.X.SnapToGrid(_gridCellSize);
+                    result.Y = result.Y.SnapToGrid(_gridCellSize);
                 }
 
                 container.Location = result;

--- a/Nodify/Utilities/MathExtensions.cs
+++ b/Nodify/Utilities/MathExtensions.cs
@@ -1,7 +1,13 @@
-﻿namespace Nodify
+﻿using System;
+
+namespace Nodify
 {
     internal static class MathExtensions
     {
+        /// <summary> Snaps a value down to the largest multiple of the specified grid cell size.</summary>
+        public static double SnapToGrid(this double value, uint gridCellSize)
+            => Math.Floor(value / gridCellSize) * gridCellSize;
+
         /// <summary> Wraps a value within a specified range.</summary>
         public static double WrapToRange(this double value, double min, double max)
         {


### PR DESCRIPTION
### 📝 Description of the Change

`SnapToGrid` documents itself as returning "the largest multiple of the grid cell size less than or equal to the value", but it is implemented as `(int)value / GridCellSize * GridCellSize`. Both the cast and the division truncate toward zero, which is symmetric about the origin rather than periodic on the lattice, so the negative half of the canvas snaps to a different set of positions than the positive half.

With `GridCellSize = 10`:

```
SnapToGrid(-25)  ->  -20     documented: -30
SnapToGrid(-5)   ->    0     documented: -10
SnapToGrid( 5)   ->    0     documented:   0
```

`-5` and `+5` land on the same coordinate, so two items dragged to opposite sides of the origin stack on top of each other, and the gap between the two lattice points either side of zero is one cell wider than everywhere else.

`Math.Floor(value / gridCellSize) * gridCellSize` is the documented behaviour and is periodic across zero.

The same expression was inlined in two more places — the snapping-correction blocks in `DraggingOptimized` and `DraggingSimple` — so all three now call one `SnapToGrid` extension in `MathExtensions` rather than repeating the arithmetic.

`GridCellSize` cannot be zero: `OnCoerceGridCellSize` coerces anything that is not greater than zero to 1, so the division is safe.

Verified with a console harness in the repository that references `Nodify.csproj` and tabulates the public `SnapToGrid` across zero for two cell sizes, checking each result against the documented contract and checking that consecutive lattice steps are uniform. It exits non-zero on unpatched `master` and zero with the change. Full solution builds across all eight target frameworks with 0 errors and the same 26 warnings as clean `master`.

### 🐛 Possible Drawbacks

It is a behaviour change on the negative half of the canvas, so a saved layout whose coordinates were produced by the old truncation will shift by up to one cell the first time an item there is dragged. Nothing re-snaps on load, so existing layouts are not rewritten on their own.

`SnapToGrid` is public API. The signature is unchanged and the return type is the same; only the value changes, and only for negative inputs that are not already on the lattice.

I did not touch `EnableSnappingCorrection`'s default or the drag paths beyond replacing the duplicated expression.

CHANGELOG.md updated under **In development** → Bugfixes.
