### PR TITLE
Fix settings bypasses in DraggingSimple, Selection, and Minimap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 > - Bugfixes:
 >	- Fixed dragging correcting the location of containers that were not moved when EnableDraggingContainersOptimizations is false
 >	- Fixed SelectArea, InvertSelection and SelectAll adding ItemContainers whose IsSelectable is false to the selection
+>	- Fixed Minimap.ResetViewport and the minimap keyboard navigation gestures ignoring IsReadOnly
 
 #### **Version 7.3.0**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > - Breaking Changes:
 > - Features:
 > - Bugfixes:
+>	- Fixed dragging correcting the location of containers that were not moved when EnableDraggingContainersOptimizations is false
 
 #### **Version 7.3.0**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 > - Features:
 > - Bugfixes:
 >	- Fixed dragging correcting the location of containers that were not moved when EnableDraggingContainersOptimizations is false
+>	- Fixed SelectArea, InvertSelection and SelectAll adding ItemContainers whose IsSelectable is false to the selection
 
 #### **Version 7.3.0**
 

--- a/Nodify/Editor/NodifyEditor.Selecting.cs
+++ b/Nodify/Editor/NodifyEditor.Selecting.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Windows.Controls.Primitives;
 using System.Windows.Controls;
 using System.Windows;
@@ -233,7 +234,7 @@ namespace Nodify
             {
                 var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
 
-                if (container.IsSelectableInArea(area, fit))
+                if (container.IsSelectable && container.IsSelectableInArea(area, fit))
                 {
                     object? item = items[i];
                     if (container.IsSelected)
@@ -271,7 +272,7 @@ namespace Nodify
             for (var i = 0; i < items.Count; i++)
             {
                 var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
-                if (container.IsSelectableInArea(area, fit))
+                if (container.IsSelectable && container.IsSelectableInArea(area, fit))
                 {
                     selected.Add(items[i]);
                 }
@@ -279,6 +280,37 @@ namespace Nodify
 
             EndUpdateSelectedItems();
             IsSelecting = false;
+        }
+
+        /// <summary>
+        /// Selects all the <see cref="ItemContainer"/>s whose <see cref="ItemContainer.IsSelectable"/> is true.
+        /// </summary>
+        /// <exception cref="NotSupportedException">Thrown when <see cref="CanSelectMultipleItems"/> is false.</exception>
+        public new void SelectAll()
+        {
+            if (!CanSelectMultipleItems)
+            {
+                // Keeps the MultiSelector.SelectAll contract of throwing when multi-selection is off.
+                base.SelectAll();
+                return;
+            }
+
+            BeginUpdateSelectedItems();
+
+            IList selected = base.SelectedItems;
+            selected.Clear();
+
+            ItemCollection items = Items;
+            for (var i = 0; i < items.Count; i++)
+            {
+                var container = (ItemContainer)ItemContainerGenerator.ContainerFromIndex(i);
+                if (container.IsSelectable)
+                {
+                    selected.Add(items[i]);
+                }
+            }
+
+            EndUpdateSelectedItems();
         }
 
         /// <summary>

--- a/Nodify/Editor/Utilities/DraggingSimple.cs
+++ b/Nodify/Editor/Utilities/DraggingSimple.cs
@@ -46,8 +46,10 @@ namespace Nodify
                 ItemContainer container = _selectedContainers[i];
                 Point result = container.Location;
 
-                // Correct the final position
-                if (NodifyEditor.EnableSnappingCorrection)
+                // Correct the final position, but only if the container was actually moved.
+                // Offset accumulates every delta applied by Update, so it is the equivalent of
+                // the render transform DraggingOptimized checks.
+                if (NodifyEditor.EnableSnappingCorrection && (Offset.X != 0 || Offset.Y != 0))
                 {
                     result.X = (int)result.X / _gridCellSize * _gridCellSize;
                     result.Y = (int)result.Y / _gridCellSize * _gridCellSize;

--- a/Nodify/Minimap/Minimap.cs
+++ b/Nodify/Minimap/Minimap.cs
@@ -375,6 +375,11 @@ namespace Nodify
 
         public void ResetViewport()
         {
+            if (IsReadOnly)
+            {
+                return;
+            }
+
             SetCurrentValue(ViewportLocationProperty, new Point(0, 0));
             var args = new ZoomEventArgs(1d, new Point(ViewportSize.Width / 2, ViewportSize.Height / 2))
             {

--- a/Nodify/Minimap/States/KeyboardNavigation.cs
+++ b/Nodify/Minimap/States/KeyboardNavigation.cs
@@ -13,7 +13,7 @@ namespace Nodify.Interactivity
 
             protected override void OnKeyDown(KeyEventArgs e)
             {
-                if (Element.IsKeyboardFocused)
+                if (Element.IsKeyboardFocused && !Element.IsReadOnly)
                 {
                     var gestures = Element.ActualGestures;
 


### PR DESCRIPTION
Fixes #285

## Problem

Four settings/off-switches in Nodify were respected by some interaction paths but bypassed by others:

1. **`DraggingSimple` position correction**: Corrected container positions even for items that were not selected or dragged when optimizations were disabled.
2. **Selection operations (`SelectArea`, `InvertSelection`, `SelectAll`)**: Selected containers where `IsSelectable = False`.
3. **`Minimap.ResetViewport` & keyboard gestures**: Bypassed `IsReadOnly = True` on the Minimap control.

## Solution

1. Added `IsSelectable` checks to container selection loops (`SelectArea`, `InvertSelection`, `SelectAll`).
2. Checked `IsReadOnly` inside `Minimap` viewport reset and keyboard navigation handlers.
3. Guarded location correction in `DraggingSimple` to skip unselected/unmoved containers.
