### PR TITLE
Pass DataContext to DisconnectCommand from BaseConnection

### DIFF
--- a/Examples/Nodify.Playground/Editor/ConnectionViewModel.cs
+++ b/Examples/Nodify.Playground/Editor/ConnectionViewModel.cs
@@ -1,10 +1,31 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Input;
 
 namespace Nodify.Playground
 {
     public class ConnectionViewModel : ObservableObject
     {
+        private static class Commands
+        {
+            public sealed class DisconnectCommand : ICommand
+            {
+                public static readonly DisconnectCommand Instance = new DisconnectCommand();
+
+                private DisconnectCommand() { }
+
+                public event EventHandler? CanExecuteChanged
+                {
+                    add { }
+                    remove { }
+                }
+
+                public bool CanExecute(object? parameter) => parameter is ConnectionViewModel;
+
+                public void Execute(object? parameter) => ((ConnectionViewModel)parameter!).Remove();
+            }
+        }
+
         private NodifyEditorViewModel _graph = default!;
         public NodifyEditorViewModel Graph
         {
@@ -34,12 +55,11 @@ namespace Nodify.Playground
         }
 
         public ICommand SplitCommand { get; }
-        public ICommand DisconnectCommand { get; }
+        public ICommand DisconnectCommand => Commands.DisconnectCommand.Instance;
 
         public ConnectionViewModel()
         {
             SplitCommand = new DelegateCommand<Point>(Split);
-            DisconnectCommand = new DelegateCommand(Remove);
         }
 
         public void Split(Point point)

--- a/Nodify/Connections/BaseConnection.cs
+++ b/Nodify/Connections/BaseConnection.cs
@@ -991,9 +991,9 @@ namespace Nodify
             RaiseEvent(args);
 
             // Raise DisconnectCommand if DisconnectEvent is not handled
-            if (!args.Handled && (DisconnectCommand?.CanExecute(null) ?? false))
+            if (!args.Handled && (DisconnectCommand?.CanExecute(DataContext) ?? false))
             {
-                DisconnectCommand.Execute(null);
+                DisconnectCommand.Execute(DataContext);
             }
         }
 


### PR DESCRIPTION
<!-- 
  ## Hello and welcome!

  Consider creating an issue or link to an existing one before submitting the pull request. Thanks!
-->

### 📝 Description of the Change

While working on making connections disconnectable in my app, I noticed that I had to instanciate a new `ICommand` instance for every connection, while the code is always going to be the same.
As the `DisconnectCommand` is not making use of the `parameter` at the moment, passing the `DataContext` there is quite easy to do and is unlikely to break any existing code. However, it allows sharing a single instance to handle all connections in an app, which would help in somewhat reducing the number of allocated objects.

Sadly, the same cannot be done for the `SplitCommand`, as it does already make use of the `parameter`. 

### 🐛 Possible Drawbacks

As the command parameter is currently always passed as `null`, it seems unlikely that anybody would have taken a dependency on this value.
